### PR TITLE
feat: allow overriding properties of (Mock)FileSystem

### DIFF
--- a/src/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Reflection;
 
@@ -9,7 +8,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
     /// <inheritdoc />
     [Serializable]
-    public class MockFileSystem : IFileSystem, IMockFileDataAccessor
+    public class MockFileSystem : FileSystemBase, IMockFileDataAccessor
     {
         private const string DEFAULT_CURRENT_DIRECTORY = @"C:\";
         private const string TEMP_DIRECTORY = @"C:\temp";
@@ -69,21 +68,21 @@ namespace System.IO.Abstractions.TestingHelpers
         /// <inheritdoc />
         public StringOperations StringOperations { get; }
         /// <inheritdoc />
-        public IFile File { get; }
+        public override IFile File { get; }
         /// <inheritdoc />
-        public IDirectory Directory { get; }
+        public override IDirectory Directory { get; }
         /// <inheritdoc />
-        public IFileInfoFactory FileInfo { get; }
+        public override IFileInfoFactory FileInfo { get; }
         /// <inheritdoc />
-        public IFileStreamFactory FileStream { get; }
+        public override IFileStreamFactory FileStream { get; }
         /// <inheritdoc />
-        public IPath Path { get; }
+        public override IPath Path { get; }
         /// <inheritdoc />
-        public IDirectoryInfoFactory DirectoryInfo { get; }
+        public override IDirectoryInfoFactory DirectoryInfo { get; }
         /// <inheritdoc />
-        public IDriveInfoFactory DriveInfo { get; }
+        public override IDriveInfoFactory DriveInfo { get; }
         /// <inheritdoc />
-        public IFileSystemWatcherFactory FileSystemWatcher { get; set; }
+        public override IFileSystemWatcherFactory FileSystemWatcher { get; }
         /// <inheritdoc />
         public IFileSystem FileSystem => this;
         /// <inheritdoc />

--- a/src/System.IO.Abstractions/FileSystem.cs
+++ b/src/System.IO.Abstractions/FileSystem.cs
@@ -2,7 +2,7 @@
 {
     /// <inheritdoc />
     [Serializable]
-    public class FileSystem : IFileSystem
+    public class FileSystem : FileSystemBase
     {
         /// <inheritdoc />
         public FileSystem()
@@ -18,27 +18,27 @@
         }
 
         /// <inheritdoc />
-        public IDirectory Directory { get; }
+        public override IDirectory Directory { get; }
 
         /// <inheritdoc />
-        public IFile File { get; }
+        public override IFile File { get; }
 
         /// <inheritdoc />
-        public IFileInfoFactory FileInfo { get; }
+        public override IFileInfoFactory FileInfo { get; }
 
         /// <inheritdoc />
-        public IFileStreamFactory FileStream { get; }
+        public override IFileStreamFactory FileStream { get; }
 
         /// <inheritdoc />
-        public IPath Path { get; }
+        public override IPath Path { get; }
 
         /// <inheritdoc />
-        public IDirectoryInfoFactory DirectoryInfo { get; }
+        public override IDirectoryInfoFactory DirectoryInfo { get; }
 
         /// <inheritdoc />
-        public IDriveInfoFactory DriveInfo { get; }
+        public override IDriveInfoFactory DriveInfo { get; }
 
         /// <inheritdoc />
-        public IFileSystemWatcherFactory FileSystemWatcher { get; }
+        public override IFileSystemWatcherFactory FileSystemWatcher { get; }
     }
 }

--- a/src/System.IO.Abstractions/FileSystemBase.cs
+++ b/src/System.IO.Abstractions/FileSystemBase.cs
@@ -1,0 +1,31 @@
+﻿namespace System.IO.Abstractions
+{
+    /// <inheritdoc />
+    [Serializable]
+    public abstract class FileSystemBase : IFileSystem
+    {
+        /// <inheritdoc />
+        public abstract IDirectory Directory { get; }
+
+        /// <inheritdoc />
+        public abstract IFile File { get; }
+
+        /// <inheritdoc />
+        public abstract IFileInfoFactory FileInfo { get; }
+
+        /// <inheritdoc />
+        public abstract IFileStreamFactory FileStream { get; }
+
+        /// <inheritdoc />
+        public abstract IPath Path { get; }
+
+        /// <inheritdoc />
+        public abstract IDirectoryInfoFactory DirectoryInfo { get; }
+
+        /// <inheritdoc />
+        public abstract IDriveInfoFactory DriveInfo { get; }
+
+        /// <inheritdoc />
+        public abstract IFileSystemWatcherFactory FileSystemWatcher { get; }
+    }
+}

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -393,23 +393,24 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFileSystem_FileSystemWatcher_PathShouldBeAssignable()
+        public void MockFileSystem_FileSystemWatcher_Can_Be_Overridden()
         {
             var path = XFS.Path(@"C:\root");
-            var fileSystem = new MockFileSystem { FileSystemWatcher = new TestFileSystemWatcherFactory() };
+            var fileSystem = new TestFileSystem(new TestFileSystemWatcherFactory());
             var watcher = fileSystem.FileSystemWatcher.CreateNew(path);
             Assert.AreEqual(path, watcher.Path);
         }
 
-        [Test]
-        public void MockFileSystem_FileSystemWatcher_PathAndFilterShouldBeAssignable()
+        private class TestFileSystem : MockFileSystem
         {
-            var path = XFS.Path(@"C:\root");
-            var filter = "*.txt";
-            var fileSystem = new MockFileSystem { FileSystemWatcher = new TestFileSystemWatcherFactory() };
-            var watcher = fileSystem.FileSystemWatcher.CreateNew(path, filter);
-            Assert.AreEqual(path, watcher.Path);
-            Assert.AreEqual(filter, watcher.Filter);
+            private readonly IFileSystemWatcherFactory fileSystemWatcherFactory;
+
+            public TestFileSystem(IFileSystemWatcherFactory fileSystemWatcherFactory)
+            {
+                this.fileSystemWatcherFactory = fileSystemWatcherFactory;
+            }
+
+            public override IFileSystemWatcherFactory FileSystemWatcher => fileSystemWatcherFactory;
         }
 
         private class TestFileSystemWatcherFactory : IFileSystemWatcherFactory

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "15.0",
+  "version": "16.0",
   "assemblyVersion": {
     "precision": "major"
   },


### PR DESCRIPTION
BREAKING CHANGES:
- (Mock)FileSystem are now derived from a new public class FileSystemBase for symmetry with other types
- The setter for MockFileSystem.FileSystemWatcher has been removed. It is now virtual and should be overriden if required.

Fixes #757, #778 and #776