### PR TITLE
feat: Add `LinkTarget` to `FileSystemInfo` for .NET 6 targets

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,6 +13,7 @@
     <DefineConstants Condition="'$(TargetFramework)' != 'net461'">$(DefineConstants);FEATURE_FILE_SYSTEM_ACL_EXTENSIONS</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'netstandard2.1'">$(DefineConstants);FEATURE_ASYNC_FILE;FEATURE_ENUMERATION_OPTIONS;FEATURE_ADVANCED_PATH_OPERATIONS;FEATURE_PATH_JOIN_WITH_SPAN</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net5.0'">$(DefineConstants);FEATURE_FILE_MOVE_WITH_OVERWRITE;FEATURE_SUPPORTED_OS_ATTRIBUTE;FEATURE_FILE_SYSTEM_WATCHER_FILTERS;FEATURE_ENDS_IN_DIRECTORY_SEPARATOR;FEATURE_PATH_JOIN_WITH_PARAMS;FEATURE_PATH_JOIN_WITH_FOUR_PATHS</DefineConstants>
+	<DefineConstants Condition="'$(TargetFramework)' == 'net6.0'">$(DefineConstants);FEATURE_FILE_SYSTEM_INFO_LINK_TARGET</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.255">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <DefineConstants Condition="'$(TargetFramework)' != 'net461'">$(DefineConstants);FEATURE_FILE_SYSTEM_ACL_EXTENSIONS</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'netstandard2.1'">$(DefineConstants);FEATURE_ASYNC_FILE;FEATURE_ENUMERATION_OPTIONS;FEATURE_ADVANCED_PATH_OPERATIONS;FEATURE_PATH_JOIN_WITH_SPAN</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net5.0'">$(DefineConstants);FEATURE_FILE_MOVE_WITH_OVERWRITE;FEATURE_SUPPORTED_OS_ATTRIBUTE;FEATURE_FILE_SYSTEM_WATCHER_FILTERS;FEATURE_ENDS_IN_DIRECTORY_SEPARATOR;FEATURE_PATH_JOIN_WITH_PARAMS;FEATURE_PATH_JOIN_WITH_FOUR_PATHS</DefineConstants>
-	<DefineConstants Condition="'$(TargetFramework)' == 'net6.0'">$(DefineConstants);FEATURE_FILE_SYSTEM_INFO_LINK_TARGET</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' == 'net6.0'">$(DefineConstants);FEATURE_FILE_SYSTEM_INFO_LINK_TARGET</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.255">

--- a/src/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
@@ -134,11 +134,11 @@ namespace System.IO.Abstractions.TestingHelpers
             set { GetMockFileDataForWrite().LastWriteTime = value.ToLocalTime(); }
         }
 
-#if NET6_0_OR_GREATER
+#if FEATURE_FILE_SYSTEM_INFO_LINK_TARGET
         /// <inheritdoc />
         public override string LinkTarget
         {
-            get { return null; }
+            get { return GetMockFileDataForRead().LinkTarget; }
         }
 #endif
 

--- a/src/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
@@ -134,7 +134,15 @@ namespace System.IO.Abstractions.TestingHelpers
             set { GetMockFileDataForWrite().LastWriteTime = value.ToLocalTime(); }
         }
 
+#if NET6_0_OR_GREATER
         /// <inheritdoc />
+        public override string LinkTarget
+        {
+            get { return null; }
+        }
+#endif
+
+            /// <inheritdoc />
         public override string Name
         {
             get

--- a/src/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
@@ -142,7 +142,7 @@ namespace System.IO.Abstractions.TestingHelpers
         }
 #endif
 
-            /// <inheritdoc />
+        /// <inheritdoc />
         public override string Name
         {
             get

--- a/src/System.IO.Abstractions.TestingHelpers/MockFileData.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFileData.cs
@@ -142,7 +142,7 @@ namespace System.IO.Abstractions.TestingHelpers
         /// <summary>
         /// Gets or sets the link target of the <see cref="MockFileData"/>.
         /// </summary>
-        public string LinkTarget { get; set; } = null;
+        public string LinkTarget { get; set; }
 #endif
 
         /// <summary>

--- a/src/System.IO.Abstractions.TestingHelpers/MockFileData.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFileData.cs
@@ -101,6 +101,9 @@ namespace System.IO.Abstractions.TestingHelpers
             CreationTime = template.CreationTime;
             LastAccessTime = template.LastAccessTime;
             LastWriteTime = template.LastWriteTime;
+#if FEATURE_FILE_SYSTEM_INFO_LINK_TARGET
+            LinkTarget = template.LinkTarget;
+#endif
         }
 
         /// <summary>
@@ -134,6 +137,13 @@ namespace System.IO.Abstractions.TestingHelpers
         /// Gets or sets the date and time of the <see cref="MockFileData"/> was last written to.
         /// </summary>
         public DateTimeOffset LastWriteTime { get; set; } = new DateTimeOffset(2010, 01, 04, 00, 00, 00, TimeSpan.FromHours(4));
+
+#if FEATURE_FILE_SYSTEM_INFO_LINK_TARGET
+        /// <summary>
+        /// Gets or sets the link target of the <see cref="MockFileData"/>.
+        /// </summary>
+        public string LinkTarget { get; set; } = null;
+#endif
 
         /// <summary>
         /// Casts a string into <see cref="MockFileData"/>.

--- a/src/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
@@ -173,9 +173,8 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             get
             {
-                // TODO Refactor to match #791 style (also hold on merge until that is merged)
-                if (MockFileData == null) throw CommonExceptions.FileNotFound(path);
-                return MockFileData.LinkTarget;
+                var mockFileData = GetMockFileDataForWrite();
+                return mockFileData.LinkTarget;
             }
         }
 #endif

--- a/src/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
@@ -167,6 +167,14 @@ namespace System.IO.Abstractions.TestingHelpers
             }
         }
 
+#if NET6_0_OR_GREATER
+        /// <inheritdoc />
+        public override string LinkTarget
+        {
+            get { return null; }
+        }
+#endif
+
         /// <inheritdoc />
         public override string Name
         {

--- a/src/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
@@ -167,11 +167,16 @@ namespace System.IO.Abstractions.TestingHelpers
             }
         }
 
-#if NET6_0_OR_GREATER
+#if FEATURE_FILE_SYSTEM_INFO_LINK_TARGET
         /// <inheritdoc />
         public override string LinkTarget
         {
-            get { return null; }
+            get
+            {
+                // TODO Refactor to match #791 style (also hold on merge until that is merged)
+                if (MockFileData == null) throw CommonExceptions.FileNotFound(path);
+                return MockFileData.LinkTarget;
+            }
         }
 #endif
 

--- a/src/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
@@ -173,7 +173,7 @@ namespace System.IO.Abstractions.TestingHelpers
         {
             get
             {
-                var mockFileData = GetMockFileDataForWrite();
+                var mockFileData = GetMockFileDataForRead();
                 return mockFileData.LinkTarget;
             }
         }

--- a/src/System.IO.Abstractions.TestingHelpers/System.IO.Abstractions.TestingHelpers.csproj
+++ b/src/System.IO.Abstractions.TestingHelpers/System.IO.Abstractions.TestingHelpers.csproj
@@ -3,7 +3,7 @@
         <AssemblyName>System.IO.Abstractions.TestingHelpers</AssemblyName>
         <RootNamespace>System.IO.Abstractions.TestingHelpers</RootNamespace>
         <Description>A set of pre-built mocks to help when testing file system interactions.</Description>
-        <TargetFrameworks>net5.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
+        <TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
         <PackageIcon>icon_256x256.png</PackageIcon>
     </PropertyGroup>
     <ItemGroup>
@@ -16,6 +16,6 @@
         </PackageReference>
     </ItemGroup>
     <ItemGroup>
-        <None Include="..\..\images\icon_256x256.png" Pack="true" PackagePath="\"/>
+        <None Include="..\..\images\icon_256x256.png" Pack="true" PackagePath="\" />
     </ItemGroup>
 </Project>

--- a/src/System.IO.Abstractions/DirectoryInfoWrapper.cs
+++ b/src/System.IO.Abstractions/DirectoryInfoWrapper.cs
@@ -96,7 +96,7 @@ namespace System.IO.Abstractions
             set { instance.LastWriteTimeUtc = value; }
         }
 
-#if NET6_0_OR_GREATER
+#if FEATURE_FILE_SYSTEM_INFO_LINK_TARGET
         /// <inheritdoc />
         public override string LinkTarget
         {

--- a/src/System.IO.Abstractions/DirectoryInfoWrapper.cs
+++ b/src/System.IO.Abstractions/DirectoryInfoWrapper.cs
@@ -96,6 +96,14 @@ namespace System.IO.Abstractions
             set { instance.LastWriteTimeUtc = value; }
         }
 
+#if NET6_0_OR_GREATER
+        /// <inheritdoc />
+        public override string LinkTarget
+        {
+            get { return instance.LinkTarget; }
+        }
+#endif
+
         /// <inheritdoc />
         public override string Name
         {

--- a/src/System.IO.Abstractions/FileInfoWrapper.cs
+++ b/src/System.IO.Abstractions/FileInfoWrapper.cs
@@ -94,7 +94,7 @@ namespace System.IO.Abstractions
             set { instance.LastWriteTimeUtc = value; }
         }
 
-#if NET6_0_OR_GREATER
+#if FEATURE_FILE_SYSTEM_INFO_LINK_TARGET
         /// <inheritdoc />
         public override string LinkTarget
         {

--- a/src/System.IO.Abstractions/FileInfoWrapper.cs
+++ b/src/System.IO.Abstractions/FileInfoWrapper.cs
@@ -94,6 +94,14 @@ namespace System.IO.Abstractions
             set { instance.LastWriteTimeUtc = value; }
         }
 
+#if NET6_0_OR_GREATER
+        /// <inheritdoc />
+        public override string LinkTarget
+        {
+            get { return instance.LinkTarget; }
+        }
+#endif
+
         /// <inheritdoc />
         public override string Name
         {

--- a/src/System.IO.Abstractions/FileSystemInfoBase.cs
+++ b/src/System.IO.Abstractions/FileSystemInfoBase.cs
@@ -54,6 +54,11 @@
         /// <inheritdoc cref="FileSystemInfo.LastWriteTimeUtc"/>
         public abstract DateTime LastWriteTimeUtc { get; set; }
 
+#if NET6_0_OR_GREATER
+        /// <inheritdoc cref="FileSystemInfo.LinkTarget"/>
+        public abstract string LinkTarget { get; }
+#endif
+
         /// <inheritdoc cref="FileSystemInfo.Name"/>
         public abstract string Name { get; }
     }

--- a/src/System.IO.Abstractions/FileSystemInfoBase.cs
+++ b/src/System.IO.Abstractions/FileSystemInfoBase.cs
@@ -54,7 +54,7 @@
         /// <inheritdoc cref="FileSystemInfo.LastWriteTimeUtc"/>
         public abstract DateTime LastWriteTimeUtc { get; set; }
 
-#if NET6_0_OR_GREATER
+#if FEATURE_FILE_SYSTEM_INFO_LINK_TARGET
         /// <inheritdoc cref="FileSystemInfo.LinkTarget"/>
         public abstract string LinkTarget { get; }
 #endif

--- a/src/System.IO.Abstractions/System.IO.Abstractions.csproj
+++ b/src/System.IO.Abstractions/System.IO.Abstractions.csproj
@@ -3,14 +3,14 @@
     <AssemblyName>System.IO.Abstractions</AssemblyName>
     <RootNamespace>System.IO.Abstractions</RootNamespace>
     <Description>A set of abstractions to help make file system interactions testable.</Description>
-    <TargetFrameworks>net5.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0;net461</TargetFrameworks>
     <PackageIcon>icon_256x256.png</PackageIcon>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.7.0"/>
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0"/>
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.2">

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryArgumentPathTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryArgumentPathTests.cs
@@ -28,7 +28,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             yield return ds => ds.EnumerateDirectories(null, "foo", SearchOption.AllDirectories);
         }
 
-        [TestCaseSource("GetFileSystemActionsForArgumentNullException")]
+        [TestCaseSource(nameof(GetFileSystemActionsForArgumentNullException))]
         public void Operations_ShouldThrowArgumentNullExceptionIfPathIsNull(Action<IDirectory> action)
         {
             // Arrange

--- a/tests/System.IO.Abstractions.Tests/__snapshots__/ApiParityTests.DirectoryInfo_.NET 6.0.snap
+++ b/tests/System.IO.Abstractions.Tests/__snapshots__/ApiParityTests.DirectoryInfo_.NET 6.0.snap
@@ -9,8 +9,6 @@
     "System.IO.Abstractions.IFileSystemInfo ResolveLinkTarget(Boolean)",
     "System.Object GetLifetimeService()",
     "System.Object InitializeLifetimeService()",
-    "System.String LinkTarget",
-    "System.String get_LinkTarget()",
     "Void .ctor(System.String)",
     "Void CreateAsSymbolicLink(System.String)",
     "Void GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)"

--- a/tests/System.IO.Abstractions.Tests/__snapshots__/ApiParityTests.FileInfo_.NET 6.0.snap
+++ b/tests/System.IO.Abstractions.Tests/__snapshots__/ApiParityTests.FileInfo_.NET 6.0.snap
@@ -9,8 +9,6 @@
     "System.IO.Abstractions.IFileSystemInfo ResolveLinkTarget(Boolean)",
     "System.Object GetLifetimeService()",
     "System.Object InitializeLifetimeService()",
-    "System.String LinkTarget",
-    "System.String get_LinkTarget()",
     "Void .ctor(System.String)",
     "Void CreateAsSymbolicLink(System.String)",
     "Void GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)"

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "16.0",
+  "version": "16.1",
   "assemblyVersion": {
     "precision": "major"
   },


### PR DESCRIPTION
## Overview

In .NET 6, additional symlinks support was added to `FileSystemInfo`. This PR adds at least one of those properties here, the `LinkTarget` property.

See https://github.com/TestableIO/System.IO.Abstractions/issues/789

We need to discuss the mock portion of this though as I'm not sure how this codebase expects that.
