### PR TITLE
fix: add `LinkTarget` to `IFileSystemInfo`

### DIFF
--- a/src/System.IO.Abstractions/IFileSystemInfo.cs
+++ b/src/System.IO.Abstractions/IFileSystemInfo.cs
@@ -33,7 +33,7 @@
         DateTime LastWriteTimeUtc { get; set; }
 #if FEATURE_FILE_SYSTEM_INFO_LINK_TARGET
         /// <inheritdoc cref="FileSystemInfo.LinkTarget"/>
-        public abstract string LinkTarget { get; }
+        string LinkTarget { get; }
 #endif
         /// <inheritdoc cref="FileSystemInfo.Name"/>
         string Name { get; }

--- a/src/System.IO.Abstractions/IFileSystemInfo.cs
+++ b/src/System.IO.Abstractions/IFileSystemInfo.cs
@@ -31,6 +31,10 @@
         DateTime LastWriteTime { get; set; }
         /// <inheritdoc cref="FileSystemInfo.LastWriteTimeUtc"/>
         DateTime LastWriteTimeUtc { get; set; }
+#if FEATURE_FILE_SYSTEM_INFO_LINK_TARGET
+        /// <inheritdoc cref="FileSystemInfo.LinkTarget"/>
+        public abstract string LinkTarget { get; }
+#endif
         /// <inheritdoc cref="FileSystemInfo.Name"/>
         string Name { get; }
     }


### PR DESCRIPTION
In https://github.com/TestableIO/System.IO.Abstractions/pull/790 we added `LinkTarget` to `FileSystemInfoBase`, but I forgot to also add it to the interface (which was the whole point in the first place).

So this is embarrassing, but also it will allow `LinkTarget` to be used and mocked.