### PR TITLE
fix: initialize streams returned by MockFile.Create with ReadWrite access

### DIFF
--- a/src/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -138,7 +138,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         /// <inheritdoc />
         public override Stream Create(string path, int bufferSize, FileOptions options) =>
-           CreateInternal(path, FileAccess.Write, options);
+           CreateInternal(path, FileAccess.ReadWrite, options);
 
         private Stream CreateInternal(string path, FileAccess access, FileOptions options)
         {

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileCreateTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileCreateTests.cs
@@ -288,5 +288,18 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.That(fileSystem.File.Exists(relativeFile));
         }
+
+        [Test]
+        public void MockFile_Create_CanReadFromNewStream()
+        {
+            string fullPath = XFS.Path(@"c:\something\demo.txt");
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDirectory(XFS.Path(@"c:\something"));
+
+            using (var stream = fileSystem.File.Create(fullPath))
+            {
+                Assert.That(stream.CanRead, Is.True);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #801 