### PR TITLE
fix: make MockFile.Exists handle empty string

### DIFF
--- a/src/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -208,6 +208,7 @@ namespace System.IO.Abstractions.TestingHelpers
                 return false;
             }
 
+            //Not handling exceptions here so that mock behaviour is as similar as possible to System.IO.File.Exists (See #810)
             try
             {
                 mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, nameof(path));

--- a/src/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -203,13 +203,23 @@ namespace System.IO.Abstractions.TestingHelpers
                 return false;
             }
 
-            if (path.Length == 0)
+            if (path.Trim() == string.Empty)
             {
                 return false;
             }
 
-            var file = mockFileDataAccessor.GetFile(path);
-            return file != null && !file.IsDirectory;
+            try
+            {
+                mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, nameof(path));
+
+                var file = mockFileDataAccessor.GetFile(path);
+                return file != null && !file.IsDirectory;
+            }
+            catch (ArgumentException) { }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+
+            return false;
         }
 
         /// <inheritdoc />

--- a/src/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -216,6 +216,7 @@ namespace System.IO.Abstractions.TestingHelpers
                 return file != null && !file.IsDirectory;
             }
             catch (ArgumentException) { }
+            catch (NotSupportedException) { }
             catch (IOException) { }
             catch (UnauthorizedAccessException) { }
 

--- a/src/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -203,6 +203,11 @@ namespace System.IO.Abstractions.TestingHelpers
                 return false;
             }
 
+            if (path.Length == 0)
+            {
+                return false;
+            }
+
             var file = mockFileDataAccessor.GetFile(path);
             return file != null && !file.IsDirectory;
         }

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileExistsTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileExistsTests.cs
@@ -102,6 +102,19 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockFile_Exists_ShouldReturnFalseForInvalidCharactersInPath()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            var result = fileSystem.File.Exists(@"C:""*/:<>?|abc");
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
         public void MockFile_Exists_ShouldReturnFalseForDirectories()
         {
             // Arrange

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileExistsTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileExistsTests.cs
@@ -89,6 +89,19 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockFile_Exists_ShouldReturnFalseForEmptyStringPath()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+
+            // Act
+            var result = fileSystem.File.Exists(string.Empty);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
         public void MockFile_Exists_ShouldReturnFalseForDirectories()
         {
             // Arrange


### PR DESCRIPTION
PR created in relation to #810

Added check for path.Length in MockFile and added corresponding unit test.

I am a bit new to contributing so please let me know if I have missed anything :)