### PR TITLE
fix: GetDirectories returns relative paths if applicable

### DIFF
--- a/src/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -567,11 +567,13 @@ namespace System.IO.Abstractions.TestingHelpers
             return EnumerateDirectories(path, searchPattern, SearchOption.TopDirectoryOnly);
         }
 
+
         /// <inheritdoc />
         public override IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption)
         {
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
             var isOriginalPathRooted = mockFileDataAccessor.Path.IsPathRooted(path);
+            string originalPath = path;
             path = path.TrimSlashes();
             path = mockFileDataAccessor.Path.GetFullPath(path);
             var directories = GetFilesInternal(mockFileDataAccessor.AllDirectories, path, searchPattern, searchOption)
@@ -579,7 +581,10 @@ namespace System.IO.Abstractions.TestingHelpers
             if (!isOriginalPathRooted)
             {
                 //if the path was orginally relative, return relative paths: #815
-                directories = directories.Select(p => p.Substring(currentDirectory.Length + 1));
+                directories = directories
+                    .Select(p => p.Split(Path.DirectorySeparatorChar).Last()) //first get the last component of the path
+                    .Select(p => Path.Combine(originalPath, p)) //we combine the last component with the original base path
+                ;
             }
             return directories;
         }

--- a/src/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -571,10 +571,17 @@ namespace System.IO.Abstractions.TestingHelpers
         public override IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption)
         {
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
+            var isOriginalPathRooted = mockFileDataAccessor.Path.IsPathRooted(path);
             path = path.TrimSlashes();
             path = mockFileDataAccessor.Path.GetFullPath(path);
-            return GetFilesInternal(mockFileDataAccessor.AllDirectories, path, searchPattern, searchOption)
+            var directories = GetFilesInternal(mockFileDataAccessor.AllDirectories, path, searchPattern, searchOption)
                 .Where(p => !mockFileDataAccessor.StringOperations.Equals(p, path));
+            if (!isOriginalPathRooted)
+            {
+                //if the path was orginally relative, return relative paths: #815
+                directories = directories.Select(p => p.Substring(currentDirectory.Length + 1));
+            }
+            return directories;
         }
 
 #if FEATURE_ENUMERATION_OPTIONS

--- a/src/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -567,7 +567,6 @@ namespace System.IO.Abstractions.TestingHelpers
             return EnumerateDirectories(path, searchPattern, SearchOption.TopDirectoryOnly);
         }
 
-
         /// <inheritdoc />
         public override IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption)
         {

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -1211,7 +1211,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
         [TestCase(@"Folder\SubFolder")]
         [TestCase(@"Folder")]
-        public void MockDirectory_GetDirectories_RelativeDirectory_WithChildren_ShouldReturnChildDirectories(string relativeDirPath)
+        public void MockDirectory_GetDirectories_RelativeDirectory_WithChildren_ShouldReturnRelativeChildDirectories(string relativeDirPath)
         {
             // Arrange
             var currentDirectory = XFS.Path(@"T:\foo");
@@ -1224,7 +1224,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             CollectionAssert.AreEqual(
-                new[] { XFS.Path(currentDirectory + @"\" + relativeDirPath + @"\child") },
+                new[] { XFS.Path(relativeDirPath + @"\child") },
                 actualResult
             );
         }
@@ -1242,6 +1242,26 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             Assert.That(actualResult, Is.Empty);
+        }
+
+        [TestCase(@"Folder\SubFolder")]
+        [TestCase(@"Folder")]
+        public void MockDirectory_GetDirectories_AbsoluteDirectory_WithChildren_ShouldReturnAbsoluteChildDirectories(string relativeDirPath)
+        {
+            // Arrange
+            var currentDirectory = XFS.Path(@"T:\foo");
+            var fileSystem = new MockFileSystem(null, currentDirectory: currentDirectory);
+            fileSystem.Directory.CreateDirectory(XFS.Path(relativeDirPath));
+            fileSystem.Directory.CreateDirectory(XFS.Path(relativeDirPath + @"\child"));
+
+            // Act
+            var actualResult = fileSystem.Directory.GetDirectories(XFS.Path(currentDirectory + @"\" + relativeDirPath));
+
+            // Assert
+            CollectionAssert.AreEqual(
+                new[] { XFS.Path(currentDirectory + @"\" + relativeDirPath + @"\child") },
+                actualResult
+            );
         }
 
         [Test]

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -1211,6 +1211,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
         [TestCase(@"Folder\SubFolder")]
         [TestCase(@"Folder")]
+        [TestCase(@".\Folder")]
+        [TestCase(@"..\foo\Folder")]
+        [TestCase(@".\.\Folder")]
+        [TestCase(@"..\.\foo\.\Folder")]
         public void MockDirectory_GetDirectories_RelativeDirectory_WithChildren_ShouldReturnRelativeChildDirectories(string relativeDirPath)
         {
             // Arrange


### PR DESCRIPTION
This should fix #815 

If the path orginally given is relative, we return relative paths as well.
For instance in a folder structure like:
```
.
./foo
./foo/bar
```
where current directory is `/foobar`

Initially, the underlying method returns absolute paths i.e. calling `GetFilesInternal("/foobar/foo")` returns `/foobar/foo/bar`.
We then compute the last component of the full path i.e. `bar`, which we combine with the path originally requested:
- `foo -> foo/bar`
- `./foo -> ./foo/bar`
- `../foobar/foo -> ../foobar/foo/bar`

This works better than trying to get the absolute path relative to the current directory

Also, we add a new relevant test and adapt an existing incorrect test: 
It verifies that the returned paths are absolute, even though the path given is relative:
[MockDirectory_GetDirectories_RelativeDirectory_WithChildren_ShouldReturnChildDirectories(string relativeDirPath)](https://github.com/TestableIO/System.IO.Abstractions/blob/ced2f2b8e2a251cd87a0ee1049d19c947d0edfe3/tests/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs#L1214)
That test was added by #258 for #169 