### PR TITLE
ci: deploy only fixes and features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,13 @@ jobs:
           path: packages/*.*
   deploy:
     name: Deploy
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: |
+      github.ref == 'refs/heads/main' && 
+      github.event_name == 'push' &&
+      (
+        startsWith(github.event.head_commit.message, 'feat:') ||
+        startsWith(github.event.head_commit.message, 'fix:')
+      )
     needs: [pack]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I'd like to reduce the release noise a bit. There are more advanced options like `semantic-release` but they would require quite some rework. So I went for this simplistic approach 😄 