### PR TITLE
fix: MockFile - clone the bytes in read/write allbytes methods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,13 @@ jobs:
           path: packages/*.*
   deploy:
     name: Deploy
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: |
+      github.ref == 'refs/heads/main' && 
+      github.event_name == 'push' &&
+      (
+        startsWith(github.event.head_commit.message, 'feat:') ||
+        startsWith(github.event.head_commit.message, 'fix:')
+      )
     needs: [pack]
     runs-on: ubuntu-latest
     steps:

--- a/src/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -538,7 +538,7 @@ namespace System.IO.Abstractions.TestingHelpers
                 throw CommonExceptions.FileNotFound(path);
             }
             mockFileDataAccessor.GetFile(path).CheckFileAccess(path, FileAccess.Read);
-            return mockFileDataAccessor.GetFile(path).Contents;
+            return mockFileDataAccessor.GetFile(path).Contents.ToArray();
         }
 
         /// <inheritdoc />
@@ -784,7 +784,7 @@ namespace System.IO.Abstractions.TestingHelpers
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, "path");
             VerifyDirectoryExists(path);
 
-            mockFileDataAccessor.AddFile(path, new MockFileData(bytes));
+            mockFileDataAccessor.AddFile(path, new MockFileData(bytes.ToArray()));
         }
 
         /// <summary>

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileReadAllBytesTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileReadAllBytesTests.cs
@@ -66,10 +66,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockFile_ReadAllBytes_ShouldReturnANewCopyOfTheFileContents()
         {
-            const string path = @"c:\something\demo.bin";
+            var path = XFS.Path(@"c:\something\demo.bin");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
-                { XFS.Path(path), new MockFileData(new byte[] { 1, 2, 3, 4 }) }
+                { path, new MockFileData(new byte[] { 1, 2, 3, 4 }) }
             });
 
             var firstRead = fileSystem.File.ReadAllBytes(path);

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileReadAllBytesTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileReadAllBytesTests.cs
@@ -62,6 +62,28 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.AreEqual(data, fileSystem.File.ReadAllBytes(altPath));
         }
+
+        [Test]
+        public void MockFile_ReadAllBytes_ShouldReturnANewCopyOfTheFileContents()
+        {
+            const string path = @"c:\something\demo.bin";
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(path), new MockFileData(new byte[] { 1, 2, 3, 4 }) }
+            });
+
+            var firstRead = fileSystem.File.ReadAllBytes(path);
+
+            var secondRead = fileSystem.File.ReadAllBytes(path);
+
+            for (int i = 0; i < firstRead.Length; i++)
+            {
+                firstRead[i] += 1;
+            }
+
+            Assert.AreNotEqual(firstRead, secondRead);
+        }
+
 #if FEATURE_ASYNC_FILE
         [Test]
         public async Task MockFile_ReadAllBytesAsync_ShouldReturnOriginalByteData()

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllBytesTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllBytesTests.cs
@@ -83,6 +83,27 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(exception.ParamName, Is.EqualTo("bytes"));
         }
 
+        [Test]
+        public void MockFile_WriteAllBytes_ShouldWriteASeparateCopyToTheFileSystem()
+        {
+            var fileSystem = new MockFileSystem();
+            string path = XFS.Path(@"c:\something\file.bin");
+            fileSystem.AddDirectory(XFS.Path(@"c:\something"));
+            var fileContent = new byte[] { 1, 2, 3, 4 };
+
+            fileSystem.File.WriteAllBytes(path, fileContent);
+
+            for(int i = 0; i < fileContent.Length; i++)
+            {
+                fileContent[i] += 1;
+            }
+
+            var readAgain = fileSystem.File.ReadAllBytes(path);
+
+            Assert.AreNotEqual(fileContent, readAgain);
+        }
+
+
 #if FEATURE_ASYNC_FILE
         [Test]
         public void MockFile_WriteAllBytesAsync_ShouldThrowDirectoryNotFoundExceptionIfPathDoesNotExists()


### PR DESCRIPTION
### What is this doing?
* When reading from the MockFile's content with the ReadAllBytes method return a copy of the content, not a reference to the content itself.
* When writing to the MockFile content update it with a copy of the new content, not a reference to the new content.
### Why are we doing this?
These Read/WriteAllBytes should be result in two instances of the file content - one on the mock filesystem and the in-memory instance.
### How was it tested?
Unit tests to ensure there are two independent instances of the content after each operation.
