### PR TITLE
feat: Add support for default values on stream creation

### DIFF
--- a/src/System.IO.Abstractions.TestingHelpers/IMockFileDataAccessor.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/IMockFileDataAccessor.cs
@@ -78,6 +78,11 @@ namespace System.IO.Abstractions.TestingHelpers
         PathVerifier PathVerifier { get; }
 
         /// <summary>
+        /// Get if attributes for a file created via stream should be set to default or not
+        /// </summary>
+        bool SetAttributesOnStreamCreation { get; }
+
+        /// <summary>
         /// Gets a reference to the underlying file system. 
         /// </summary>
         IFileSystem FileSystem { get; }

--- a/src/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -150,7 +150,10 @@ namespace System.IO.Abstractions.TestingHelpers
             mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, nameof(path));
             VerifyDirectoryExists(path);
 
-            var mockFileData = new MockFileData(new byte[0]);
+            var mockFileData = mockFileDataAccessor.SetAttributesOnStreamCreation
+                ? MockFileData.NewObject
+                : new MockFileData(Array.Empty<byte>());
+
             mockFileDataAccessor.AddFile(path, mockFileData);
             return OpenInternal(path, FileMode.Open, access, options);
         }

--- a/src/System.IO.Abstractions.TestingHelpers/MockFileData.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFileData.cs
@@ -27,6 +27,14 @@ namespace System.IO.Abstractions.TestingHelpers
             Attributes = (FileAttributes)(-1),
         };
 
+        internal static readonly MockFileData NewObject = new MockFileData(string.Empty)
+        {
+            CreationTime = DateTime.Now,
+            LastWriteTime = DateTime.Now,
+            LastAccessTime = DateTime.Now,
+            Attributes = FileAttributes.Normal,
+        };
+
         /// <summary>
         /// Gets the default date time offset.
         /// E.g. for not existing files.

--- a/src/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFileStream.cs
@@ -59,7 +59,11 @@
                     throw CommonExceptions.FileNotFound(path);
                 }
 
-                mockFileDataAccessor.AddFile(path, new MockFileData(new byte[] { }));
+                var mfd = mockFileDataAccessor.SetAttributesOnStreamCreation
+                    ? MockFileData.NewObject
+                    : new MockFileData(Array.Empty<byte>());
+
+                mockFileDataAccessor.AddFile(path, mfd);
             }
 
             this.access = access;

--- a/src/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
@@ -87,6 +87,8 @@ namespace System.IO.Abstractions.TestingHelpers
         public IFileSystem FileSystem => this;
         /// <inheritdoc />
         public PathVerifier PathVerifier => pathVerifier;
+        /// <inheritdoc/>
+        public bool SetAttributesOnStreamCreation { get; set; }
 
         private string FixPath(string path, bool checkCaps = false)
         {

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
@@ -854,6 +854,28 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockFileInfo_Create_ShouldSetProperDefaultAttributes()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.SetAttributesOnStreamCreation = true;
+            var file = XFS.Path(@"C:\test\test.txt");
+            var fi = fileSystem.FileInfo.FromFileName(file);
+            if (!fi.Directory.Exists)
+            {
+                fi.Directory.Create();
+            }
+
+            // Act
+            using (var stream = fi.Create())
+            {
+                // Assert
+                Assert.AreEqual(FileAttributes.Normal, fi.Attributes);
+                Assert.LessOrEqual(DateTime.Now - fi.CreationTime, TimeSpan.FromSeconds(1));
+            }
+        }
+
+        [Test]
         public void MockFileInfo_Delete_ShouldUpdateCachedDataAndReturnFalseForExists()
         {
             var fileSystem = new MockFileSystem();

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
@@ -184,5 +184,25 @@
                 Assert.AreEqual(200, stream.Position);
             }
         }
+
+        [Test]
+        public void MockFileStream_Create_ShouldSetProperDefaultAttributes()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            fileSystem.SetAttributesOnStreamCreation = true;
+            var dir = XFS.Path(@"C:\test\");
+            var file = XFS.Path(@"C:\test\test.txt");
+            fileSystem.Directory.CreateDirectory(dir);
+
+            // Act
+            using (var stream = fileSystem.FileStream.Create(file, FileMode.Create))
+            {
+                var fi = fileSystem.FileInfo.FromFileName(file);
+                // Assert
+                Assert.AreEqual(FileAttributes.Normal, fi.Attributes);
+                Assert.LessOrEqual(DateTime.Now - fi.CreationTime, TimeSpan.FromSeconds(1));
+            }
+        }
     }
 }


### PR DESCRIPTION
For some tests we need the current `Datetime` and normal `FileAttributes` in order for the system under tests to work properly. This PR adds a new property to the `MockFileSystem` which initializes the `MockFileData` with the current `Datetime` and `FileAttributes` if needed.