### PR TITLE
Add adjusted timestamps on copied MockFiles

### DIFF
--- a/src/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -125,7 +125,9 @@ namespace System.IO.Abstractions.TestingHelpers
 
             var sourceFileData = mockFileDataAccessor.GetFile(sourceFileName);
             sourceFileData.CheckFileAccess(sourceFileName, FileAccess.Read);
-            mockFileDataAccessor.AddFile(destFileName, new MockFileData(sourceFileData));
+            var destFileData = new MockFileData(sourceFileData);
+            destFileData.CreationTime = destFileData.LastAccessTime = DateTime.Now;
+            mockFileDataAccessor.AddFile(destFileName, destFileData);
         }
 
         /// <inheritdoc />

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileCopyTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileCopyTests.cs
@@ -28,6 +28,23 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockFile_Copy_ShouldAdjustTimestampsOnDestination()
+        {
+            var sourceFileName = XFS.Path(@"c:\source\demo.txt");
+            var destFileName = XFS.Path(@"c:\source\demo_copy.txt");
+
+            var mockFileSystem = new MockFileSystem();
+            mockFileSystem.AddFile(sourceFileName, "Original");
+            mockFileSystem.File.Copy(sourceFileName, destFileName);
+
+            var sourceFileInfo = mockFileSystem.FileInfo.FromFileName(sourceFileName);
+            var destFileInfo = mockFileSystem.FileInfo.FromFileName(destFileName);
+            Assert.AreEqual(sourceFileInfo.LastWriteTime, destFileInfo.LastWriteTime);
+            Assert.LessOrEqual(DateTime.Now - destFileInfo.CreationTime, TimeSpan.FromSeconds(1));
+            Assert.AreEqual(destFileInfo.CreationTime, destFileInfo.LastAccessTime);
+        }
+
+        [Test]
         public void MockFile_Copy_ShouldCloneContents()
         {
             var sourceFileName = XFS.Path(@"c:\source\demo.txt");


### PR DESCRIPTION
For tests with MockFiles we would like to have the same behaviour as on a real 
file system regarding the timestamps on the copied file.