### PR TITLE
fix: improve cache invalidation in MockDirectoryInfo

### DIFF
--- a/src/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
@@ -42,6 +42,7 @@ namespace System.IO.Abstractions.TestingHelpers
         public override void Delete()
         {
             mockFileDataAccessor.Directory.Delete(directoryPath);
+            refreshOnNextRead = true;
         }
 
         /// <inheritdoc />
@@ -160,12 +161,14 @@ namespace System.IO.Abstractions.TestingHelpers
         public override void Create()
         {
             mockFileDataAccessor.Directory.CreateDirectory(FullName);
+            refreshOnNextRead = true;
         }
 
         /// <inheritdoc />
         public override void Create(DirectorySecurity directorySecurity)
         {
             mockFileDataAccessor.Directory.CreateDirectory(FullName, directorySecurity);
+            refreshOnNextRead = true;
         }
 
         /// <inheritdoc />
@@ -178,6 +181,7 @@ namespace System.IO.Abstractions.TestingHelpers
         public override void Delete(bool recursive)
         {
             mockFileDataAccessor.Directory.Delete(directoryPath, recursive);
+            refreshOnNextRead = true;
         }
 
         /// <inheritdoc />

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Security.AccessControl;
 using NUnit.Framework;
 
 namespace System.IO.Abstractions.TestingHelpers.Tests
@@ -439,6 +440,76 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Act
             fileSystem.AddDirectory(path);
             directoryInfo.Refresh();
+
+            // Assert
+            Assert.IsTrue(directoryInfo.Exists);
+        }
+
+        [Test]
+        public void Directory_exists_after_creation()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var directoryInfo = fileSystem.DirectoryInfo.FromDirectoryName(XFS.Path(@"c:\abc"));
+
+            // Act
+            directoryInfo.Create();
+
+            // Assert
+            Assert.IsTrue(directoryInfo.Exists);
+        }
+
+        [Test, WindowsOnly(WindowsSpecifics.AccessControlLists)]
+        public void Directory_exists_after_creation_with_security()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var directoryInfo = fileSystem.DirectoryInfo.FromDirectoryName(XFS.Path(@"c:\abc"));
+
+            // Act
+            directoryInfo.Create(new DirectorySecurity());
+
+            // Assert
+            Assert.IsTrue(directoryInfo.Exists);
+        }
+
+        [Test]
+        public void Directory_does_not_exist_after_delete()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var directoryInfo = fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\abc"));
+
+            // Act
+            directoryInfo.Delete();
+
+            // Assert
+            Assert.IsFalse(directoryInfo.Exists);
+        }
+
+        [Test]
+        public void Directory_does_not_exist_after_recursive_delete()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var directoryInfo = fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\abc"));
+
+            // Act
+            directoryInfo.Delete(true);
+
+            // Assert
+            Assert.IsFalse(directoryInfo.Exists);
+        }
+
+        [Test]
+        public void Directory_still_exists_after_move()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var directoryInfo = fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\abc"));
+
+            // Act
+            directoryInfo.MoveTo(XFS.Path(@"c:\abc2"));
 
             // Assert
             Assert.IsTrue(directoryInfo.Exists);


### PR DESCRIPTION
When invoking the `Create()` and `Delete()` methods on
`MockDirectoryInfo`, the `Exists` property should intrinsically invoke
`Refresh()` the next time it is called. This is necessary to prevent
returning stale state about the directory after those operations.

Additional test cases have been added for `MoveTo()` as well, to ensure
it also not returning stale state.

For context, this change was motivated by PR #828 where similar issues
were solved in `MockFileInfo`.