### PR TITLE
#849 - Implementing directory validation for ReadOnly files

### DIFF
--- a/src/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
@@ -176,8 +176,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
             lock (files)
             {
-                if (FileExists(fixedPath) &&
-                    (GetFile(fixedPath).Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
+                if (FileExists(fixedPath) && FileIsReadOnly(fixedPath))
                 {
                     throw CommonExceptions.AccessDenied(fixedPath);
                 }
@@ -302,7 +301,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
             lock (files)
             {
-                if (FileExists(path) && (GetFile(path).Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly)
+                if (FileExists(path) && (FileIsReadOnly(path) || Directory.Exists(path) && AnyFileIsReadOnly(path)))
                 {
                     throw CommonExceptions.AccessDenied(path);
                 }
@@ -375,6 +374,14 @@ namespace System.IO.Abstractions.TestingHelpers
             }
         }
 
+        private bool AnyFileIsReadOnly(string path)
+        {
+            lock (files)
+            {
+                return Directory.GetFiles(path).Any(file => FileIsReadOnly(file));
+            }
+        }
+
         private bool IsStartOfAnotherPath(string path)
         {
             return AllPaths.Any(otherPath => otherPath.StartsWith(path) && otherPath != path);
@@ -393,6 +400,14 @@ namespace System.IO.Abstractions.TestingHelpers
             lock (files)
             {
                 return files.TryGetValue(path, out var result) && result.Data.IsDirectory;
+            }
+        }
+
+        private bool FileIsReadOnly(string path)
+        {
+            lock (files)
+            {
+                return (GetFile(path).Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly;
             }
         }
 

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -401,6 +401,24 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.AreEqual(path, watcher.Path);
         }
 
+        [Test]
+        public void MockFileSystem_DeleteDirectoryRecursive_WithReadOnlyFile_ShouldThrowUnauthorizedException()
+        {
+            string baseDirectory = XFS.Path(@"C:\Test");
+            string textFile = XFS.Path(@"C:\Test\file.txt");
+
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(baseDirectory, new MockFileData(string.Empty));
+            fileSystem.AddFile(textFile, new MockFileData("Content"));
+            fileSystem.File.SetAttributes(textFile, FileAttributes.ReadOnly);
+
+            TestDelegate action = () => fileSystem.Directory.Delete(baseDirectory, true);
+
+            Assert.Throws<UnauthorizedAccessException>(action);
+            Assert.True(fileSystem.File.Exists(textFile));
+            Assert.True(fileSystem.Directory.Exists(baseDirectory));
+        }
+
         private class TestFileSystem : MockFileSystem
         {
             private readonly IFileSystemWatcherFactory fileSystemWatcherFactory;


### PR DESCRIPTION
#849 - Implementing directory validation for ReadOnly files when trying to delete directory recursively

On the RemoveFile method, there was no validation to check if there is a ReadOnly file inside the directory berfore trying to remove. This PR implements this validation.