### PR TITLE
fix: #736 - MoveTo implementation for MockDirectoryInfo under TestingHelpers

### DIFF
--- a/src/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
@@ -11,7 +11,7 @@ namespace System.IO.Abstractions.TestingHelpers
     public class MockDirectoryInfo : DirectoryInfoBase
     {
         private readonly IMockFileDataAccessor mockFileDataAccessor;
-        private readonly string directoryPath;
+        private string directoryPath;
         private readonly string originalPath;
         private MockFileData cachedMockFileData;
         private bool refreshOnNextRead;
@@ -27,14 +27,7 @@ namespace System.IO.Abstractions.TestingHelpers
             this.mockFileDataAccessor = mockFileDataAccessor ?? throw new ArgumentNullException(nameof(mockFileDataAccessor));
 
             originalPath = directoryPath;
-            directoryPath = mockFileDataAccessor.Path.GetFullPath(directoryPath);
-
-            directoryPath = directoryPath.TrimSlashes();
-            if (XFS.IsWindowsPlatform())
-            {
-                directoryPath = directoryPath.TrimEnd(' ');
-            }
-            this.directoryPath = directoryPath;
+            this.directoryPath = GetCleanDirectoryPath(directoryPath);
             Refresh();
         }
 
@@ -367,6 +360,7 @@ namespace System.IO.Abstractions.TestingHelpers
         public override void MoveTo(string destDirName)
         {
             mockFileDataAccessor.Directory.Move(directoryPath, destDirName);
+            directoryPath = GetCleanDirectoryPath(destDirName);
         }
 
         /// <inheritdoc />
@@ -408,6 +402,19 @@ namespace System.IO.Abstractions.TestingHelpers
             refreshOnNextRead = true;
             return mockFileDataAccessor.GetFile(directoryPath)
                 ?? throw CommonExceptions.CouldNotFindPartOfPath(directoryPath);
+        }
+        
+        private string GetCleanDirectoryPath(string path)
+        {
+            string cleanPath = mockFileDataAccessor.Path.GetFullPath(path);
+
+            cleanPath = cleanPath.TrimSlashes();
+            if (XFS.IsWindowsPlatform())
+            {
+                cleanPath = cleanPath.TrimEnd(' ');
+            }
+
+            return cleanPath;
         }
 
         /// <inheritdoc />

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
@@ -46,7 +46,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
-                {XFS.Path(@"c:\temp\folder\file.txt"), new MockFileData("Hello World")}
+                { XFS.Path(@"c:\temp\folder\file.txt"), new MockFileData("Hello World") }
             });
             var directoryInfo = new MockDirectoryInfo(fileSystem, path);
 
@@ -60,7 +60,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             var fileSystem = new MockFileSystem();
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\non\existing\file.txt"));
-            FileAttributes expected = (FileAttributes)(-1);
+            FileAttributes expected = (FileAttributes) (-1);
 
             Assert.That(directoryInfo.Attributes, Is.EqualTo(expected));
         }
@@ -83,7 +83,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
-                {fileName, ""}
+                { fileName, "" }
             });
 
             var directoryInfo = new MockDirectoryInfo(fileSystem, directoryName);
@@ -96,7 +96,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
 
-
         [Test]
         public void MockDirectoryInfo_FullName_ShouldReturnFullNameWithoutIncludingTrailingPathDelimiter()
         {
@@ -104,7 +103,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             {
                 {
                     XFS.Path(@"c:\temp\folder\file.txt"),
-                        new MockFileData("Hello World")
+                    new MockFileData("Hello World")
                 }
             });
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\temp\folder"));
@@ -529,6 +528,23 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(result, Is.EqualTo(MockFileData.DefaultDateTimeOffset.UtcDateTime));
         }
 
+        [Test]
+        public void MockDirectoryInfo_MoveTo_ShouldUpdateFullName()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { @"c:\source", new MockDirectoryData() },
+            });
+            var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\source"));
+        
+            // Act
+            directoryInfo.MoveTo(@"c:\destination");
+        
+            // Assert
+            Assert.AreEqual(@"c:\destination", directoryInfo.FullName);
+        }
+
         public void MockDirectoryInfo_CreationTime_SetterShouldThrowDirectoryNotFoundExceptionForNonExistingDirectory()
         {
             var newTime = new DateTime(2022, 04, 06);
@@ -582,6 +598,5 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.That(() => directoryInfo.LastWriteTime = newTime, Throws.TypeOf<DirectoryNotFoundException>());
         }
-
     }
 }


### PR DESCRIPTION
Fix for issue #736.
Made changes to the `MockDirectoryInfo` under `System.IO.Abstractions.TestingHelpers`.
`MoveTo` now updates the `directoryName` when moving the directory to the destination folder.

This should also fix the following methods (if they are called after `MoveTo` is called):
* Delete
* GetAccessControl
* GetDirectories
* SetAccessControl
* GetMockFileDataForWrite