### PR TITLE
chore(mergify): use PR title & body in commit message

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -5,7 +5,9 @@ pull_request_rules:
     actions:
       merge:
         method: squash
-        commit_message: title+body
+        commit_message_template: |-
+	        {{ title }} (#{{ number }})
+	        {{ body }}
   - name: Automatic merge for Renovate pull requests
     conditions:
       - author=renovate[bot]

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,8 +6,8 @@ pull_request_rules:
       merge:
         method: squash
         commit_message_template: |-
-	        {{ title }} (#{{ number }})
-	        {{ body }}
+          {{ title }} (#{{ number }})
+          {{ body }}
   - name: Automatic merge for Renovate pull requests
     conditions:
       - author=renovate[bot]

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -5,6 +5,7 @@ pull_request_rules:
     actions:
       merge:
         method: squash
+        commit_message: title+body
   - name: Automatic merge for Renovate pull requests
     conditions:
       - author=renovate[bot]


### PR DESCRIPTION
This will make mergify use the PR title and body in the message of the squash commit which is what we assume in our CI checks. 