### PR TITLE
feat: add CreateSymbolicLink support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <DefineConstants Condition="'$(TargetFramework)' != 'net461'">$(DefineConstants);FEATURE_FILE_SYSTEM_ACL_EXTENSIONS</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net5.0' OR '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'netstandard2.1'">$(DefineConstants);FEATURE_ASYNC_FILE;FEATURE_ENUMERATION_OPTIONS;FEATURE_ADVANCED_PATH_OPERATIONS;FEATURE_PATH_JOIN_WITH_SPAN</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net5.0'">$(DefineConstants);FEATURE_FILE_MOVE_WITH_OVERWRITE;FEATURE_SUPPORTED_OS_ATTRIBUTE;FEATURE_FILE_SYSTEM_WATCHER_FILTERS;FEATURE_ENDS_IN_DIRECTORY_SEPARATOR;FEATURE_PATH_JOIN_WITH_PARAMS;FEATURE_PATH_JOIN_WITH_FOUR_PATHS</DefineConstants>
-    <DefineConstants Condition="'$(TargetFramework)' == 'net6.0'">$(DefineConstants);FEATURE_FILE_SYSTEM_INFO_LINK_TARGET</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' == 'net6.0'">$(DefineConstants);FEATURE_FILE_SYSTEM_INFO_LINK_TARGET;FEATURE_CREATE_SYMBOLIC_LINK</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.109">

--- a/src/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -84,6 +84,30 @@ namespace System.IO.Abstractions.TestingHelpers
             return created;
         }
 
+#if FEATURE_CREATE_SYMBOLIC_LINK
+        /// <inheritdoc />
+        public override IFileSystemInfo CreateSymbolicLink(string path, string pathToTarget)
+        {
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(path, nameof(path));
+            mockFileDataAccessor.PathVerifier.IsLegalAbsoluteOrRelative(pathToTarget, nameof(pathToTarget));
+
+            if (Exists(path))
+            {
+                throw CommonExceptions.FileAlreadyExists(nameof(path));
+            }
+
+            var targetExists = Exists(pathToTarget);
+            if (!targetExists)
+            {
+                throw CommonExceptions.FileNotFound(pathToTarget);
+            }
+
+            mockFileDataAccessor.AddDirectory(path);
+            mockFileDataAccessor.GetFile(path).LinkTarget = pathToTarget;
+
+            return new MockDirectoryInfo(mockFileDataAccessor, path);
+        }
+#endif
 
         /// <inheritdoc />
         public override void Delete(string path)

--- a/src/System.IO.Abstractions/Converters.cs
+++ b/src/System.IO.Abstractions/Converters.cs
@@ -12,6 +12,9 @@ namespace System.IO.Abstractions
         internal static FileSystemInfoBase[] WrapFileSystemInfos(this FileSystemInfo[] input, IFileSystem fileSystem)
             => input.Select(info => WrapFileSystemInfo(fileSystem, info)).ToArray();
 
+        internal static FileSystemInfoBase WrapFileSystemInfo(this FileSystemInfo input, IFileSystem fileSystem)
+            => WrapFileSystemInfo(fileSystem, input);
+
         internal static IEnumerable<DirectoryInfoBase> WrapDirectories(this IEnumerable<DirectoryInfo> input, IFileSystem fileSystem)
             => input.Select(info => WrapDirectoryInfo(fileSystem, info));
 

--- a/src/System.IO.Abstractions/DirectoryBase.cs
+++ b/src/System.IO.Abstractions/DirectoryBase.cs
@@ -28,7 +28,10 @@ namespace System.IO.Abstractions
         /// <inheritdoc cref="IDirectory.CreateDirectory(string,DirectorySecurity)"/>
         [SupportedOSPlatform("windows")]
         public abstract IDirectoryInfo CreateDirectory(string path, DirectorySecurity directorySecurity);
-
+#if FEATURE_CREATE_SYMBOLIC_LINK
+        /// <inheritdoc cref="IDirectory.CreateSymbolicLink(string, string)"/>
+        public abstract IFileSystemInfo CreateSymbolicLink(string path, string pathToTarget);
+#endif
         /// <inheritdoc cref="IDirectory.Delete(string)"/>
         public abstract void Delete(string path);
 

--- a/src/System.IO.Abstractions/DirectoryWrapper.cs
+++ b/src/System.IO.Abstractions/DirectoryWrapper.cs
@@ -29,7 +29,13 @@ namespace System.IO.Abstractions
             directoryInfo.Create(directorySecurity);
             return new DirectoryInfoWrapper(FileSystem, directoryInfo);
         }
-
+#if FEATURE_CREATE_SYMBOLIC_LINK
+        /// <inheritdoc />
+        public override IFileSystemInfo CreateSymbolicLink(string path, string pathToTarget)
+        {
+            return Directory.CreateSymbolicLink(path, pathToTarget).WrapFileSystemInfo(FileSystem);
+        }
+#endif
         /// <inheritdoc />
         public override void Delete(string path)
         {

--- a/src/System.IO.Abstractions/FileBase.cs
+++ b/src/System.IO.Abstractions/FileBase.cs
@@ -52,7 +52,10 @@ namespace System.IO.Abstractions
 
         /// <inheritdoc cref="IFile.Create(string,int,FileOptions)"/>
         public abstract Stream Create(string path, int bufferSize, FileOptions options);
-
+#if FEATURE_CREATE_SYMBOLIC_LINK
+        /// <inheritdoc cref="IFile.CreateSymbolicLink(string, string)"/>
+        public abstract IFileSystemInfo CreateSymbolicLink(string path, string pathToTarget);
+#endif
         /// <inheritdoc cref="IFile.CreateText"/>
         public abstract StreamWriter CreateText(string path);
         /// <inheritdoc cref="IFile.Decrypt"/>

--- a/src/System.IO.Abstractions/FileWrapper.cs
+++ b/src/System.IO.Abstractions/FileWrapper.cs
@@ -75,6 +75,13 @@ namespace System.IO.Abstractions
             return File.Create(path, bufferSize, options);
         }
 
+#if FEATURE_CREATE_SYMBOLIC_LINK
+        /// <inheritdoc />
+        public override IFileSystemInfo CreateSymbolicLink(string path, string pathToTarget)
+        {
+            return File.CreateSymbolicLink(path, pathToTarget).WrapFileSystemInfo(FileSystem);
+        }
+#endif
         /// <inheritdoc />
         public override StreamWriter CreateText(string path)
         {

--- a/src/System.IO.Abstractions/IDirectory.cs
+++ b/src/System.IO.Abstractions/IDirectory.cs
@@ -20,6 +20,10 @@ namespace System.IO.Abstractions
         /// <inheritdoc cref="Directory.CreateDirectory(string,DirectorySecurity)"/>
 #endif
         IDirectoryInfo CreateDirectory(string path, DirectorySecurity directorySecurity);
+#if FEATURE_CREATE_SYMBOLIC_LINK
+        /// <inheritdoc cref="Directory.CreateSymbolicLink"/>
+        IFileSystemInfo CreateSymbolicLink(string path, string pathToTarget);
+#endif
         /// <inheritdoc cref="Directory.Delete(string)"/>
         void Delete(string path);
         /// <inheritdoc cref="Directory.Delete(string,bool)"/>

--- a/src/System.IO.Abstractions/IFile.cs
+++ b/src/System.IO.Abstractions/IFile.cs
@@ -33,6 +33,10 @@ namespace System.IO.Abstractions
         Stream Create(string path, int bufferSize);
         /// <inheritdoc cref="File.Create(string,int,FileOptions)"/>
         Stream Create(string path, int bufferSize, FileOptions options);
+#if FEATURE_CREATE_SYMBOLIC_LINK
+        /// <inheritdoc cref="File.CreateSymbolicLink"/>
+        IFileSystemInfo CreateSymbolicLink(string path, string pathToTarget);
+#endif
         /// <inheritdoc cref="File.CreateText"/>
         StreamWriter CreateText(string path);
         /// <inheritdoc cref="File.Decrypt"/>

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockDirectorySymlinkTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockDirectorySymlinkTests.cs
@@ -1,0 +1,205 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Versioning;
+using System.Security.AccessControl;
+using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using XFS = MockUnixSupport;
+
+    [TestFixture]
+    public class MockDirectorySimlinkTests
+    {
+
+#if FEATURE_CREATE_SYMBOLIC_LINK
+
+        [Test]
+        public void MockDirectory_CreateSymbolicLink_ShouldReturnFileSystemInfo()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var pathToTarget = XFS.Path(@"C:\Folder\foo");
+            var path = XFS.Path(@"C:\bar");
+            fileSystem.AddDirectory(pathToTarget);
+
+            // Act
+            IFileSystemInfo fileSystemInfo = fileSystem.Directory.CreateSymbolicLink(path, pathToTarget);
+
+            // Assert
+            Assert.AreEqual(path, fileSystemInfo.FullName);
+            Assert.AreEqual(pathToTarget, fileSystemInfo.LinkTarget);
+        }
+
+        [Test]
+        public void MockDirectory_CreateSymbolicLink_ShouldSucceedFromDirectoryInfo()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var pathToTarget = XFS.Path(@"C:\Folder\foo");
+            var path = XFS.Path(@"C:\bar");
+            fileSystem.AddDirectory(pathToTarget);
+
+            // Act
+            fileSystem.Directory.CreateSymbolicLink(path, pathToTarget);
+            IDirectoryInfo directoryInfo = fileSystem.DirectoryInfo.FromDirectoryName(path);
+
+            // Assert
+            Assert.AreEqual(path, directoryInfo.FullName);
+            Assert.AreEqual(pathToTarget, directoryInfo.LinkTarget);
+        }
+
+        [Test]
+        public void MockDirectory_CreateSymbolicLink_ShouldFailWithNullPath()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var pathToTarget = XFS.Path(@"C:\Folder\foo");
+            fileSystem.AddDirectory(pathToTarget);
+
+            // Act
+            var ex = Assert.Throws<ArgumentNullException>(() => fileSystem.Directory.CreateSymbolicLink(null, pathToTarget));
+
+            // Assert
+            Assert.That(ex.ParamName, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void MockDirectory_CreateSymbolicLink_ShouldFailWithNullTarget()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var path = XFS.Path(@"C:\Folder\foo");
+            fileSystem.AddDirectory(path);
+
+            // Act
+            var ex = Assert.Throws<ArgumentNullException>(() => fileSystem.Directory.CreateSymbolicLink(path, null));
+
+            // Assert
+            Assert.That(ex.ParamName, Is.EqualTo("pathToTarget"));
+        }
+
+        [Test]
+        public void MockDirectory_CreateSymbolicLink_ShouldFailWithEmptyPath()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var pathToTarget = XFS.Path(@"C:\Folder\foo");
+            fileSystem.AddDirectory(pathToTarget);
+
+            // Act
+            var ex = Assert.Throws<ArgumentException>(() => fileSystem.Directory.CreateSymbolicLink("", pathToTarget));
+
+            // Assert
+            Assert.That(ex.ParamName, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void MockDirectory_CreateSymbolicLink_ShouldFailWithEmptyTarget()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            string path = XFS.Path(@"C:\Folder\foo");
+            fileSystem.AddDirectory(path);
+
+            // Act
+            var ex = Assert.Throws<ArgumentException>(() => fileSystem.Directory.CreateSymbolicLink(path, ""));
+
+            // Assert
+            Assert.That(ex.ParamName, Is.EqualTo("pathToTarget"));
+        }
+
+        [Test]
+        public void MockDirectory_CreateSymbolicLink_ShouldFailWithIllegalPath()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            string pathToTarget = XFS.Path(@"C:\Folder\foo");
+            fileSystem.AddDirectory(pathToTarget);
+
+            // Act
+            var ex = Assert.Throws<ArgumentException>(() => fileSystem.Directory.CreateSymbolicLink(" ", pathToTarget));
+
+            // Assert
+            Assert.That(ex.ParamName, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void MockDirectory_CreateSymbolicLink_ShouldFailWithIllegalTarget()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            string path = XFS.Path(@"C:\Folder\foo");
+            fileSystem.AddDirectory(path);
+
+            // Act
+            var ex = Assert.Throws<ArgumentException>(() => fileSystem.Directory.CreateSymbolicLink(path, " "));
+
+            // Assert
+            Assert.That(ex.ParamName, Is.EqualTo("pathToTarget"));
+        }
+
+        [Test]
+        public void MockDirectory_CreateSymbolicLink_ShouldFailWithIllegalCharactersInPath()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            string pathToTarget = XFS.Path(@"C:\Folder\foo");
+            fileSystem.AddDirectory(pathToTarget);
+
+            // Act
+            TestDelegate ex = () => fileSystem.Directory.CreateSymbolicLink(@"C:\bar_?_", pathToTarget);
+
+            // Assert
+            Assert.Throws<ArgumentException>(ex);
+        }
+
+        [Test]
+        public void MockDirectory_CreateSymbolicLink_ShouldFailWithIllegalCharactersInTarget()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            string path = XFS.Path(@"C:\Folder\foo");
+            fileSystem.AddDirectory(path);
+
+            // Act
+            TestDelegate ex = () => fileSystem.Directory.CreateSymbolicLink(path, @"C:\bar_?_");
+
+            // Assert
+            Assert.Throws<ArgumentException>(ex);
+        }
+
+        [Test]
+        public void MockDirectory_CreateSymbolicLink_ShouldFailIfPathExists()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            string pathToTarget = XFS.Path(@"C:\Folder\foo");
+            string path = XFS.Path(@"C:\Folder\bar");
+            fileSystem.AddDirectory(pathToTarget);
+            fileSystem.AddDirectory(path);
+
+            // Act
+            var ex = Assert.Throws<IOException>(() => fileSystem.Directory.CreateSymbolicLink(path, pathToTarget));
+
+            // Assert
+            Assert.That(ex.Message.Contains("path"));
+        }
+
+        [Test]
+        public void MockDirectory_CreateSymbolicLink_ShouldFailIfTargetDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            string path = XFS.Path(@"C:\Folder\foo");
+            string pathToTarget = XFS.Path(@"C:\Target");
+
+            // Act
+            var ex = Assert.Throws<FileNotFoundException>(() => fileSystem.Directory.CreateSymbolicLink(path, pathToTarget));
+
+            // Assert
+            Assert.That(ex.Message.Contains(pathToTarget));
+        }
+#endif
+    }
+}

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockDirectorySymlinkTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockDirectorySymlinkTests.cs
@@ -9,7 +9,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     using XFS = MockUnixSupport;
 
     [TestFixture]
-    public class MockDirectorySimlinkTests
+    public class MockDirectorySymlinkTests
     {
 
 #if FEATURE_CREATE_SYMBOLIC_LINK
@@ -140,6 +140,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        [WindowsOnly(WindowsSpecifics.StrictPathRules)]
         public void MockDirectory_CreateSymbolicLink_ShouldFailWithIllegalCharactersInPath()
         {
             // Arrange
@@ -155,12 +156,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        [WindowsOnly(WindowsSpecifics.StrictPathRules)]
         public void MockDirectory_CreateSymbolicLink_ShouldFailWithIllegalCharactersInTarget()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
-            string path = XFS.Path(@"C:\Folder\foo");
-            fileSystem.AddDirectory(path);
+            string path = XFS.Path(@"C:\foo");
 
             // Act
             TestDelegate ex = () => fileSystem.Directory.CreateSymbolicLink(path, @"C:\bar_?_");

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSymlinkTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSymlinkTests.cs
@@ -9,7 +9,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     using XFS = MockUnixSupport;
 
     [TestFixture]
-    public class MockFileSimlinkTests
+    public class MockFileSymlinkTests
     {
 
 #if FEATURE_CREATE_SYMBOLIC_LINK
@@ -148,6 +148,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        [WindowsOnly(WindowsSpecifics.StrictPathRules)]
         public void MockFile_CreateSymbolicLink_ShouldFailWithIllegalCharactersInPath()
         {
             // Arrange
@@ -164,13 +165,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        [WindowsOnly(WindowsSpecifics.StrictPathRules)]
+
         public void MockFile_CreateSymbolicLink_ShouldFailWithIllegalCharactersInTarget()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
             string path = XFS.Path(@"C:\Folder\foo.txt");
-            var data = new MockFileData("foobar");
-            fileSystem.AddFile(path, data);
 
             // Act
             TestDelegate ex = () => fileSystem.File.CreateSymbolicLink(path, @"C:\bar.txt_?_");

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSymlinkTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSymlinkTests.cs
@@ -1,0 +1,235 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Versioning;
+using System.Security.AccessControl;
+using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using XFS = MockUnixSupport;
+
+    [TestFixture]
+    public class MockFileSimlinkTests
+    {
+
+#if FEATURE_CREATE_SYMBOLIC_LINK
+
+        [Test]
+        public void MockFile_CreateSymbolicLink_ShouldReturnFileSystemInfo()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var pathToTarget = XFS.Path(@"C:\Folder\foo.txt");
+            var path = XFS.Path(@"C:\bar.txt");
+            var data = new MockFileData("foobar");
+            fileSystem.AddFile(pathToTarget, data);
+
+            // Act
+            IFileSystemInfo fileSystemInfo = fileSystem.File.CreateSymbolicLink(path, pathToTarget);
+
+            // Assert
+            Assert.AreEqual(path, fileSystemInfo.FullName);
+            Assert.AreEqual(pathToTarget, fileSystemInfo.LinkTarget);
+        }
+
+        [Test]
+        public void MockFile_CreateSymbolicLink_ShouldSucceedFromFileInfo()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var pathToTarget = XFS.Path(@"C:\Folder\foo.txt");
+            var path = XFS.Path(@"C:\bar.txt");
+            var data = new MockFileData("foobar");
+            fileSystem.AddFile(pathToTarget, data);
+
+            // Act
+            fileSystem.File.CreateSymbolicLink(path, pathToTarget);
+            IFileInfo directoryInfo = fileSystem.FileInfo.FromFileName(path);
+
+            // Assert
+            Assert.AreEqual(path, directoryInfo.FullName);
+            Assert.AreEqual(pathToTarget, directoryInfo.LinkTarget);
+        }
+
+        [Test]
+        public void MockFile_CreateSymbolicLink_ShouldFailWithNullPath()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var pathToTarget = XFS.Path(@"C:\Folder\foo.txt");
+            var data = new MockFileData("foobar");
+            fileSystem.AddFile(pathToTarget, data);
+
+            // Act
+            var ex = Assert.Throws<ArgumentNullException>(() => fileSystem.File.CreateSymbolicLink(null, pathToTarget));
+
+            // Assert
+            Assert.That(ex.ParamName, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void MockFile_CreateSymbolicLink_ShouldFailWithNullTarget()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var path = XFS.Path(@"C:\Folder\foo.txt");
+            var data = new MockFileData("foobar");
+            fileSystem.AddFile(path, data);
+
+            // Act
+            var ex = Assert.Throws<ArgumentNullException>(() => fileSystem.File.CreateSymbolicLink(path, null));
+
+            // Assert
+            Assert.That(ex.ParamName, Is.EqualTo("pathToTarget"));
+        }
+
+        [Test]
+        public void MockFile_CreateSymbolicLink_ShouldFailWithEmptyPath()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var pathToTarget = XFS.Path(@"C:\Folder\foo.txt");
+            var data = new MockFileData("foobar");
+            fileSystem.AddFile(pathToTarget, data);
+
+            // Act
+            var ex = Assert.Throws<ArgumentException>(() => fileSystem.File.CreateSymbolicLink("", pathToTarget));
+
+            // Assert
+            Assert.That(ex.ParamName, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void MockFile_CreateSymbolicLink_ShouldFailWithEmptyTarget()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            string path = XFS.Path(@"C:\Folder\foo.txt");
+            var data = new MockFileData("foobar");
+            fileSystem.AddFile(path, data);
+
+            // Act
+            var ex = Assert.Throws<ArgumentException>(() => fileSystem.File.CreateSymbolicLink(path, ""));
+
+            // Assert
+            Assert.That(ex.ParamName, Is.EqualTo("pathToTarget"));
+        }
+
+        [Test]
+        public void MockFile_CreateSymbolicLink_ShouldFailWithIllegalPath()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            string pathToTarget = XFS.Path(@"C:\Folder\foo.txt");
+            var data = new MockFileData("foobar");
+            fileSystem.AddFile(pathToTarget, data);
+
+            // Act
+            var ex = Assert.Throws<ArgumentException>(() => fileSystem.File.CreateSymbolicLink(" ", pathToTarget));
+
+            // Assert
+            Assert.That(ex.ParamName, Is.EqualTo("path"));
+        }
+
+        [Test]
+        public void MockFile_CreateSymbolicLink_ShouldFailWithIllegalTarget()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            string path = XFS.Path(@"C:\Folder\foo.txt");
+            var data = new MockFileData("foobar");
+            fileSystem.AddFile(path, data);
+
+            // Act
+            var ex = Assert.Throws<ArgumentException>(() => fileSystem.File.CreateSymbolicLink(path, " "));
+
+            // Assert
+            Assert.That(ex.ParamName, Is.EqualTo("pathToTarget"));
+        }
+
+        [Test]
+        public void MockFile_CreateSymbolicLink_ShouldFailWithIllegalCharactersInPath()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            string pathToTarget = XFS.Path(@"C:\Folder\foo.txt");
+            var data = new MockFileData("foobar");
+            fileSystem.AddFile(pathToTarget, data);
+
+            // Act
+            TestDelegate ex = () => fileSystem.File.CreateSymbolicLink(@"C:\bar.txt_?_", pathToTarget);
+
+            // Assert
+            Assert.Throws<ArgumentException>(ex);
+        }
+
+        [Test]
+        public void MockFile_CreateSymbolicLink_ShouldFailWithIllegalCharactersInTarget()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            string path = XFS.Path(@"C:\Folder\foo.txt");
+            var data = new MockFileData("foobar");
+            fileSystem.AddFile(path, data);
+
+            // Act
+            TestDelegate ex = () => fileSystem.File.CreateSymbolicLink(path, @"C:\bar.txt_?_");
+
+            // Assert
+            Assert.Throws<ArgumentException>(ex);
+        }
+
+        [Test]
+        public void MockFile_CreateSymbolicLink_ShouldFailIfPathExists()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            string pathToTarget = XFS.Path(@"C:\Folder\foo.txt");
+            string path = XFS.Path(@"C:\Folder\bar.txt");
+            var data = new MockFileData("foobar");
+            fileSystem.AddFile(pathToTarget, data);
+            fileSystem.AddFile(path, data);
+
+            // Act
+            var ex = Assert.Throws<IOException>(() => fileSystem.File.CreateSymbolicLink(path, pathToTarget));
+
+            // Assert
+            Assert.That(ex.Message.Contains("path"));
+        }
+
+        [Test]
+        public void MockFile_CreateSymbolicLink_ShouldFailIfTargetDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            string dir = XFS.Path(@"C:\Folder");
+            string path = XFS.Path(@"C:\Folder\foo.txt");
+            string pathToTarget = XFS.Path(@"C:\bar.txt");
+            fileSystem.AddDirectory(dir);
+
+            // Act
+            var ex = Assert.Throws<FileNotFoundException>(() => fileSystem.File.CreateSymbolicLink(path, pathToTarget));
+
+            // Assert
+            Assert.That(ex.Message.Contains(pathToTarget));
+        }
+
+        [Test]
+        public void MockFile_CreateSymbolicLink_ShouldFailIfPathDirectoryDoesNotExist()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            string path = XFS.Path(@"C:\Folder\foo.txt");
+            string pathToTarget = XFS.Path(@"C:\bar.txt");
+            var data = new MockFileData("foobar");
+            fileSystem.AddFile(pathToTarget, data);
+
+            // Act
+            var ex = Assert.Throws<DirectoryNotFoundException>(() => fileSystem.File.CreateSymbolicLink(path, pathToTarget));
+
+            // Assert
+            Assert.That(ex.Message.Contains(path));
+        }
+#endif
+    }
+}

--- a/tests/System.IO.Abstractions.Tests/__snapshots__/ApiParityTests.Directory_.NET 6.0.snap
+++ b/tests/System.IO.Abstractions.Tests/__snapshots__/ApiParityTests.Directory_.NET 6.0.snap
@@ -6,7 +6,6 @@
     "Void SetAccessControl(System.String, System.Security.AccessControl.DirectorySecurity)"
   ],
   "MissingMembers": [
-    "System.IO.Abstractions.IFileSystemInfo CreateSymbolicLink(System.String, System.String)",
     "System.IO.Abstractions.IFileSystemInfo ResolveLinkTarget(System.String, Boolean)",
     "System.String[] GetFileSystemEntries(System.String, System.String, System.IO.EnumerationOptions)",
     "System.String[] GetFileSystemEntries(System.String, System.String, System.IO.SearchOption)"

--- a/tests/System.IO.Abstractions.Tests/__snapshots__/ApiParityTests.File_.NET 6.0.snap
+++ b/tests/System.IO.Abstractions.Tests/__snapshots__/ApiParityTests.File_.NET 6.0.snap
@@ -9,7 +9,6 @@
   "MissingMembers": [
     "Microsoft.Win32.SafeHandles.SafeFileHandle OpenHandle(System.String, System.IO.FileMode, System.IO.FileAccess, System.IO.FileShare, System.IO.FileOptions, Int64)",
     "System.IO.Stream Open(System.String, System.IO.StreamOptions)",
-    "System.IO.Abstractions.IFileSystemInfo CreateSymbolicLink(System.String, System.String)",
     "System.IO.Abstractions.IFileSystemInfo ResolveLinkTarget(System.String, Boolean)"
   ]
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "17.0",
+  "version": "17.1",
   "assemblyVersion": {
     "precision": "major"
   },


### PR DESCRIPTION
Adds a FileSystemInfo extension for wrapping convenience.
Adds FEATURE_CREATE_SYMBOLIC_LINK to the build properties.
Includes mock implementations and mock tests.
Updates the ApiParityTests to no longer ignore CreateSymbolicLink for .net 6.0.
Bumps the version in version.json.

See #869