### PR TITLE
fix: correctly handle access when moving a file

### DIFF
--- a/src/System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -4,8 +4,6 @@ using System.Linq;
 using System.Runtime.Versioning;
 using System.Security.AccessControl;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace System.IO.Abstractions.TestingHelpers
 {
@@ -397,8 +395,8 @@ namespace System.IO.Abstractions.TestingHelpers
             }
             VerifyDirectoryExists(destFileName);
 
-            mockFileDataAccessor.AddFile(destFileName, new MockFileData(sourceFile));
             mockFileDataAccessor.RemoveFile(sourceFileName);
+            mockFileDataAccessor.AddFile(destFileName, new MockFileData(sourceFile));
         }
 
 #if FEATURE_FILE_MOVE_WITH_OVERWRITE
@@ -443,8 +441,8 @@ namespace System.IO.Abstractions.TestingHelpers
             }
             VerifyDirectoryExists(destFileName);
 
-            mockFileDataAccessor.AddFile(destFileName, new MockFileData(sourceFile));
             mockFileDataAccessor.RemoveFile(sourceFileName);
+            mockFileDataAccessor.AddFile(destFileName, new MockFileData(sourceFile));
         }
 #endif
 

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileMoveTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileMoveTests.cs
@@ -28,6 +28,21 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockFile_Move_WithReadOnlyAttribute_ShouldThrowUnauthorizedAccessExceptionAndNotMoveFile()
+        {
+            var sourceFilePath = @"c:\foo.txt";
+            var destFilePath = @"c:\bar.txt";
+            var fileSystem = new MockFileSystem();
+            fileSystem.File.WriteAllText(sourceFilePath, "this is some content");
+            fileSystem.File.SetAttributes(sourceFilePath, FileAttributes.ReadOnly);
+
+            Assert.Throws<UnauthorizedAccessException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
+
+            Assert.That(fileSystem.File.Exists(sourceFilePath), Is.EqualTo(true));
+            Assert.That(fileSystem.File.Exists(destFilePath), Is.EqualTo(false));
+        }
+
+        [Test]
         public void MockFile_Move_SameSourceAndTargetIsANoOp()
         {
             string sourceFilePath = XFS.Path(@"c:\something\demo.txt");


### PR DESCRIPTION
Fixes #870:
Change the order when moving files:
1. Remove the previous file (throws an exception, if the file access is not sufficient)
2. Add the moved file on the new location

Also added a unit test to verify the behavior.