### PR TITLE
fix: set last access time with unspecified date time kind

### DIFF
--- a/src/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
@@ -137,7 +137,7 @@ namespace System.IO.Abstractions.TestingHelpers
             set
             {
                 var mockFileData = GetMockFileDataForWrite();
-                mockFileData.LastAccessTime = value;
+                mockFileData.LastAccessTime = value.ToLocalTime();
             }
         }
 

--- a/src/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
@@ -1,6 +1,5 @@
 ﻿using System.Runtime.Versioning;
 using System.Security.AccessControl;
-using System.Text;
 
 namespace System.IO.Abstractions.TestingHelpers
 {
@@ -65,7 +64,7 @@ namespace System.IO.Abstractions.TestingHelpers
             set
             {
                 var mockFileData = GetMockFileDataForWrite();
-                mockFileData.CreationTime = value;
+                mockFileData.CreationTime = AdjustUnspecifiedKind(value, DateTimeKind.Local);
             }
         }
 
@@ -80,7 +79,7 @@ namespace System.IO.Abstractions.TestingHelpers
             set
             {
                 var mockFileData = GetMockFileDataForWrite();
-                mockFileData.CreationTime = value.ToLocalTime();
+                mockFileData.CreationTime = AdjustUnspecifiedKind(value, DateTimeKind.Utc);
             }
         }
 
@@ -122,7 +121,7 @@ namespace System.IO.Abstractions.TestingHelpers
             set
             {
                 var mockFileData = GetMockFileDataForWrite();
-                mockFileData.LastAccessTime = value;
+                mockFileData.LastAccessTime = AdjustUnspecifiedKind(value, DateTimeKind.Local);
             }
         }
 
@@ -137,7 +136,7 @@ namespace System.IO.Abstractions.TestingHelpers
             set
             {
                 var mockFileData = GetMockFileDataForWrite();
-                mockFileData.LastAccessTime = value.ToLocalTime();
+                mockFileData.LastAccessTime = AdjustUnspecifiedKind(value, DateTimeKind.Utc);
             }
         }
 
@@ -152,7 +151,7 @@ namespace System.IO.Abstractions.TestingHelpers
             set
             {
                 var mockFileData = GetMockFileDataForWrite();
-                mockFileData.LastWriteTime = value;
+                mockFileData.LastWriteTime = AdjustUnspecifiedKind(value, DateTimeKind.Local);
             }
         }
 
@@ -167,7 +166,7 @@ namespace System.IO.Abstractions.TestingHelpers
             set
             {
                 var mockFileData = GetMockFileDataForWrite();
-                mockFileData.LastWriteTime = value.ToLocalTime();
+                mockFileData.LastWriteTime = AdjustUnspecifiedKind(value, DateTimeKind.Utc);
             }
         }
 
@@ -379,6 +378,16 @@ namespace System.IO.Abstractions.TestingHelpers
         public override string ToString()
         {
             return originalPath;
+        }
+
+        private static DateTime AdjustUnspecifiedKind(DateTime time, DateTimeKind fallbackKind)
+        {
+            if (time.Kind == DateTimeKind.Unspecified)
+            {
+                return DateTime.SpecifyKind(time, fallbackKind);
+            }
+
+            return time;
         }
 
         private MockFileData GetMockFileDataForRead()

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
@@ -393,6 +393,57 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockFileInfo_CreationTimeUtcWithUnspecifiedDateTimeKind_ShouldSetCreationTimeUtcOfFileInMemoryFileSystem()
+        {
+            var date = DateTime.SpecifyKind(DateTime.Now.AddHours(-4), DateTimeKind.Unspecified);
+            var fileData = new MockFileData("Demo text content");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { MockUnixSupport.Path(@"c:\a.txt"), fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, MockUnixSupport.Path(@"c:\a.txt"))
+            {
+                CreationTimeUtc = date,
+            };
+
+            Assert.AreEqual(date, fileInfo.CreationTimeUtc);
+        }
+
+        [Test]
+        public void MockFileInfo_LastAccessTimeUtcWithUnspecifiedDateTimeKind_ShouldSetLastAccessTimeUtcOfFileInMemoryFileSystem()
+        {
+            var date = DateTime.SpecifyKind(DateTime.Now.AddHours(-4), DateTimeKind.Unspecified);
+            var fileData = new MockFileData("Demo text content");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { MockUnixSupport.Path(@"c:\a.txt"), fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, MockUnixSupport.Path(@"c:\a.txt"))
+            {
+                LastAccessTimeUtc = date
+            };
+
+            Assert.AreEqual(date, fileInfo.LastAccessTimeUtc);
+        }
+
+        [Test]
+        public void MockFileInfo_LastWriteTimeUtcWithUnspecifiedDateTimeKind_ShouldSetLastWriteTimeUtcOfFileInMemoryFileSystem()
+        {
+            var date = DateTime.SpecifyKind(DateTime.Now.AddHours(-4), DateTimeKind.Unspecified);
+            var fileData = new MockFileData("Demo text content");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { MockUnixSupport.Path(@"c:\a.txt"), fileData }
+            });
+            var fileInfo = new MockFileInfo(fileSystem, MockUnixSupport.Path(@"c:\a.txt"))
+            {
+                LastWriteTimeUtc = date,
+            };
+
+            Assert.AreEqual(date, fileInfo.LastWriteTimeUtc);
+        }
+
+        [Test]
         public void MockFileInfo_LastWriteTime_ShouldReturnDefaultTimeForNonExistingFile()
         {
             var fileSystem = new MockFileSystem();

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
@@ -930,5 +930,101 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.Throws(typeof(System.IO.IOException), () => fi.Delete());
         }
+
+        [Test]
+        public void MockFileInfo_LastAccessTimeUtcWithUnspecifiedDateTimeKind_ShouldSetLastAccessTimeUtcOfFileInFileSystem()
+        {
+            var date = DateTime.SpecifyKind(DateTime.Now.AddHours(-4), DateTimeKind.Unspecified);
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory(@"c:\test");
+            fileSystem.File.WriteAllText(@"c:\test\a.txt", "Demo text content");
+            var fileInfo = new MockFileInfo(fileSystem, @"c:\test\a.txt")
+            {
+                LastAccessTimeUtc = date
+            };
+
+            Assert.AreEqual(date, fileInfo.LastAccessTimeUtc);
+            Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.LastAccessTimeUtc);
+        }
+
+        [Test]
+        public void MockFileInfo_LastAccessTimeWithUnspecifiedDateTimeKind_ShouldSetLastAccessTimeOfFileInFileSystem()
+        {
+            var date = DateTime.SpecifyKind(DateTime.Now.AddHours(-4), DateTimeKind.Unspecified);
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory(@"c:\test");
+            fileSystem.File.WriteAllText(@"c:\test\a.txt", "Demo text content");
+            var fileInfo = new MockFileInfo(fileSystem, @"c:\test\a.txt")
+            {
+                LastAccessTime = date
+            };
+
+            Assert.AreEqual(date, fileInfo.LastAccessTime);
+            Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.LastAccessTime);
+        }
+
+        [Test]
+        public void MockFileInfo_CreationTimeUtcWithUnspecifiedDateTimeKind_ShouldSetCreationTimeUtcOfFileInFileSystem()
+        {
+            var date = DateTime.SpecifyKind(DateTime.Now.AddHours(-4), DateTimeKind.Unspecified);
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory(@"c:\test");
+            fileSystem.File.WriteAllText(@"c:\test\a.txt", "Demo text content");
+            var fileInfo = new MockFileInfo(fileSystem, @"c:\test\a.txt")
+            {
+                CreationTimeUtc = date
+            };
+
+            Assert.AreEqual(date, fileInfo.CreationTimeUtc);
+            Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.CreationTimeUtc);
+        }
+
+        [Test]
+        public void MockFileInfo_CreationTimeWithUnspecifiedDateTimeKind_ShouldSetCreationTimeOfFileInFileSystem()
+        {
+            var date = DateTime.SpecifyKind(DateTime.Now.AddHours(-4), DateTimeKind.Unspecified);
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory(@"c:\test");
+            fileSystem.File.WriteAllText(@"c:\test\a.txt", "Demo text content");
+            var fileInfo = new MockFileInfo(fileSystem, @"c:\test\a.txt")
+            {
+                CreationTime = date
+            };
+
+            Assert.AreEqual(date, fileInfo.CreationTime);
+            Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.CreationTime);
+        }
+
+        [Test]
+        public void MockFileInfo_LastWriteTimeUtcWithUnspecifiedDateTimeKind_ShouldSetLastWriteTimeUtcOfFileInFileSystem()
+        {
+            var date = DateTime.SpecifyKind(DateTime.Now.AddHours(-4), DateTimeKind.Unspecified);
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory(@"c:\test");
+            fileSystem.File.WriteAllText(@"c:\test\a.txt", "Demo text content");
+            var fileInfo = new MockFileInfo(fileSystem, @"c:\test\a.txt")
+            {
+                LastWriteTimeUtc = date
+            };
+
+            Assert.AreEqual(date, fileInfo.LastWriteTimeUtc);
+            Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.LastWriteTimeUtc);
+        }
+
+        [Test]
+        public void MockFileInfo_LastWriteTimeWithUnspecifiedDateTimeKind_ShouldSetLastWriteTimeOfFileInFileSystem()
+        {
+            var date = DateTime.SpecifyKind(DateTime.Now.AddHours(-4), DateTimeKind.Unspecified);
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory(@"c:\test");
+            fileSystem.File.WriteAllText(@"c:\test\a.txt", "Demo text content");
+            var fileInfo = new MockFileInfo(fileSystem, @"c:\test\a.txt")
+            {
+                LastWriteTime = date
+            };
+
+            Assert.AreEqual(date, fileInfo.LastWriteTime);
+            Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.LastWriteTime);
+        }
     }
 }


### PR DESCRIPTION
This fixes a missing `ToLocalTime` conversion in the `MockFileInfo.LastAccessTimeUtc` setter, which leads to inconsistent results when dealing with `DateTime` values having `DateTimeKind.Unspecified`.