### PR TITLE
fix: Fixing UNC path GetFullPath when Current Directory is a UNC path

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockPath.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockPath.cs
@@ -85,7 +85,7 @@ namespace System.IO.Abstractions.TestingHelpers
             // unc paths need at least two segments, the others need one segment
             var isUnixRooted = mockFileDataAccessor.StringOperations.StartsWith(
                 mockFileDataAccessor.Directory.GetCurrentDirectory(),
-                string.Format(CultureInfo.InvariantCulture, "{0}", DirectorySeparatorChar));
+                "/");
 
             var minPathSegments = isUnc
                 ? 2
@@ -121,7 +121,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
             if (isUnixRooted && !isUnc)
             {
-                fullPath = DirectorySeparatorChar + fullPath;
+                fullPath = "/" + fullPath;
             }
             else if (isUnixRooted)
             {

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
@@ -96,7 +96,28 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.AreEqual(fileName, files[0].FullName);
         }
 
+        [Test]
+        [WindowsOnly(WindowsSpecifics.UNCPaths)]
+        public void MockDirectoryInfo_GetFiles_ShouldWorkWithUNCPath_WhenCurrentDirectoryIsUnc()
+        {
+            var fileName = XFS.Path(@"\\unc\folder\file.txt");
+            var directoryName = XFS.Path(@"\\unc\folder");
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                {fileName, ""}
+            });
+            
+            fileSystem.Directory.SetCurrentDirectory(directoryName);
 
+            var directoryInfo = new MockDirectoryInfo(fileSystem, directoryName);
+            
+            // Act
+            var files = directoryInfo.GetFiles();
+
+            // Assert
+            Assert.AreEqual(fileName, files[0].FullName);
+        }
 
         [Test]
         public void MockDirectoryInfo_FullName_ShouldReturnFullNameWithoutIncludingTrailingPathDelimiter()


### PR DESCRIPTION
Currently, if you switch current directory in the `MockFileSystem` to a UNC path, and try to enumerate files, it blows up.

Attempting to fix it, although it feels like a hack.