### PR TITLE
chg: Make mocked data lazy-loaded

### DIFF
--- a/src/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
+++ b/src/System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
@@ -12,7 +12,7 @@ namespace System.IO.Abstractions.TestingHelpers
         private readonly string originalPath;
         private MockFileData cachedMockFileData;
         private MockFile mockFile;
-        private bool refreshOnNextRead;
+        private bool refreshOnNextRead = true;
 
         /// <inheritdoc />
         public MockFileInfo(IMockFileDataAccessor mockFileSystem, string path) : base(mockFileSystem?.FileSystem)
@@ -21,7 +21,6 @@ namespace System.IO.Abstractions.TestingHelpers
             this.originalPath = path ?? throw new ArgumentNullException(nameof(path));
             this.path = mockFileSystem.Path.GetFullPath(path);
             this.mockFile = new MockFile(mockFileSystem);
-            Refresh();
         }
 
         /// <inheritdoc />

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
@@ -794,21 +794,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFileInfo_Exists_ShouldReturnCachedData()
-        {
-            // Arrange
-            var fileSystem = new MockFileSystem();
-            var path1 = XFS.Path(@"c:\temp\file1.txt");
-            var fileInfo = fileSystem.FileInfo.FromFileName(path1);
-
-            // Act
-            fileSystem.AddFile(path1, new MockFileData("1"));
-
-            // Assert
-            Assert.IsFalse(fileInfo.Exists);
-        }
-
-        [Test]
         public void MockFileInfo_Exists_ShouldUpdateCachedDataOnRefresh()
         {
             // Arrange

--- a/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -231,6 +231,21 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockFileSystem_AddFile_ShouldMarkFileAsExisting()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var path1 = XFS.Path(@"c:\temp\file1.txt");
+            var fileInfo = fileSystem.FileInfo.FromFileName(path1);
+
+            // Act
+            fileSystem.AddFile(path1, new MockFileData("1"));
+
+            // Assert
+            Assert.IsTrue(fileInfo.Exists);
+        }
+
+        [Test]
         public void MockFileSystem_AddFileFromEmbeddedResource_ShouldAddTheFile()
         {
             var fileSystem = new MockFileSystem();


### PR DESCRIPTION
This moves the initialization of `cachedMockFileData` to the first time that it is actually used. Apparently, this is more closely to how it works in .NET 6.