### PR TITLE
fix: change rollForward to "latestMinor" in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.100",
-    "rollForward": "latestFeature"
+    "version": "6.0.403",
+    "rollForward": "latestMajor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.403",
-    "rollForward": "latestMinor"
+    "version": "7.0.100",
+    "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "6.0.403",
-    "rollForward": "latestFeature"
+    "rollForward": "latestMajor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "version": "6.0.403",
-    "rollForward": "latestMajor"
+    "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
**Currently it is impossible to build System.IO.Abstractions with the latest Visual Studio version (v17.4.0) :-(**

"latestMinor" means:
> Uses the highest installed minor, feature band, and patch level that matches the requested major with a minor, feature band, and patch level that is greater or equal than the specified value.

*See [Microsoft Documentation](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json#rollforward)*