### PR TITLE
chore: ignore .NET 7

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.100",
+    "version": "6.0.403",
     "rollForward": "latestMinor"
   }
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -3,4 +3,11 @@
   ignorePaths: [
     // Clear the default list to enable Renovate for all files
   ],
+  packageRules: [
+    {
+      description: "Ignore .NET 7",
+      matchPackageNames: ["dotnet-sdk"],
+      allowedVersions: "<7"
+    }
+  ]
 }


### PR DESCRIPTION
Let's stick with LTS versions for the moment.

If we decide to upgrade we can probably also bump C# language version and maybe more.