### PR TITLE
feat: Add an explicit cast operator for FileSystemStream

### DIFF
--- a/src/TestableIO.System.IO.Abstractions/FileSystemStream.cs
+++ b/src/TestableIO.System.IO.Abstractions/FileSystemStream.cs
@@ -204,5 +204,15 @@ namespace System.IO.Abstractions
             _stream.Dispose();
             base.Dispose(disposing);
         }
+
+        /// <summary>
+        /// Allows to cast the internal Stream to a FileStream
+        /// </summary>
+        /// <param name="fsStream">The FileSystemStream to cast</param>
+        /// <exception cref="InvalidCastException"></exception>
+        public static explicit operator FileStream(FileSystemStream fsStream)
+        {
+            return (FileStream) fsStream._stream;
+        }
     }
 }


### PR DESCRIPTION
This commit adds an explicit cast to change the fact, that the underlaying FileStream can not be accessed in any way.
This has also the advantage that if the library is updated no code change is necessary if a cast was present from a stream.