### PR TITLE
fix: Fixed typos in test names, variables and method parameter name

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
@@ -275,15 +275,15 @@ namespace System.IO.Abstractions.TestingHelpers
         }
 
         /// <inheritdoc />
-        public void AddFilesFromEmbeddedNamespace(string path, Assembly resourceAssembly, string embeddedRresourcePath)
+        public void AddFilesFromEmbeddedNamespace(string path, Assembly resourceAssembly, string embeddedResourcePath)
         {
-            var matchingResources = resourceAssembly.GetManifestResourceNames().Where(f => f.StartsWith(embeddedRresourcePath));
+            var matchingResources = resourceAssembly.GetManifestResourceNames().Where(f => f.StartsWith(embeddedResourcePath));
             foreach (var resource in matchingResources)
             {
                 using (var embeddedResourceStream = resourceAssembly.GetManifestResourceStream(resource))
                 using (var streamReader = new BinaryReader(embeddedResourceStream))
                 {
-                    var fileName = resource.Substring(embeddedRresourcePath.Length + 1);
+                    var fileName = resource.Substring(embeddedResourcePath.Length + 1);
                     var fileData = streamReader.ReadBytes((int)embeddedResourceStream.Length);
                     var filePath = Path.Combine(path, fileName);
                     AddFile(filePath, new MockFileData(fileData));

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
@@ -67,7 +67,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockDirectoryInfo_Attributes_SetterShouldThrowDirectoryNotFoundEceptionOnNonExistingFileOrDirectory()
+        public void MockDirectoryInfo_Attributes_SetterShouldThrowDirectoryNotFoundExceptionOnNonExistingFileOrDirectory()
         {
             var fileSystem = new MockFileSystem();
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\non\existing"));

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -139,7 +139,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockDirectory_GetFiles_ShouldFilterByExtensionBasedSearchPatternWithThreeCharacterLongFileExtension_RepectingAllDirectorySearchOption()
+        public void MockDirectory_GetFiles_ShouldFilterByExtensionBasedSearchPatternWithThreeCharacterLongFileExtension_RespectingAllDirectorySearchOption()
         {
             // Arrange
             var additionalFilePath = XFS.Path(@"c:\a\a\c.gifx");
@@ -163,7 +163,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockDirectory_GetFiles_ShouldFilterByExtensionBasedSearchPatternWithThreeCharacterLongFileExtension_RepectingTopDirectorySearchOption()
+        public void MockDirectory_GetFiles_ShouldFilterByExtensionBasedSearchPatternWithThreeCharacterLongFileExtension_RespectingTopDirectorySearchOption()
         {
             // Arrange
             var additionalFilePath = XFS.Path(@"c:\a\c.gifx");
@@ -1485,7 +1485,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockDirectory_Move_ShouldMoveDirectoryAtrributes()
+        public void MockDirectory_Move_ShouldMoveDirectoryAttributes()
         {
             // Arrange
             var sourceDirName = XFS.Path(@"a:\folder1\");
@@ -1731,7 +1731,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockDirectory_Move_ShouldThrowADirectoryNotFoundExceptionIfDesinationDirectoryDoesNotExist()
+        public void MockDirectory_Move_ShouldThrowADirectoryNotFoundExceptionIfDestinationDirectoryDoesNotExist()
         {
             // Arrange
             string sourcePath = XFS.Path(@"c:\a");
@@ -1746,7 +1746,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockDirectory_Move_ShouldThrowAnIOExceptionIfDesinationDirectoryExists()
+        public void MockDirectory_Move_ShouldThrowAnIOExceptionIfDestinationDirectoryExists()
         {
             // Arrange
             string sourcePath = XFS.Path(@"c:\a");

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileCreateTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileCreateTests.cs
@@ -248,7 +248,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFile_Create_EncryptedOption_FileNotYetEncryptedsWhenStreamIsOpen()
+        public void MockFile_Create_EncryptedOption_FileNotYetEncryptedWhenStreamIsOpen()
         {
             var root = XFS.Path(@"C:\");
             var filePath = XFS.Path(@"C:\test.txt");

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoFactoryTests.cs
@@ -25,7 +25,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFileInfoFactory_New_ShouldReturnFileInfoForNonExistantFile()
+        public void MockFileInfoFactory_New_ShouldReturnFileInfoForNonExistentFile()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
@@ -51,7 +51,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFileInfo_Exists_ShouldRetunFalseIfPathLeadsToDirectory()
+        public void MockFileInfo_Exists_ShouldReturnFalseIfPathLeadsToDirectory()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -211,7 +211,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFileInfo_Attributes_SetterShouldThrowFileNotFoundEceptionOnNonExistingFileOrDirectory()
+        public void MockFileInfo_Attributes_SetterShouldThrowFileNotFoundExceptionOnNonExistingFileOrDirectory()
         {
             var fileSystem = new MockFileSystem();
             var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\non\existing\file.txt"));
@@ -578,7 +578,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFileInfo_MoveTo_SameSourceAndTargetThrowsExceptionIfSourceDoesntExist()
+        public void MockFileInfo_MoveTo_SameSourceAndTargetThrowsExceptionIfSourceDoesNotExist()
         {
             var fileSystem = new MockFileSystem();
             var fileInfo = fileSystem.FileInfo.New(XFS.Path(@"c:\temp\file.txt"));
@@ -590,7 +590,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFileInfo_MoveTo_ThrowsExceptionIfSourceDoesntExist()
+        public void MockFileInfo_MoveTo_ThrowsExceptionIfSourceDoesNotExist()
         {
             var fileSystem = new MockFileSystem();
             var fileInfo = fileSystem.FileInfo.New(XFS.Path(@"c:\temp\file.txt"));
@@ -640,7 +640,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFileInfo_CopyTo_ThrowsExceptionIfSourceDoesntExist()
+        public void MockFileInfo_CopyTo_ThrowsExceptionIfSourceDoesNotExist()
         {
             var fileSystem = new MockFileSystem();
             var fileInfo = fileSystem.FileInfo.New(XFS.Path(@"c:\temp\file.txt"));

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
@@ -121,7 +121,7 @@
         }
 
         [Test]
-        public void MockFileStream_Close_MultipleCallsDontThrow()
+        public void MockFileStream_Close_MultipleCallsDoNotThrow()
         {
             var fileSystem = new MockFileSystem();
             var path = XFS.Path("C:\\test");
@@ -136,7 +136,7 @@
         }
 
         [Test]
-        public void MockFileStream_Dispose_MultipleCallsDontThrow()
+        public void MockFileStream_Dispose_MultipleCallsDoNotThrow()
         {
             var fileSystem = new MockFileSystem();
             var path = XFS.Path("C:\\test");

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -103,7 +103,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFileSystem_AddFile_ShouldRepaceExistingFile()
+        public void MockFileSystem_AddFile_ShouldReplaceExistingFile()
         {
             var path = XFS.Path(@"c:\some\file.txt");
             const string existingContent = "Existing content";

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
@@ -178,31 +178,31 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFile_GetLastWriteTimeOfNonExistantFile_ShouldReturnDefaultValue()
+        public void MockFile_GetLastWriteTimeOfNonExistentFile_ShouldReturnDefaultValue()
         {
             ExecuteDefaultValueTest((f, p) => f.GetLastWriteTime(p));
         }
 
         [Test]
-        public void MockFile_GetLastWriteTimeUtcOfNonExistantFile_ShouldReturnDefaultValue()
+        public void MockFile_GetLastWriteTimeUtcOfNonExistentFile_ShouldReturnDefaultValue()
         {
             ExecuteDefaultValueTest((f, p) => f.GetLastWriteTimeUtc(p));
         }
 
         [Test]
-        public void MockFile_GetLastAccessTimeUtcOfNonExistantFile_ShouldReturnDefaultValue()
+        public void MockFile_GetLastAccessTimeUtcOfNonExistentFile_ShouldReturnDefaultValue()
         {
             ExecuteDefaultValueTest((f, p) => f.GetLastAccessTimeUtc(p));
         }
 
         [Test]
-        public void MockFile_GetLastAccessTimeOfNonExistantFile_ShouldReturnDefaultValue()
+        public void MockFile_GetLastAccessTimeOfNonExistentFile_ShouldReturnDefaultValue()
         {
             ExecuteDefaultValueTest((f, p) => f.GetLastAccessTime(p));
         }
 
         [Test]
-        public void MockFile_GetAttributeOfNonExistantFileButParentDirectoryExists_ShouldThrowOneFileNotFoundException()
+        public void MockFile_GetAttributeOfNonExistentFileButParentDirectoryExists_ShouldThrowOneFileNotFoundException()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -216,7 +216,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFile_GetAttributeOfNonExistantFile_ShouldThrowOneDirectoryNotFoundException()
+        public void MockFile_GetAttributeOfNonExistentFile_ShouldThrowOneDirectoryNotFoundException()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -288,13 +288,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFile_GetCreationTimeOfNonExistantFile_ShouldReturnDefaultValue()
+        public void MockFile_GetCreationTimeOfNonExistentFile_ShouldReturnDefaultValue()
         {
             ExecuteDefaultValueTest((f, p) => f.GetCreationTime(p));
         }
 
         [Test]
-        public void MockFile_GetCreationTimeUtcOfNonExistantFile_ShouldReturnDefaultValue()
+        public void MockFile_GetCreationTimeUtcOfNonExistentFile_ShouldReturnDefaultValue()
         {
             ExecuteDefaultValueTest((f, p) => f.GetCreationTimeUtc(p));
         }
@@ -498,7 +498,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFile_AppendText_AppendTextToanExistingFile()
+        public void MockFile_AppendText_AppendTextToAnExistingFile()
         {
             string filepath = XFS.Path(@"c:\something\does\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllLinesTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllLinesTests.cs
@@ -22,17 +22,17 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                     fileSystem.AddDirectory(XFS.Path(@"c:\something"));
                     var fileContentEnumerable = new List<string> { "first line", "second line", "third line", "fourth and last line" };
                     var fileContentArray = fileContentEnumerable.ToArray();
-                    Action writeEnumberable = () => fileSystem.File.WriteAllLines(Path, fileContentEnumerable);
-                    Action writeEnumberableUtf32 = () => fileSystem.File.WriteAllLines(Path, fileContentEnumerable, Encoding.UTF32);
+                    Action writeEnumerable = () => fileSystem.File.WriteAllLines(Path, fileContentEnumerable);
+                    Action writeEnumerableUtf32 = () => fileSystem.File.WriteAllLines(Path, fileContentEnumerable, Encoding.UTF32);
                     Action writeArray = () => fileSystem.File.WriteAllLines(Path, fileContentArray);
                     Action writeArrayUtf32 = () => fileSystem.File.WriteAllLines(Path, fileContentArray, Encoding.UTF32);
                     var expectedContent = string.Format(CultureInfo.InvariantCulture,
                         "first line{0}second line{0}third line{0}fourth and last line{0}", Environment.NewLine);
 
                     // IEnumerable
-                    yield return new TestCaseData(fileSystem, writeEnumberable, expectedContent)
+                    yield return new TestCaseData(fileSystem, writeEnumerable, expectedContent)
                         .SetName("WriteAllLines(string, IEnumerable<string>)");
-                    yield return new TestCaseData(fileSystem, writeEnumberableUtf32, expectedContent)
+                    yield return new TestCaseData(fileSystem, writeEnumerableUtf32, expectedContent)
                         .SetName("WriteAllLines(string, IEnumerable<string>, Encoding.UTF32)");
 
                     // string[]
@@ -66,15 +66,15 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 var fileSystem = new MockFileSystem();
                 var fileContentEnumerable = new List<string>();
                 var fileContentArray = fileContentEnumerable.ToArray();
-                TestDelegate writeEnumberable = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable);
-                TestDelegate writeEnumberableUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable, Encoding.UTF32);
+                TestDelegate writeEnumerable = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable);
+                TestDelegate writeEnumerableUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable, Encoding.UTF32);
                 TestDelegate writeArray = () => fileSystem.File.WriteAllLines(path, fileContentArray);
                 TestDelegate writeArrayUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentArray, Encoding.UTF32);
 
                 // IEnumerable
-                yield return new TestCaseData(writeEnumberable)
+                yield return new TestCaseData(writeEnumerable)
                     .SetName("WriteAllLines(string, IEnumerable<string>) input: " + path);
-                yield return new TestCaseData(writeEnumberableUtf32)
+                yield return new TestCaseData(writeEnumerableUtf32)
                     .SetName("WriteAllLines(string, IEnumerable<string>, Encoding.UTF32) input: " + path);
 
                 // string[]
@@ -91,11 +91,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                     var fileSystem = new MockFileSystem();
                     var fileContentEnumerable = new List<string>();
                     var fileContentArray = fileContentEnumerable.ToArray();
-                    TestDelegate writeEnumberableNull = () => fileSystem.File.WriteAllLines(Path, fileContentEnumerable, null);
+                    TestDelegate writeEnumerableNull = () => fileSystem.File.WriteAllLines(Path, fileContentEnumerable, null);
                     TestDelegate writeArrayNull = () => fileSystem.File.WriteAllLines(Path, fileContentArray, null);
 
                     // IEnumerable
-                    yield return new TestCaseData(writeEnumberableNull)
+                    yield return new TestCaseData(writeEnumerableNull)
                         .SetName("WriteAllLines(string, IEnumerable<string>, Encoding.UTF32)");
 
                     // string[]
@@ -113,15 +113,15 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                     fileSystem.Directory.CreateDirectory(path);
                     var fileContentEnumerable = new List<string>();
                     var fileContentArray = fileContentEnumerable.ToArray();
-                    TestDelegate writeEnumberable = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable);
-                    TestDelegate writeEnumberableUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable, Encoding.UTF32);
+                    TestDelegate writeEnumerable = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable);
+                    TestDelegate writeEnumerableUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable, Encoding.UTF32);
                     TestDelegate writeArray = () => fileSystem.File.WriteAllLines(path, fileContentArray);
                     TestDelegate writeArrayUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentArray, Encoding.UTF32);
 
                     // IEnumerable
-                    yield return new TestCaseData(writeEnumberable, path)
+                    yield return new TestCaseData(writeEnumerable, path)
                         .SetName("WriteAllLines(string, IEnumerable<string>)");
-                    yield return new TestCaseData(writeEnumberableUtf32, path)
+                    yield return new TestCaseData(writeEnumerableUtf32, path)
                         .SetName("WriteAllLines(string, IEnumerable<string>, Encoding.UTF32)");
 
                     // string[]
@@ -143,15 +143,15 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                     fileSystem.AddFile(path, mockFileData);
                     var fileContentEnumerable = new List<string>();
                     var fileContentArray = fileContentEnumerable.ToArray();
-                    TestDelegate writeEnumberable = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable);
-                    TestDelegate writeEnumberableUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable, Encoding.UTF32);
+                    TestDelegate writeEnumerable = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable);
+                    TestDelegate writeEnumerableUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable, Encoding.UTF32);
                     TestDelegate writeArray = () => fileSystem.File.WriteAllLines(path, fileContentArray);
                     TestDelegate writeArrayUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentArray, Encoding.UTF32);
 
                     // IEnumerable
-                    yield return new TestCaseData(writeEnumberable, path)
+                    yield return new TestCaseData(writeEnumerable, path)
                         .SetName("WriteAllLines(string, IEnumerable<string>)");
-                    yield return new TestCaseData(writeEnumberableUtf32, path)
+                    yield return new TestCaseData(writeEnumerableUtf32, path)
                         .SetName("WriteAllLines(string, IEnumerable<string>, Encoding.UTF32)");
 
                     // string[]
@@ -176,16 +176,16 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                     string[] fileContentArray = null;
 
                     // ReSharper disable ExpressionIsAlwaysNull
-                    TestDelegate writeEnumberable = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable);
-                    TestDelegate writeEnumberableUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable, Encoding.UTF32);
+                    TestDelegate writeEnumerable = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable);
+                    TestDelegate writeEnumerableUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable, Encoding.UTF32);
                     TestDelegate writeArray = () => fileSystem.File.WriteAllLines(path, fileContentArray);
                     TestDelegate writeArrayUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentArray, Encoding.UTF32);
                     // ReSharper restore ExpressionIsAlwaysNull
 
                     // IEnumerable
-                    yield return new TestCaseData(writeEnumberable)
+                    yield return new TestCaseData(writeEnumerable)
                         .SetName("WriteAllLines(string, IEnumerable<string>)");
-                    yield return new TestCaseData(writeEnumberableUtf32)
+                    yield return new TestCaseData(writeEnumerableUtf32)
                         .SetName("WriteAllLines(string, IEnumerable<string>, Encoding.UTF32)");
 
                     // string[]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllTextTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllTextTests.cs
@@ -32,7 +32,7 @@
         }
 
         [Test]
-        public void MockFile_WriteAllText_ShouldOverriteAnExistingFile()
+        public void MockFile_WriteAllText_ShouldOverwriteAnExistingFile()
         {
             // http://msdn.microsoft.com/en-us/library/ms143375.aspx
 

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/StringExtensionsTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/StringExtensionsTests.cs
@@ -98,7 +98,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void TrimSlashes_RootedPath_DontAlterPathWithoutTrailingSlashes()
+        public void TrimSlashes_RootedPath_DoNotAlterPathWithoutTrailingSlashes()
         {
             Assert.AreEqual(XFS.Path(@"c:\x"), XFS.Path(@"c:\x").TrimSlashes());
         }


### PR DESCRIPTION
While searching for a fix for #942, I noticed a few typos in (mostly) test method names so I fixed them. I didn't change any public methods that had any references.

I kept 'typos' like variable names that consist of multiple words but did not use camelcase, like 'newcontents'.