### PR TITLE
feat: introduce convenience methods into MockFileSystem

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
@@ -209,6 +209,53 @@ namespace System.IO.Abstractions.TestingHelpers
             }
         }
 
+        /// <summary>
+        /// Add a new file that is empty.
+        /// </summary>
+        /// <param name="path">A string representing the path of the new file to add.</param>
+        public void AddEmptyFile(string path)
+        {
+            AddFile(path, new MockFileData(""));
+        }
+
+        /// <summary>
+        /// Add a new file that is empty.
+        /// </summary>
+        /// <param name="path">An <see cref="IFileInfo"/> representing the path of the new file to add.</param>
+        public void AddEmptyFile(IFileInfo path)
+        {
+            AddEmptyFile(path.FullName);
+        }
+
+        /// <summary>
+        /// Add a new, empty directory.
+        /// </summary>
+        /// <param name="path">An <see cref="IDirectoryInfo"/> representing the path of the new directory to add.</param>
+        public void AddDirectory(IDirectoryInfo path)
+        {
+            AddDirectory(path.FullName);
+        }
+
+        /// <summary>
+        /// Add a new file with its contents set to a specified <see cref="MockFileData"/>.
+        /// </summary>
+        /// <param name="path">An <see cref="IFileInfo"/> representing the path of the new file to add.</param>
+        /// <param name="data">The data to use for the contents of the new file.</param>
+        public void AddFile(IFileInfo path, MockFileData data)
+        {
+            AddFile(path.FullName, data);
+        }
+
+        /// <summary>
+        /// Gets a file.
+        /// </summary>
+        /// <param name="path">The path of the file to get.</param>
+        /// <returns>The file. <see langword="null"/> if the file does not exist.</returns>
+        public MockFileData GetFile(IFileInfo path)
+        {
+            return GetFile(path.FullName);
+        }
+
         /// <inheritdoc />
         public void AddDirectory(string path)
         {

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -120,6 +120,17 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockFileSystem_AddEmptyFile_ShouldBeEmpty()
+        {
+            var path = XFS.Path(@"c:\some\file.txt");
+            var fileSystem = new MockFileSystem();
+
+            fileSystem.AddEmptyFile(path);
+
+            Assert.That(fileSystem.GetFile(path).TextContents, Is.EqualTo(""));
+        }
+
+        [Test]
         public void MockFileSystem_ByDefault_IsSerializable()
         {
             var file1 = new MockFileData("Demo\r\ntext\ncontent\rvalue");

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "19.1",
+  "version": "19.2",
   "assemblyVersion": {
     "precision": "major"
   },


### PR DESCRIPTION
- `AddEmptyFile()` added which is a convenience wrapper for `AddFile()` with an empty `MockFileData`.
- `AddFile()` overload added which consumes an `IFileInfo`.
- `AddDirectory()` overload added which consumes an `IDirectoryInfo`.
- `GetFile()` overload added which consumes an `IFileInfo`.

Unit test added for `AddEmptyFile()` but not the others, as the test code for them would have very little value.

Fixes TestableIO/System.IO.Abstractions.Extensions#32