### PR TITLE
Make FileSystemStream path argument non-nullable

### DIFF
--- a/src/TestableIO.System.IO.Abstractions/FileSystemStream.cs
+++ b/src/TestableIO.System.IO.Abstractions/FileSystemStream.cs
@@ -66,7 +66,7 @@ namespace System.IO.Abstractions
         ///     The <see cref="FileStream.IsAsync" /> flag, indicating if the <see cref="FileStream" /> was
         ///     opened asynchronously or synchronously.
         /// </param>
-        protected FileSystemStream(Stream stream, string? path, bool isAsync)
+        protected FileSystemStream(Stream stream, string path, bool isAsync)
         {
             if (path is null)
             {


### PR DESCRIPTION
Make "path" argument nullable in FileSystemStream constructor

Solving the second point #943 