### PR TITLE
fix: ensure `FlushAsync` behaves like `Flush`

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileStream.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileStream.cs
@@ -198,6 +198,13 @@ namespace System.IO.Abstractions.TestingHelpers
             InternalFlush();
         }
 
+        /// <inheritdoc />
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            InternalFlush();
+            return Task.CompletedTask;
+        }
+
         /// <inheritdoc cref="IFileSystemAclSupport.GetAccessControl()" />
         [SupportedOSPlatform("windows")]
         public object GetAccessControl()

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
@@ -42,7 +42,7 @@
             var cut = new MockFileStream(fileSystem, filepath, FileMode.Create);
 
             // Act
-            await cut.WriteAsync(new byte[] { 255 });
+            await cut.WriteAsync(new byte[] { 255 }, 0, 1);
             await cut.FlushAsync();
 
             // Assert

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace System.IO.Abstractions.TestingHelpers.Tests
 {
     using System.Collections.Generic;
+    using System.Threading.Tasks;
 
     using NUnit.Framework;
 
@@ -22,6 +23,27 @@
             // Act
             cut.WriteByte(255);
             cut.Flush();
+
+            // Assert
+            CollectionAssert.AreEqual(new byte[] { 255 }, fileSystem.GetFile(filepath).Contents);
+        }
+
+        [Test]
+        public async Task MockFileStream_FlushAsync_WritesByteToFile()
+        {
+            // bug replication test for issue
+            // https://github.com/TestableIO/System.IO.Abstractions/issues/959
+
+            // Arrange
+            var filepath = XFS.Path(@"C:\something\foo.txt");
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            fileSystem.AddDirectory(XFS.Path(@"C:\something"));
+
+            var cut = new MockFileStream(fileSystem, filepath, FileMode.Create);
+
+            // Act
+            await cut.WriteAsync(new byte[] { 255 });
+            await cut.FlushAsync();
 
             // Assert
             CollectionAssert.AreEqual(new byte[] { 255 }, fileSystem.GetFile(filepath).Contents);


### PR DESCRIPTION
Added an overwrite for `Stream.FlushAsync` to the `MockFileStream` class, which ensures that the internal flush implementation is called. This way `FlushAsync` will correctly project the changes to the underlying `MockFile`, exactly like `Flush` does. 

Closes #959