### PR TITLE
feat: Implemented MockDirectory.CreateTempSubDirectory

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -32,6 +32,7 @@ namespace System.IO.Abstractions.TestingHelpers
                 mockFileDataAccessor ?? throw new ArgumentNullException(nameof(mockFileDataAccessor));
         }
 
+
         /// <inheritdoc />
         public override IDirectoryInfo CreateDirectory(string path)
         {

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -2,7 +2,6 @@
 using System.Globalization;
 using System.Linq;
 using System.Runtime.Serialization;
-using System.Text;
 using System.Text.RegularExpressions;
 
 namespace System.IO.Abstractions.TestingHelpers

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
 
 namespace System.IO.Abstractions.TestingHelpers

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -16,7 +16,6 @@ namespace System.IO.Abstractions.TestingHelpers
     {
         private readonly IMockFileDataAccessor mockFileDataAccessor;
         private string currentDirectory;
-        
         /// <inheritdoc />
         public MockDirectory(IMockFileDataAccessor mockFileDataAccessor, FileBase fileBase, string currentDirectory) :
             this(mockFileDataAccessor, currentDirectory)

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -16,6 +16,7 @@ namespace System.IO.Abstractions.TestingHelpers
     {
         private readonly IMockFileDataAccessor mockFileDataAccessor;
         private string currentDirectory;
+
         /// <inheritdoc />
         public MockDirectory(IMockFileDataAccessor mockFileDataAccessor, FileBase fileBase, string currentDirectory) :
             this(mockFileDataAccessor, currentDirectory)

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -133,15 +133,7 @@ namespace System.IO.Abstractions.TestingHelpers
             // Perform directory name generation is a loop, just in case the randomly generated name already exists.
             do
             {
-                var randomChars = new StringBuilder();
-                lock (random)
-                {
-                    for (var i = 0; i < 6; i++)
-                    {
-                        randomChars.Append(ValidRandomSubdirChars[random.Next(ValidRandomSubdirChars.Length)]);
-                    }
-                }
-                var randomDir = $"{prefix}{randomChars}";
+                var randomDir = $"{prefix}{Path.GetRandomFileName()}";
                 potentialTempDirectory = Path.Combine(Path.GetTempPath(), randomDir);
             } while (Exists(potentialTempDirectory));
 

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -15,16 +15,9 @@ namespace System.IO.Abstractions.TestingHelpers
     [Serializable]
     public class MockDirectory : DirectoryBase
     {
-        private static readonly char[] ValidRandomSubdirChars = 
-            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".ToCharArray();
-
         private readonly IMockFileDataAccessor mockFileDataAccessor;
         private string currentDirectory;
         
-        // Random is not thread-safe, create our own instance and lock when accessing it.
-        [NonSerialized]
-        private Random random;
-
         /// <inheritdoc />
         public MockDirectory(IMockFileDataAccessor mockFileDataAccessor, FileBase fileBase, string currentDirectory) :
             this(mockFileDataAccessor, currentDirectory)
@@ -38,16 +31,7 @@ namespace System.IO.Abstractions.TestingHelpers
             this.currentDirectory = currentDirectory;
             this.mockFileDataAccessor =
                 mockFileDataAccessor ?? throw new ArgumentNullException(nameof(mockFileDataAccessor));
-            this.random = new Random();
         }
-
-        [OnDeserializing]
-        private void OnDeserializing(StreamingContext context)
-        {
-            // Random can't be serialized, create a new random when deserialized.
-            this.random = new Random();
-        }
-
 
         /// <inheritdoc />
         public override IDirectoryInfo CreateDirectory(string path)

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -128,16 +128,24 @@ namespace System.IO.Abstractions.TestingHelpers
         public override IDirectoryInfo CreateTempSubdirectory(string prefix = null)
         {
             prefix ??= "";
-            var randomChars = new StringBuilder();
-            lock (random)
+            string potentialTempDirectory;
+
+            // Perform directory name generation is a loop, just in case the randomly generated name already exists.
+            do
             {
-                for (var i = 0; i < 6; i++)
+                var randomChars = new StringBuilder();
+                lock (random)
                 {
-                    randomChars.Append(ValidRandomSubdirChars[random.Next(ValidRandomSubdirChars.Length)]);
+                    for (var i = 0; i < 6; i++)
+                    {
+                        randomChars.Append(ValidRandomSubdirChars[random.Next(ValidRandomSubdirChars.Length)]);
+                    }
                 }
-            }
-            var randomDir = $"{prefix}{randomChars}";
-            return CreateDirectoryInternal(Path.Combine(Path.GetTempPath(), randomDir));
+                var randomDir = $"{prefix}{randomChars}";
+                potentialTempDirectory = Path.Combine(Path.GetTempPath(), randomDir);
+            } while (Exists(potentialTempDirectory));
+
+            return CreateDirectoryInternal(Path.Combine(Path.GetTempPath(), potentialTempDirectory));
         }
 #endif
 

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace System.IO.Abstractions.TestingHelpers
@@ -14,8 +16,15 @@ namespace System.IO.Abstractions.TestingHelpers
     [Serializable]
     public class MockDirectory : DirectoryBase
     {
+        private static readonly char[] ValidRandomSubdirChars = 
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".ToCharArray();
+
         private readonly IMockFileDataAccessor mockFileDataAccessor;
         private string currentDirectory;
+        
+        // Random is not thread-safe, create our own instance and lock when accessing it.
+        [NonSerialized]
+        private Random random;
 
         /// <inheritdoc />
         public MockDirectory(IMockFileDataAccessor mockFileDataAccessor, FileBase fileBase, string currentDirectory) :
@@ -30,6 +39,14 @@ namespace System.IO.Abstractions.TestingHelpers
             this.currentDirectory = currentDirectory;
             this.mockFileDataAccessor =
                 mockFileDataAccessor ?? throw new ArgumentNullException(nameof(mockFileDataAccessor));
+            this.random = new Random();
+        }
+
+        [OnDeserializing]
+        private void OnDeserializing(StreamingContext context)
+        {
+            // Random can't be serialized, create a new random when deserialized.
+            this.random = new Random();
         }
 
 
@@ -110,7 +127,17 @@ namespace System.IO.Abstractions.TestingHelpers
         /// <inheritdoc />
         public override IDirectoryInfo CreateTempSubdirectory(string prefix = null)
         {
-            throw CommonExceptions.NotImplemented();
+            prefix ??= "";
+            var randomChars = new StringBuilder();
+            lock (random)
+            {
+                for (var i = 0; i < 6; i++)
+                {
+                    randomChars.Append(ValidRandomSubdirChars[random.Next(ValidRandomSubdirChars.Length)]);
+                }
+            }
+            var randomDir = $"{prefix}{randomChars}";
+            return CreateDirectoryInternal(Path.Combine(Path.GetTempPath(), randomDir));
         }
 #endif
 

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -113,14 +113,14 @@ namespace System.IO.Abstractions.TestingHelpers
             prefix ??= "";
             string potentialTempDirectory;
 
-            // Perform directory name generation is a loop, just in case the randomly generated name already exists.
+            // Perform directory name generation in a loop, just in case the randomly generated name already exists.
             do
             {
                 var randomDir = $"{prefix}{Path.GetRandomFileName()}";
                 potentialTempDirectory = Path.Combine(Path.GetTempPath(), randomDir);
             } while (Exists(potentialTempDirectory));
 
-            return CreateDirectoryInternal(Path.Combine(Path.GetTempPath(), potentialTempDirectory));
+            return CreateDirectoryInternal(potentialTempDirectory);
         }
 #endif
 

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -826,7 +826,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             Assert.IsTrue(fileSystem.Directory.Exists(result.FullName));
-            Assert.IsTrue(result.FullName.StartsWith(Path.GetTempPath()));
+            Assert.IsTrue(result.FullName.Contains(Path.GetTempPath()));
         }
 
         [Test]
@@ -841,7 +841,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Assert
             Assert.IsTrue(fileSystem.Directory.Exists(result.FullName));
             Assert.IsTrue(Path.GetFileName(result.FullName).StartsWith("foo-"));
-            Assert.IsTrue(result.FullName.StartsWith(Path.GetTempPath()));
+            Assert.IsTrue(result.FullName.Contains(Path.GetTempPath()));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.Serialization.Formatters.Binary;
 using System.Runtime.Versioning;
 using System.Security.AccessControl;
 using NUnit.Framework;

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -830,27 +830,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockDirectory_CreateTempSubdirectory_ShouldHaveCharactersFromUpperLowerOrDigits()
-        {
-            // Arrange
-            var fileSystem = new MockFileSystem();
-
-            // Act
-            var result = fileSystem.Directory.CreateTempSubdirectory();
-
-            // Assert
-            var name = Path.GetFileName(result.FullName);
-            for (var i = 0; i < name.Length; i++)
-            {
-                var c = name[i];
-                if (!char.IsUpper(c) && !char.IsLower(c) && !char.IsDigit(c))
-                {
-                    Assert.Fail($"Character '{c}' at position {i} of directory {name} is not upper, lower or digit", c, i);
-                }
-            }
-        }
-
-        [Test]
         public void MockDirectory_CreateTempSubdirectoryWithPrefix_ShouldCreateDirectoryWithGivenPrefixInTempDirectory()
         {
             // Arrange
@@ -863,28 +842,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.IsTrue(fileSystem.Directory.Exists(result.FullName));
             Assert.IsTrue(Path.GetFileName(result.FullName).StartsWith("foo-"));
             Assert.IsTrue(result.FullName.StartsWith(Path.GetTempPath()));
-        }
-
-        [Test]
-        public void MockDirectory_CreateTempSubdirectoryWithPrefix_ShouldEndWithCharactersFromUpperLowerOfDigits()
-        {
-            // Arrange
-            var prefix = "foo-";
-            var fileSystem = new MockFileSystem();
-
-            // Act
-            var result = fileSystem.Directory.CreateTempSubdirectory(prefix);
-
-            // Assert
-            var name = Path.GetFileName(result.FullName);
-            for (var i = prefix.Length; i < name.Length; i++)
-            {
-                var c = name[i];
-                if (!char.IsUpper(c) && !char.IsLower(c) && !char.IsDigit(c))
-                {
-                    Assert.Fail($"Character '{c}' at position {i} of directoy {name} is not upper, lower or digit", c, i);
-                }
-            }
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -843,30 +843,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.IsTrue(Path.GetFileName(result.FullName).StartsWith("foo-"));
             Assert.IsTrue(result.FullName.Contains(Path.GetTempPath()));
         }
-
-        [Test]
-        public void MockDirectory_CreateTempSubdirectory_ShouldCreateDirectoryAfterDeserialization()
-        {
-            // The random number generator used by CreateTempSubdirectory cannot be serialized, so
-            // we create a new Random after deserialization. Check that the random number generator
-            // is created after deserialization and we can still create a temp subdirectory.
-
-            // Arrange
-            var fileSystem = new MockFileSystem();
-            using var stream = new MemoryStream();
-            var formatter = new BinaryFormatter();
-            formatter.Serialize(stream, fileSystem);
-            stream.Position = 0;
-#pragma warning disable SYSLIB0011 // Allow call to obsolete Deserialize method            
-            var deserializedFileSystem = (MockFileSystem)formatter.Deserialize(stream);
-#pragma warning restore SYSLIB0011
-
-            // Act
-            var result = deserializedFileSystem.Directory.CreateTempSubdirectory();
-
-            // Assert
-            Assert.IsTrue(deserializedFileSystem.Directory.Exists(result.FullName));
-        }
 #endif
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests.csproj
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests.csproj
@@ -7,6 +7,7 @@
     <RootNamespace>System.IO.Abstractions.TestingHelpers.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
     <IsTestable>true</IsTestable>
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>    
   </PropertyGroup>
   <PropertyGroup>
     <!--  

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests.csproj
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests.csproj
@@ -7,7 +7,6 @@
     <RootNamespace>System.IO.Abstractions.TestingHelpers.Tests</RootNamespace>
     <IsPackable>false</IsPackable>
     <IsTestable>true</IsTestable>
-    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>    
   </PropertyGroup>
   <PropertyGroup>
     <!--  


### PR DESCRIPTION
Implemented MockDirectory.CreateTempSubdirectory(). This implementation generates a random 6 character string with an optional user specified prefix and creates the directory in the temporary directory returned by `Path.GetTempPath()`.

The 6 random characters seems to be the algorithm used on my platform (Mac) by the System.IO implementation.

Notes on this PR
1. There's a potential temporary directory namespace of $62^6$ or about 56.8 billion. As we get closer to this limit, the likelihood of generating a duplicate increases as well as the likelihood of slowdowns of the random generation. At the extreme case, if all possible temporary directories are created, creating a random directory name will effectively become an infinite loop. I assume we don't need to handle conditions close to the limit.
2. `MockDirectory` now contains a `Random` instance to generate random temp directory names. `Random.Shared` can't be used as it was introduced in .NET 6 it it appears we are supporting earlier .NET versions.
3. `MockDirectory` is marked as `[Serializable]`, however the `Random` instance cannot be serialized. I have marked the `Random` instance as `[NonSerialized]` and created a new `Random` instance on deserializing. The state of the random number generator will be different when deserialized. I don't think this is an issue as there was no way to specify the seed of the `Random` instance when creating the `MockDirectory` instance, so there's no way to generate the same sequence of random directories again (besides a very slim chance).
4. I have had to add `<EnableUnsafeBinaryFormatterSerialization>` on the test project and `#pragma warning disable SYSLIB0011` on the deserialize method to allow testing that deserialization of a `MockDirectory` also instantiates a new random number generator. Deserialization is heavily deprecated and this is only on test classes, so I am assuming this is OK.
