### PR TITLE
feat: add symbolic link functionality

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -550,6 +550,11 @@ namespace System.IO.Abstractions.TestingHelpers
                         nextLocation = nextContainer.LinkTarget;
                         nextContainer = mockFileDataAccessor.GetFile(nextLocation);
                     }
+
+                    if (nextContainer.LinkTarget != null)
+                    {
+                        throw new IOException($"The name of the file cannot be resolved by the system. : '{linkPath}'");
+                    }
                 }
 
                 if (nextContainer.IsDirectory)

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -530,7 +530,38 @@ namespace System.IO.Abstractions.TestingHelpers
         /// <inheritdoc />
         public override IFileSystemInfo ResolveLinkTarget(string linkPath, bool returnFinalTarget)
         {
-            throw CommonExceptions.NotImplemented();
+            var initialContainer = mockFileDataAccessor.GetFile(linkPath);
+            if (initialContainer.LinkTarget != null)
+            {
+                var nextLocation = initialContainer.LinkTarget;
+                var nextContainer = mockFileDataAccessor.GetFile(nextLocation);
+
+                if (returnFinalTarget)
+                {
+                    // The maximum number of symbolic links that are followed:
+                    // https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.resolvelinktarget?view=net-6.0#remarks
+                    int maxResolveLinks = XFS.IsWindowsPlatform() ? 63 : 40;
+                    for (int i = 1; i < maxResolveLinks; i++)
+                    {
+                        if (nextContainer.LinkTarget == null)
+                        {
+                            break;
+                        }
+                        nextLocation = nextContainer.LinkTarget;
+                        nextContainer = mockFileDataAccessor.GetFile(nextLocation);
+                    }
+                }
+
+                if (nextContainer.IsDirectory)
+                {
+                    return new MockDirectoryInfo(mockFileDataAccessor, nextLocation);
+                }
+                else
+                {
+                    return new MockFileInfo(mockFileDataAccessor, nextLocation);
+                }
+            }
+            throw new IOException($"The name of the file cannot be resolved by the system. : '{linkPath}'");
         }
     
 #endif

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
@@ -52,7 +52,7 @@ namespace System.IO.Abstractions.TestingHelpers
         /// <inheritdoc />
         public override void CreateAsSymbolicLink(string pathToTarget)
         {
-            throw CommonExceptions.NotImplemented();
+            FileSystem.Directory.CreateSymbolicLink(FullName, pathToTarget);
         }
 #endif
 
@@ -74,7 +74,7 @@ namespace System.IO.Abstractions.TestingHelpers
         /// <inheritdoc />
         public override IFileSystemInfo ResolveLinkTarget(bool returnFinalTarget)
         {
-            throw CommonExceptions.NotImplemented();
+            return FileSystem.Directory.ResolveLinkTarget(FullName, returnFinalTarget);
         }
 #endif
 

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -777,7 +777,38 @@ namespace System.IO.Abstractions.TestingHelpers
         /// <inheritdoc />
         public override IFileSystemInfo ResolveLinkTarget(string linkPath, bool returnFinalTarget)
         {
-            throw CommonExceptions.NotImplemented();
+            var initialContainer = mockFileDataAccessor.GetFile(linkPath);
+            if (initialContainer.LinkTarget != null)
+            {
+                var nextLocation = initialContainer.LinkTarget;
+                var nextContainer = mockFileDataAccessor.GetFile(nextLocation);
+
+                if (returnFinalTarget)
+                {
+                    // The maximum number of symbolic links that are followed:
+                    // https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.resolvelinktarget?view=net-6.0#remarks
+                    int maxResolveLinks = XFS.IsWindowsPlatform() ? 63 : 40;
+                    for (int i = 1; i < maxResolveLinks; i++)
+                    {
+                        if (nextContainer.LinkTarget == null)
+                        {
+                            break;
+                        }
+                        nextLocation = nextContainer.LinkTarget;
+                        nextContainer = mockFileDataAccessor.GetFile(nextLocation);
+                    }
+                }
+
+                if (nextContainer.IsDirectory)
+                {
+                    return new MockDirectoryInfo(mockFileDataAccessor, nextLocation);
+                }
+                else
+                {
+                    return new MockFileInfo(mockFileDataAccessor, nextLocation);
+                }
+            }
+            throw new IOException($"The name of the file cannot be resolved by the system. : '{linkPath}'");
         }
 #endif
 

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -797,6 +797,11 @@ namespace System.IO.Abstractions.TestingHelpers
                         nextLocation = nextContainer.LinkTarget;
                         nextContainer = mockFileDataAccessor.GetFile(nextLocation);
                     }
+
+                    if (nextContainer.LinkTarget != null)
+                    {
+                        throw new IOException($"The name of the file cannot be resolved by the system. : '{linkPath}'");
+                    }
                 }
 
                 if (nextContainer.IsDirectory)

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
@@ -29,7 +29,7 @@ namespace System.IO.Abstractions.TestingHelpers
         /// <inheritdoc />
         public override void CreateAsSymbolicLink(string pathToTarget)
         {
-            throw CommonExceptions.NotImplemented();
+            FileSystem.File.CreateSymbolicLink(FullName, pathToTarget);
         }
 #endif
 
@@ -51,7 +51,7 @@ namespace System.IO.Abstractions.TestingHelpers
         /// <inheritdoc />
         public override IFileSystemInfo ResolveLinkTarget(bool returnFinalTarget)
         {
-            throw CommonExceptions.NotImplemented();
+            return FileSystem.File.ResolveLinkTarget(FullName, returnFinalTarget);
         }
 #endif
 

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryInfoWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryInfoWrapper.cs
@@ -22,7 +22,7 @@ namespace System.IO.Abstractions
         /// <inheritdoc />
         public override void CreateAsSymbolicLink(string pathToTarget)
         {
-            throw new NotImplementedException();
+            instance.CreateAsSymbolicLink(pathToTarget);
         }
 #endif
 
@@ -42,7 +42,8 @@ namespace System.IO.Abstractions
         /// <inheritdoc />
         public override IFileSystemInfo ResolveLinkTarget(bool returnFinalTarget)
         {
-            throw new NotImplementedException();
+            return instance.ResolveLinkTarget(returnFinalTarget)
+                .WrapFileSystemInfo(FileSystem);
         }
 #endif
 

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryWrapper.cs
@@ -34,7 +34,8 @@ namespace System.IO.Abstractions
         /// <inheritdoc />
         public override IFileSystemInfo CreateSymbolicLink(string path, string pathToTarget)
         {
-            return Directory.CreateSymbolicLink(path, pathToTarget).WrapFileSystemInfo(FileSystem);
+            return Directory.CreateSymbolicLink(path, pathToTarget)
+                .WrapFileSystemInfo(FileSystem);
         }
 #endif
 
@@ -219,7 +220,8 @@ namespace System.IO.Abstractions
         /// <inheritdoc />
         public override IFileSystemInfo ResolveLinkTarget(string linkPath, bool returnFinalTarget)
         {
-            throw new NotSupportedException("TODO: Missing object implementing `IFileSystemInfo`");
+            return Directory.ResolveLinkTarget(linkPath, returnFinalTarget)
+                .WrapFileSystemInfo(FileSystem);
         }
 #endif
 

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileInfoWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileInfoWrapper.cs
@@ -39,7 +39,8 @@ namespace System.IO.Abstractions
         /// <inheritdoc />
         public override IFileSystemInfo ResolveLinkTarget(bool returnFinalTarget)
         {
-            throw new NotImplementedException();
+            return instance.ResolveLinkTarget(returnFinalTarget)
+                .WrapFileSystemInfo(FileSystem);
         }
 #endif
 

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileWrapper.cs
@@ -79,7 +79,8 @@ namespace System.IO.Abstractions
         /// <inheritdoc />
         public override IFileSystemInfo CreateSymbolicLink(string path, string pathToTarget)
         {
-            return File.CreateSymbolicLink(path, pathToTarget).WrapFileSystemInfo(FileSystem);
+            return File.CreateSymbolicLink(path, pathToTarget)
+                .WrapFileSystemInfo(FileSystem);
         }
 #endif
         /// <inheritdoc />
@@ -347,7 +348,8 @@ namespace System.IO.Abstractions
         /// <inheritdoc />
         public override IFileSystemInfo ResolveLinkTarget(string linkPath, bool returnFinalTarget)
         {
-            throw new NotImplementedException();
+            return File.ResolveLinkTarget(linkPath, returnFinalTarget)
+                .WrapFileSystemInfo(FileSystem);
         }
 #endif
 

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoSymlinkTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoSymlinkTests.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Versioning;
+using System.Security.AccessControl;
+using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using XFS = MockUnixSupport;
+
+    [TestFixture]
+    public class MockDirectoryInfoSymlinkTests
+    {
+
+#if FEATURE_CREATE_SYMBOLIC_LINK
+
+        [Test]
+        public void MockDirectoryInfo_ResolveLinkTarget_ShouldReturnPathOfTargetLink()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory("bar");
+            fileSystem.Directory.CreateSymbolicLink("foo", "bar");
+
+            var result = fileSystem.DirectoryInfo.New("foo").ResolveLinkTarget(false);
+
+            Assert.AreEqual("bar", result.Name);
+        }
+
+        [Test]
+        public void MockDirectoryInfo_ResolveLinkTarget_WithFinalTarget_ShouldReturnPathOfTargetLink()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory("bar");
+            fileSystem.Directory.CreateSymbolicLink("foo", "bar");
+            fileSystem.Directory.CreateSymbolicLink("foo1", "foo");
+
+            var result = fileSystem.DirectoryInfo.New("foo1").ResolveLinkTarget(true);
+
+            Assert.AreEqual("bar", result.Name);
+        }
+
+        [Test]
+        public void MockDirectoryInfo_ResolveLinkTarget_WithoutFinalTarget_ShouldReturnFirstLink()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory("bar");
+            fileSystem.Directory.CreateSymbolicLink("foo", "bar");
+            fileSystem.Directory.CreateSymbolicLink("foo1", "foo");
+
+            var result = fileSystem.DirectoryInfo.New("foo1").ResolveLinkTarget(false);
+
+            Assert.AreEqual("foo", result.Name);
+        }
+
+        [Test]
+        public void MockDirectoryInfo_ResolveLinkTarget_WithoutTargetLink_ShouldThrowIOException()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory("bar");
+            fileSystem.Directory.CreateSymbolicLink("foo", "bar");
+
+            Assert.Throws<IOException>(() =>
+            {
+                fileSystem.DirectoryInfo.New("bar").ResolveLinkTarget(false);
+            });
+        }
+#endif
+    }
+}

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectorySymlinkTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectorySymlinkTests.cs
@@ -201,6 +201,57 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Assert
             Assert.That(ex.Message.Contains(pathToTarget));
         }
+
+        [Test]
+        public void MockDirectory_ResolveLinkTarget_ShouldReturnPathOfTargetLink()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory("bar");
+            fileSystem.Directory.CreateSymbolicLink("foo", "bar");
+
+            var result = fileSystem.Directory.ResolveLinkTarget("foo", false);
+
+            Assert.AreEqual("bar", result.Name);
+        }
+
+        [Test]
+        public void MockDirectory_ResolveLinkTarget_WithFinalTarget_ShouldReturnPathOfTargetLink()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory("bar");
+            fileSystem.Directory.CreateSymbolicLink("foo", "bar");
+            fileSystem.Directory.CreateSymbolicLink("foo1", "foo");
+
+            var result = fileSystem.Directory.ResolveLinkTarget("foo1", true);
+
+            Assert.AreEqual("bar", result.Name);
+        }
+
+        [Test]
+        public void MockDirectory_ResolveLinkTarget_WithoutFinalTarget_ShouldReturnFirstLink()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory("bar");
+            fileSystem.Directory.CreateSymbolicLink("foo", "bar");
+            fileSystem.Directory.CreateSymbolicLink("foo1", "foo");
+
+            var result = fileSystem.Directory.ResolveLinkTarget("foo1", false);
+
+            Assert.AreEqual("foo", result.Name);
+        }
+
+        [Test]
+        public void MockDirectory_ResolveLinkTarget_WithoutTargetLink_ShouldThrowIOException()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory("bar");
+            fileSystem.Directory.CreateSymbolicLink("foo", "bar");
+
+            Assert.Throws<IOException>(() =>
+            {
+                fileSystem.Directory.ResolveLinkTarget("bar", false);
+            });
+        }
 #endif
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoSymlinkTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoSymlinkTests.cs
@@ -1,0 +1,69 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Versioning;
+using System.Security.AccessControl;
+using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    using XFS = MockUnixSupport;
+
+    [TestFixture]
+    public class MockFileInfoSymlinkTests
+    {
+
+#if FEATURE_CREATE_SYMBOLIC_LINK
+
+        [Test]
+        public void MockFileInfo_ResolveLinkTarget_ShouldReturnPathOfTargetLink()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.File.WriteAllText("bar", "some content");
+            fileSystem.File.CreateSymbolicLink("foo", "bar");
+
+            var result = fileSystem.FileInfo.New("foo").ResolveLinkTarget(false);
+
+            Assert.AreEqual("bar", result.Name);
+        }
+
+        [Test]
+        public void MockFileInfo_ResolveLinkTarget_WithFinalTarget_ShouldReturnPathOfTargetLink()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.File.WriteAllText("bar", "some content");
+            fileSystem.File.CreateSymbolicLink("foo", "bar");
+            fileSystem.File.CreateSymbolicLink("foo1", "foo");
+
+            var result = fileSystem.FileInfo.New("foo1").ResolveLinkTarget(true);
+
+            Assert.AreEqual("bar", result.Name);
+        }
+
+        [Test]
+        public void MockFileInfo_ResolveLinkTarget_WithoutFinalTarget_ShouldReturnFirstLink()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.File.WriteAllText("bar", "some content");
+            fileSystem.File.CreateSymbolicLink("foo", "bar");
+            fileSystem.File.CreateSymbolicLink("foo1", "foo");
+
+            var result = fileSystem.FileInfo.New("foo1").ResolveLinkTarget(false);
+
+            Assert.AreEqual("foo", result.Name);
+        }
+
+        [Test]
+        public void MockFileInfo_ResolveLinkTarget_WithoutTargetLink_ShouldThrowIOException()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.File.WriteAllText("bar", "some content");
+            fileSystem.File.CreateSymbolicLink("foo", "bar");
+
+            Assert.Throws<IOException>(() =>
+            {
+                fileSystem.FileInfo.New("bar").ResolveLinkTarget(false);
+            });
+        }
+#endif
+    }
+}

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSymlinkTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSymlinkTests.cs
@@ -1,8 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.Versioning;
-using System.Security.AccessControl;
-using NUnit.Framework;
+﻿using NUnit.Framework;
 
 namespace System.IO.Abstractions.TestingHelpers.Tests
 {
@@ -247,14 +243,42 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         public void MockFile_ResolveLinkTarget_WithFinalTarget_ShouldReturnPathOfTargetLink()
         {
+            // The maximum number of symbolic links that are followed:
+            // https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.resolvelinktarget?view=net-6.0#remarks
+            var maxResolveLinks = XFS.IsWindowsPlatform() ? 63 : 40;
             var fileSystem = new MockFileSystem();
             fileSystem.File.WriteAllText("bar", "some content");
-            fileSystem.File.CreateSymbolicLink("foo", "bar");
-            fileSystem.File.CreateSymbolicLink("foo1", "foo");
+            var previousPath = "bar";
+            for (int i = 0; i < maxResolveLinks; i++)
+            {
+                string newPath = $"foo-{i}";
+                fileSystem.File.CreateSymbolicLink(newPath, previousPath);
+                previousPath = newPath;
+            }
 
-            var result = fileSystem.File.ResolveLinkTarget("foo1", true);
+            var result = fileSystem.File.ResolveLinkTarget(previousPath, true);
 
             Assert.AreEqual("bar", result.Name);
+        }
+
+        [Test]
+        public void MockFile_ResolveLinkTarget_WithFinalTargetWithTooManyLinks_ShouldThrowIOException()
+        {
+            // The maximum number of symbolic links that are followed:
+            // https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.resolvelinktarget?view=net-6.0#remarks
+            var maxResolveLinks = XFS.IsWindowsPlatform() ? 63 : 40;
+            maxResolveLinks++;
+            var fileSystem = new MockFileSystem();
+            fileSystem.File.WriteAllText("bar", "some content");
+            var previousPath = "bar";
+            for (int i = 0; i < maxResolveLinks; i++)
+            {
+                string newPath = $"foo-{i}";
+                fileSystem.File.CreateSymbolicLink(newPath, previousPath);
+                previousPath = newPath;
+            }
+
+            Assert.Throws<IOException>(() => fileSystem.File.ResolveLinkTarget(previousPath, true));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSymlinkTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSymlinkTests.cs
@@ -231,6 +231,57 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Assert
             Assert.That(ex.Message.Contains(path));
         }
+
+        [Test]
+        public void MockFile_ResolveLinkTarget_ShouldReturnPathOfTargetLink()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.File.WriteAllText("bar", "some content");
+            fileSystem.File.CreateSymbolicLink("foo", "bar");
+
+            var result = fileSystem.File.ResolveLinkTarget("foo", false);
+
+            Assert.AreEqual("bar", result.Name);
+        }
+
+        [Test]
+        public void MockFile_ResolveLinkTarget_WithFinalTarget_ShouldReturnPathOfTargetLink()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.File.WriteAllText("bar", "some content");
+            fileSystem.File.CreateSymbolicLink("foo", "bar");
+            fileSystem.File.CreateSymbolicLink("foo1", "foo");
+
+            var result = fileSystem.File.ResolveLinkTarget("foo1", true);
+
+            Assert.AreEqual("bar", result.Name);
+        }
+
+        [Test]
+        public void MockFile_ResolveLinkTarget_WithoutFinalTarget_ShouldReturnFirstLink()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.File.WriteAllText("bar", "some content");
+            fileSystem.File.CreateSymbolicLink("foo", "bar");
+            fileSystem.File.CreateSymbolicLink("foo1", "foo");
+
+            var result = fileSystem.File.ResolveLinkTarget("foo1", false);
+
+            Assert.AreEqual("foo", result.Name);
+        }
+
+        [Test]
+        public void MockFile_ResolveLinkTarget_WithoutTargetLink_ShouldThrowIOException()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.File.WriteAllText("bar", "some content");
+            fileSystem.File.CreateSymbolicLink("foo", "bar");
+
+            Assert.Throws<IOException>(() =>
+            {
+                fileSystem.File.ResolveLinkTarget("bar", false);
+            });
+        }
 #endif
     }
 }


### PR DESCRIPTION
Implement the `CreateSymbolicLink` and `ResolveLinkTarget` methods on `Directory`, `DirectoryInfo`, `File` and `FileInfo`.