### PR TITLE
fix: support `Directory.GetFileSystemEntries` with enumeration options

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryWrapper.cs
@@ -162,7 +162,7 @@ namespace System.IO.Abstractions
         /// <inheritdoc />
         public override string[] GetFileSystemEntries(string path, string searchPattern, EnumerationOptions enumerationOptions)
         {
-            throw new NotImplementedException();
+            return Directory.GetFileSystemEntries(path, searchPattern, enumerationOptions);
         }
 #endif
 


### PR DESCRIPTION
Implement the missing wrapper method `Directory.GetFileSystemEntries(string, string, EnumerationOptions)`.