### PR TITLE
fix: throw IOException when creating a directory with a conflicting file

### DIFF
--- a/System.IO.Abstractions.sln
+++ b/System.IO.Abstractions.sln
@@ -25,6 +25,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_", "_", "{BBF7AD8D-5522-48C0-A906-00CBB72308A0}"
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
+		global.json = global.json
 	EndProjectSection
 EndProject
 Global

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -71,9 +71,14 @@ namespace System.IO.Abstractions.TestingHelpers
                 path = path.TrimEnd(' ');
             }
 
-            if (!Exists(path))
+            var existingFile = mockFileDataAccessor.GetFile(path);
+            if (existingFile == null)
             {
                 mockFileDataAccessor.AddDirectory(path);
+            }
+            else if (!existingFile.IsDirectory)
+            {
+                throw CommonExceptions.FileAlreadyExists("path");
             }
 
             var created = new MockDirectoryInfo(mockFileDataAccessor, path);

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
@@ -621,6 +621,20 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(result, Is.EqualTo(MockFileData.DefaultDateTimeOffset.UtcDateTime));
         }
 
+        [Test]
+        public void MockDirectoryInfo_Create_WithConflictingFile_ShouldThrowIOException()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(XFS.Path(@"c:\foo\bar.txt"), new MockFileData("Demo text content"));
+            var sut = fileSystem.DirectoryInfo.New(XFS.Path(@"c:\foo\bar.txt"));
+
+            // Act
+            TestDelegate action = () => sut.Create();
+
+            // Assert
+            Assert.Throws<IOException>(action);
+        }
+
         public void MockDirectoryInfo_CreationTime_SetterShouldThrowDirectoryNotFoundExceptionForNonExistingDirectory()
         {
             var newTime = new DateTime(2022, 04, 06);

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -663,6 +663,19 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockDirectory_CreateDirectory_WithConflictingFile_ShouldThrowIOException()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddFile(XFS.Path(@"c:\foo\bar.txt"), new MockFileData("Demo text content"));
+            
+            // Act
+            TestDelegate action = () => fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\foo\bar.txt"));
+
+            // Assert
+            Assert.Throws<IOException>(action);
+        }
+
+        [Test]
         public void MockDirectory_Exists_ShouldReturnFalseForFiles()
         {
             // Arrange


### PR DESCRIPTION
Fixes #968:
When creating a directory, check if a file with the same name already exists. If so, throw an IOException.