### PR TITLE
fix: always keep `FileAttributes.Directory` on directories

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
@@ -82,7 +82,7 @@ namespace System.IO.Abstractions.TestingHelpers
         public override FileAttributes Attributes
         {
             get { return GetMockFileDataForRead().Attributes; }
-            set { GetMockFileDataForWrite().Attributes = value; }
+            set { GetMockFileDataForWrite().Attributes = value | FileAttributes.Directory; }
         }
 
         /// <inheritdoc />

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
@@ -66,7 +66,7 @@ namespace System.IO.Abstractions.TestingHelpers
             set
             {
                 var mockFileData = GetMockFileDataForWrite();
-                mockFileData.Attributes = value;
+                mockFileData.Attributes = value & ~FileAttributes.Directory;
             }
         }
 

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
@@ -67,6 +67,19 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockDirectoryInfo_Attributes_Clear_ShouldRemainDirectory()
+        {
+            var fileSystem = new MockFileSystem();
+            var path = XFS.Path(@"c:\existing\directory");
+            fileSystem.Directory.CreateDirectory(path);
+            var directoryInfo = fileSystem.DirectoryInfo.New(path);
+            directoryInfo.Attributes = 0;
+
+            Assert.That(fileSystem.File.Exists(path), Is.False);
+            Assert.That(directoryInfo.Attributes, Is.EqualTo(FileAttributes.Directory));
+        }
+
+        [Test]
         public void MockDirectoryInfo_Attributes_SetterShouldThrowDirectoryNotFoundExceptionOnNonExistingFileOrDirectory()
         {
             var fileSystem = new MockFileSystem();


### PR DESCRIPTION
Fix #957:
Always keep `FileAttributes.Directory` on directories (and never on files).