### PR TITLE
docs: improve documentation for `FileSystemStream`

### DIFF
--- a/src/TestableIO.System.IO.Abstractions/FileSystemStream.cs
+++ b/src/TestableIO.System.IO.Abstractions/FileSystemStream.cs
@@ -4,7 +4,9 @@ using System.Threading.Tasks;
 namespace System.IO.Abstractions
 {
     /// <summary>
-    ///     Wraps the <see cref="FileStream" />.
+    ///     Wrapper around a <see cref="Stream"/> which is used as a replacement
+    ///     for a <see cref="FileStream"/>. As such it implements the same
+    ///     properties and methods as a <see cref="FileStream"/>.
     /// </summary>
     public abstract class FileSystemStream : Stream
     {


### PR DESCRIPTION
Fixes #943:
> The XML docs say Wraps the &lt;see cref="FileStream" /&gt;, but the wrapped field, _stream, is of type Stream. There's no runtime check to ensure that the stream provided in the constructor is of type FileStream. This is confusing because the docs state one thing, but the implementation doesn't seem to match that.