### PR TITLE
fix: update Name of `DirectoryInfo` when using `MoveTo`

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
@@ -12,8 +12,8 @@ namespace System.IO.Abstractions.TestingHelpers
     public class MockDirectoryInfo : DirectoryInfoBase, IFileSystemAclSupport
     {
         private readonly IMockFileDataAccessor mockFileDataAccessor;
-        private readonly string directoryPath;
-        private readonly string originalPath;
+        private string directoryPath;
+        private string originalPath;
         private MockFileData cachedMockFileData;
         private bool refreshOnNextRead;
 
@@ -36,15 +36,7 @@ namespace System.IO.Abstractions.TestingHelpers
                 throw CommonExceptions.PathIsNotOfALegalForm("path");
             }
             
-            originalPath = directoryPath;
-            directoryPath = mockFileDataAccessor.Path.GetFullPath(directoryPath);
-
-            directoryPath = directoryPath.TrimSlashes();
-            if (XFS.IsWindowsPlatform())
-            {
-                directoryPath = directoryPath.TrimEnd(' ');
-            }
-            this.directoryPath = directoryPath;
+            SetDirectoryPath(directoryPath);
             Refresh();
         }
 
@@ -378,6 +370,7 @@ namespace System.IO.Abstractions.TestingHelpers
         public override void MoveTo(string destDirName)
         {
             mockFileDataAccessor.Directory.Move(directoryPath, destDirName);
+            SetDirectoryPath(destDirName);
         }
         
         /// <inheritdoc />
@@ -442,6 +435,19 @@ namespace System.IO.Abstractions.TestingHelpers
             GetMockDirectoryData().AccessControl = value as DirectorySecurity;
         }
         
+        private void SetDirectoryPath(string path)
+        {
+            originalPath = path;
+            path = mockFileDataAccessor.Path.GetFullPath(path);
+
+            path = path.TrimSlashes();
+            if (XFS.IsWindowsPlatform())
+            {
+                path = path.TrimEnd(' ');
+            }
+            this.directoryPath = path;
+        }
+
         private MockDirectoryData GetMockDirectoryData()
         {
             return mockFileDataAccessor.GetFile(directoryPath) as MockDirectoryData

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
@@ -350,6 +350,23 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.AreEqual(expectedFullName, actualFullName);
         }
 
+        [Test]
+        public void MockDirectoryInfo_MoveTo_ShouldUpdateFullName()
+        {
+            // Arrange
+            var path = XFS.Path(@"c:\source");
+            var destination = @"c:\destination";
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory(path);
+            var directoryInfo = fileSystem.DirectoryInfo.New(path);
+
+            // Act
+            directoryInfo.MoveTo(destination);
+
+            // Assert
+            Assert.AreEqual(destination, directoryInfo.FullName);
+        }
+
         [TestCase(@"c:\temp\\folder ", @"folder")]
         [WindowsOnly(WindowsSpecifics.Drives)]
         public void MockDirectoryInfo_Name_ShouldReturnNameWithTrimmedTrailingSpaces(string directoryPath, string expectedName)

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
@@ -355,7 +355,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         {
             // Arrange
             var path = XFS.Path(@"c:\source");
-            var destination = @"c:\destination";
+            var destination = XFS.Path(@"c:\destination");
             var fileSystem = new MockFileSystem();
             fileSystem.Directory.CreateDirectory(path);
             var directoryInfo = fileSystem.DirectoryInfo.New(path);


### PR DESCRIPTION
Fixes #736:
> In a unit test which consists on moving directory using the MoveTo function from IDirectoryInfo doesn't update the IDirectoryInfo entries and the moved directory info keeps the same initial values. However using the same function on the debug and release modes( FileSystem) does update the fields and properties of the DirectorytInfo

*Note: This should make #864 obsolete!*