### PR TITLE
fix: null-handling in Wrap-Method in factories for `IDirectoryInfo` or `IFileInfo`

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectoryInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectoryInfoFactory.cs
@@ -33,6 +33,11 @@ namespace System.IO.Abstractions.TestingHelpers
         /// <inheritdoc />
         public IDirectoryInfo Wrap(DirectoryInfo directoryInfo)
         {
+            if (directoryInfo == null)
+            {
+                return null;
+            }
+
             return new MockDirectoryInfo(mockFileSystem, directoryInfo.Name);
         }
     }

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileInfoFactory.cs
@@ -32,6 +32,11 @@
         /// <inheritdoc />
         public IFileInfo Wrap(FileInfo fileInfo)
         {
+            if (fileInfo == null)
+            {
+                return null;
+            }
+
             return new MockFileInfo(mockFileSystem, fileInfo.Name);
         }
     }

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryInfoFactory.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace System.IO.Abstractions
 {
     [Serializable]
@@ -28,10 +30,15 @@ namespace System.IO.Abstractions
             var realDirectoryInfo = new DirectoryInfo(path);
             return new DirectoryInfoWrapper(fileSystem, realDirectoryInfo);
         }
-
+        
         /// <inheritdoc />
         public IDirectoryInfo Wrap(DirectoryInfo directoryInfo)
         {
+            if (directoryInfo == null)
+            {
+                return null;
+            }
+
             return new DirectoryInfoWrapper(fileSystem, directoryInfo);
         }
     }

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryInfoFactory.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
-
 namespace System.IO.Abstractions
 {
     [Serializable]

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileInfoFactory.cs
@@ -1,4 +1,6 @@
-﻿namespace System.IO.Abstractions
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace System.IO.Abstractions
 {
     [Serializable]
     internal class FileInfoFactory : IFileInfoFactory
@@ -28,10 +30,15 @@
             var realFileInfo = new FileInfo(fileName);
             return new FileInfoWrapper(fileSystem, realFileInfo);
         }
-
+        
         /// <inheritdoc />
         public IFileInfo Wrap(FileInfo fileInfo)
         {
+            if (fileInfo == null)
+            {
+                return null;
+            }
+
             return new FileInfoWrapper(fileSystem, fileInfo);
         }
     }

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileInfoFactory.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-
-namespace System.IO.Abstractions
+﻿namespace System.IO.Abstractions
 {
     [Serializable]
     internal class FileInfoFactory : IFileInfoFactory

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoFactoryTests.cs
@@ -1,0 +1,18 @@
+﻿using NUnit.Framework;
+
+namespace System.IO.Abstractions.TestingHelpers.Tests
+{
+    [TestFixture]
+    public class MockDirectoryInfoFactoryTests
+    {
+        [Test]
+        public void MockDirectoryInfoFactory_Wrap_WithNull_ShouldReturnNull()
+        {
+            var fileSystem = new MockFileSystem();
+
+            var result = fileSystem.DirectoryInfo.Wrap(null);
+            
+            Assert.IsNull(result);
+        }
+    }
+}

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoFactoryTests.cs
@@ -41,5 +41,15 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Assert
             Assert.IsNotNull(result);
         }
+
+        [Test]
+        public void MockFileInfoFactory_Wrap_WithNull_ShouldReturnNull()
+        {
+            var fileSystem = new MockFileSystem();
+
+            var result = fileSystem.FileInfo.Wrap(null);
+
+            Assert.IsNull(result);
+        }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/DirectoryInfoFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/DirectoryInfoFactoryTests.cs
@@ -1,0 +1,18 @@
+﻿using NUnit.Framework;
+
+namespace System.IO.Abstractions.Tests
+{
+    [TestFixture]
+    public class DirectoryInfoFactoryTests
+    {
+        [Test]
+        public void Wrap_WithNull_ShouldReturnNull()
+        {
+            var fileSystem = new FileSystem();
+
+            var result = fileSystem.DirectoryInfo.Wrap(null);
+            
+            Assert.IsNull(result);
+        }
+    }
+}

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/FileInfoFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/FileInfoFactoryTests.cs
@@ -1,0 +1,18 @@
+﻿using NUnit.Framework;
+
+namespace System.IO.Abstractions.Tests
+{
+    [TestFixture]
+    public class FileInfoFactoryTests
+    {
+        [Test]
+        public void Wrap_WithNull_ShouldReturnNull()
+        {
+            var fileSystem = new FileSystem();
+
+            var result = fileSystem.FileInfo.Wrap(null);
+            
+            Assert.IsNull(result);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #975:
When providing `null` as parameter to the implementations of `IFileInfoFactory` or `IDirectoryInfoFactory` return `null` instead of throwing an exception.