### PR TITLE
fix: null-handling in Wrap-Method in factories for `IDriveInfo` or `IFileSystemWatcher`

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDriveInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDriveInfoFactory.cs
@@ -56,6 +56,11 @@ namespace System.IO.Abstractions.TestingHelpers
         /// <inheritdoc />
         public IDriveInfo Wrap(DriveInfo driveInfo)
         {
+            if (driveInfo == null)
+            {
+                return null;
+            }
+
             return New(driveInfo.Name);
         }
 

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileSystemWatcherFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileSystemWatcherFactory.cs
@@ -43,6 +43,13 @@
 
         /// <inheritdoc />
         public IFileSystemWatcher Wrap(FileSystemWatcher fileSystemWatcher)
-            => throw new NotImplementedException(StringResources.Manager.GetString("FILE_SYSTEM_WATCHER_NOT_IMPLEMENTED_EXCEPTION"));
+        {
+            if (fileSystemWatcher == null)
+            {
+                return null;
+            }
+
+            throw new NotImplementedException(StringResources.Manager.GetString("FILE_SYSTEM_WATCHER_NOT_IMPLEMENTED_EXCEPTION"));
+        }
     }
 }

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DriveInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DriveInfoFactory.cs
@@ -38,6 +38,11 @@
         /// <inheritdoc />
         public IDriveInfo Wrap(DriveInfo driveInfo)
         {
+            if (driveInfo == null)
+            {
+                return null;
+            }
+
             return new DriveInfoWrapper(fileSystem, driveInfo);
         }
 

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemWatcherFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemWatcherFactory.cs
@@ -42,6 +42,13 @@
 
         /// <inheritdoc />
         public IFileSystemWatcher Wrap(FileSystemWatcher fileSystemWatcher)
-            => new FileSystemWatcherWrapper(FileSystem, fileSystemWatcher);
+        {
+            if (fileSystemWatcher == null)
+            {
+                return null;
+            }
+
+            return new FileSystemWatcherWrapper(FileSystem, fileSystemWatcher);
+        }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDriveInfoFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDriveInfoFactoryTests.cs
@@ -97,5 +97,15 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Assert
             Assert.That(actualResult.Name, Is.EquivalentTo(@"Z:\"));
         }
+
+        [Test]
+        public void MockDriveInfoFactory_Wrap_WithNull_ShouldReturnNull()
+        {
+            var fileSystem = new MockFileSystem();
+
+            var result = fileSystem.DriveInfo.Wrap(null);
+
+            Assert.IsNull(result);
+        }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemWatcherFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemWatcherFactoryTests.cs
@@ -37,5 +37,15 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var factory = new MockFileSystemWatcherFactory(new MockFileSystem());
             Assert.Throws<NotImplementedException>(() => factory.New(path));
         }
+
+        [Test]
+        public void MockFileSystemWatcherFactory_Wrap_WithNull_ShouldReturnNull()
+        {
+            var fileSystem = new MockFileSystem();
+
+            var result = fileSystem.FileSystemWatcher.Wrap(null);
+
+            Assert.IsNull(result);
+        }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/DriveInfoFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/DriveInfoFactoryTests.cs
@@ -1,0 +1,18 @@
+﻿using NUnit.Framework;
+
+namespace System.IO.Abstractions.Tests
+{
+    [TestFixture]
+    public class DriveInfoFactoryTests
+    {
+        [Test]
+        public void Wrap_WithNull_ShouldReturnNull()
+        {
+            var fileSystem = new FileSystem();
+
+            var result = fileSystem.DriveInfo.Wrap(null);
+            
+            Assert.IsNull(result);
+        }
+    }
+}

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/FileSystemWatcherFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/FileSystemWatcherFactoryTests.cs
@@ -1,0 +1,18 @@
+﻿using NUnit.Framework;
+
+namespace System.IO.Abstractions.Tests
+{
+    [TestFixture]
+    public class FileSystemWatcherFactoryTests
+    {
+        [Test]
+        public void Wrap_WithNull_ShouldReturnNull()
+        {
+            var fileSystem = new FileSystem();
+
+            var result = fileSystem.FileSystemWatcher.Wrap(null);
+            
+            Assert.IsNull(result);
+        }
+    }
+}


### PR DESCRIPTION
Building on #976 also fix null-handling for DriveInfo and FileSystemWatcher factories:
When providing null as parameter to the implementations of IDriveInfoFactory or IFileSystemWatcherFactory return null instead of throwing an exception.