### PR TITLE
fix: Propagate null values in Wrap* methods

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.Wrappers/Converters.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/Converters.cs
@@ -29,6 +29,11 @@ namespace System.IO.Abstractions
 
         private static FileSystemInfoBase WrapFileSystemInfo(IFileSystem fileSystem, FileSystemInfo item)
         {
+            if (item is null)
+            {
+                return null;
+            }
+
             if (item is FileInfo fileInfo)
             {
                 return WrapFileInfo(fileSystem, fileInfo);
@@ -47,8 +52,10 @@ namespace System.IO.Abstractions
             }
         }
 
-        private static FileInfoBase WrapFileInfo(IFileSystem fileSystem, FileInfo f) => new FileInfoWrapper(fileSystem, f);
+        private static FileInfoBase WrapFileInfo(IFileSystem fileSystem, FileInfo f)
+            => f is null ? null : new FileInfoWrapper(fileSystem, f);
 
-        private static DirectoryInfoBase WrapDirectoryInfo(IFileSystem fileSystem, DirectoryInfo d) => new DirectoryInfoWrapper(fileSystem, d);
+        private static DirectoryInfoBase WrapDirectoryInfo(IFileSystem fileSystem, DirectoryInfo d)
+            => d is null ? null : new DirectoryInfoWrapper(fileSystem, d);
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/ConvertersTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/ConvertersTests.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 
 namespace System.IO.Abstractions.Tests
@@ -42,6 +43,7 @@ namespace System.IO.Abstractions.Tests
 
             Assert.DoesNotThrow(() => crashingFileInfos.WrapFiles(new FileSystem()));
         }
+
         [Test]
         public void WrapDirectories_with_IEnumerable_is_lazy()
         {
@@ -50,5 +52,24 @@ namespace System.IO.Abstractions.Tests
             Assert.DoesNotThrow(() => crashingDirectoryInfos.WrapDirectories(new FileSystem()));
         }
 
+        [Test]
+        public void WrapFileSystemInfo_handles_null_FileSystemInfo()
+        {
+            Assert.IsNull(Converters.WrapFileSystemInfo(null, new FileSystem()));
+        }
+
+        [Test]
+        public void WrapDirectories_handles_null_DirectoryInfo()
+        {
+            List<DirectoryInfo> directoryInfos = new() { null };
+            Assert.IsNull(directoryInfos.WrapDirectories(new FileSystem()).Single());
+        }
+
+        [Test]
+        public void WrapFiles_handles_null_FileInfo()
+        {
+            List<FileInfo> fileInfos = new() { null };
+            Assert.IsNull(fileInfos.WrapFiles(new FileSystem()).Single());
+        }
     }
 }


### PR DESCRIPTION
When wrapping `FileSystemInfo`, `DirectoryInfo`, and `FileInfo`, null inputs will be correctly propagated.
Prior to this change, the wrappers for all three of these types would throw exceptions:

- `NullReferenceException` for `WrapFileSystemInfo`
- `ArgumentNullException` for `WrapDirectoryInfo`/`WrapFileInfo` (thrown by `DirectoryInfoWrapper`/`FileInfoWrapper`)

Basic unit tests were also added for these null cases.

Fixes #981