### PR TITLE
feat: Add Flush(bool) to FileSystemStream.

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileStream.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileStream.cs
@@ -224,6 +224,10 @@ namespace System.IO.Abstractions.TestingHelpers
         }
 
         /// <inheritdoc />
+        public override void Flush(bool flushToDisk)
+            => InternalFlush();
+
+        /// <inheritdoc />
         public override Task FlushAsync(CancellationToken cancellationToken)
         {
             InternalFlush();

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileStreamWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileStreamWrapper.cs
@@ -41,5 +41,9 @@ namespace System.IO.Abstractions
                 throw new ArgumentException("value must be of type `FileSecurity`");
             }
         }
+
+        /// <inheritdoc />
+        public override void Flush(bool flushToDisk)
+            => fileStream.Flush(flushToDisk);
     }
 }

--- a/src/TestableIO.System.IO.Abstractions/FileSystemStream.cs
+++ b/src/TestableIO.System.IO.Abstractions/FileSystemStream.cs
@@ -128,6 +128,10 @@ namespace System.IO.Abstractions
         public override void Flush()
             => _stream.Flush();
 
+        /// <inheritDoc cref="FileStream.Flush(bool)" />
+        public virtual void Flush(bool flushToDisk)
+            => _stream.Flush();
+
         /// <inheritdoc cref="Stream.FlushAsync(CancellationToken)" />
         public override Task FlushAsync(CancellationToken cancellationToken)
             => _stream.FlushAsync(cancellationToken);

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
@@ -206,5 +206,25 @@
                 Assert.AreEqual(200, stream.Position);
             }
         }
+
+        [Test]
+        public void MockFileStream_FlushBool_ShouldNotChangePosition([Values] bool flushToDisk)
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem();
+            var path = XFS.Path("C:\\test");
+            fileSystem.AddFile(path, new MockFileData(new byte[0]));
+
+            using (var stream = fileSystem.FileInfo.New(path).OpenWrite())
+            {
+                // Act
+                stream.Write(new byte[400], 0, 400);
+                stream.Seek(200, SeekOrigin.Begin);
+                stream.Flush(flushToDisk);
+
+                // Assert
+                Assert.AreEqual(200, stream.Position);
+            }
+        }
     }
 }


### PR DESCRIPTION
`FileSystemStream` was missing the implementation of `FileStream.Flush(bool)` which allows the caller to specify whether `Flush` should ensure all buffers are written to disk.