### PR TITLE
fix: Use searchPattern argument in GetFiles method to complete the logic

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -265,7 +265,7 @@ namespace System.IO.Abstractions.TestingHelpers
         /// <inheritdoc />
         public override string[] GetFiles(string path, string searchPattern, EnumerationOptions enumerationOptions)
         {
-            return GetFiles(path, "*", EnumerationOptionsToSearchOption(enumerationOptions));
+            return GetFiles(path, searchPattern, EnumerationOptionsToSearchOption(enumerationOptions));
         }
 #endif
 

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -79,6 +79,30 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(result, Is.EquivalentTo(expected));
         }
 
+#if FEATURE_ENUMERATION_OPTIONS
+        [Test]
+        public void MockDirectory_GetFiles_ShouldReturnAllPatternMatchingFilesWhenEnumerationOptionHasRecurseSubdirectoriesSetToTrue()
+        {
+            // Arrange
+            var fileSystem = SetupFileSystem();
+            var expected = new[]
+            {
+                XFS.Path(@"c:\b.txt"),
+                XFS.Path(@"c:\c.txt"),
+                XFS.Path(@"c:\a\a.txt"),
+                XFS.Path(@"c:\a\c.txt"),
+                XFS.Path(@"c:\a\a\a.txt"),
+                XFS.Path(@"c:\a\a\b.txt")
+            };
+
+            // Act
+            var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), "*.txt", new EnumerationOptions { RecurseSubdirectories = true });
+
+            // Assert
+            Assert.That(result, Is.EquivalentTo(expected));
+        }
+#endif
+
         private MockFileSystem SetupFileSystem()
         {
             return new MockFileSystem(new Dictionary<string, MockFileData>


### PR DESCRIPTION
It should use the searchPattern argument to complete the logic.

I found it while working with MockDirectoryInfo.EnumerateFiles(searchPattern, enumerationOptions)
It didnt respect the searchPattern and my tests failed, so I decided to check the source.