### PR TITLE
feat: implement Path.GetRelativePath in MockFileSystem

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockPath.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockPath.cs
@@ -155,5 +155,36 @@ namespace System.IO.Abstractions.TestingHelpers
 
         /// <inheritdoc />
         public override string GetTempPath() => defaultTempDirectory;
+
+#if FEATURE_ADVANCED_PATH_OPERATIONS
+        /// <inheritdoc />
+        public override string GetRelativePath(string relativeTo, string path)
+        {
+            if (relativeTo == null)
+            {
+                throw new ArgumentNullException(nameof(relativeTo), StringResources.Manager.GetString("VALUE_CANNOT_BE_NULL"));
+            }
+
+            if (relativeTo.Length == 0)
+            {
+                throw CommonExceptions.PathIsNotOfALegalForm(nameof(relativeTo));
+            }
+
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path), StringResources.Manager.GetString("VALUE_CANNOT_BE_NULL"));
+            }
+
+            if (path.Length == 0)
+            {
+                throw CommonExceptions.PathIsNotOfALegalForm(nameof(path));
+            }
+
+            relativeTo = GetFullPath(relativeTo);
+            path = GetFullPath(path);
+
+            return Path.GetRelativePath(relativeTo, path);
+        }
+#endif
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockPathTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockPathTests.cs
@@ -557,5 +557,23 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.IsFalse(result);
         }
 #endif
+
+#if FEATURE_ADVANCED_PATH_OPERATIONS
+        [Test]
+        public void GetRelativePath_ShouldUseCurrentDirectoryFromMockFileSystem()
+        {
+            var fs = new MockFileSystem();
+
+            fs.AddDirectory("input");
+            fs.AddDirectory("output");
+            fs.Directory.SetCurrentDirectory("input");
+
+            fs.AddFile("input/a.txt", "foo");
+
+            var result = fs.Path.GetRelativePath("/input", "a.txt");
+
+            Assert.AreEqual("a.txt", result);
+        }
+#endif
     }
 }


### PR DESCRIPTION
Override the `Path.GetRelativePath` implementation on mocked file systems and use the current directory to change the parameters to a full path relative to the current directory in the mocked file system.

Fixes:
- #773