### PR TITLE
docs: mention correct package to install in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ At the core of the library is `IFileSystem` and `FileSystem`. Instead of calling
 ## Usage
 
 ```shell
-dotnet add package TestableIO.System.IO.Abstractions
+dotnet add package TestableIO.System.IO.Abstractions.Wrappers
 ```
 
 *Note: This NuGet package is also published as `System.IO.Abstractions` but we suggest to use the prefix to make clear that this is not an official .NET package.*

--- a/System.IO.Abstractions.sln
+++ b/System.IO.Abstractions.sln
@@ -26,6 +26,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_", "_", "{BBF7AD8D-5522-48
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
 		global.json = global.json
+		README.md = README.md
 	EndProjectSection
 EndProject
 Global


### PR DESCRIPTION
Mention the correct package ([TestableIO.System.IO.Abstractions.Wrappers](https://www.nuget.org/packages/TestableIO.System.IO.Abstractions.Wrappers)) to use in README.md, so that the file system wrappers are available.

Fixes
- #938 