### PR TITLE
feat: add `ReparsePoint` attribute when creating a symbolic link

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -107,7 +107,9 @@ namespace System.IO.Abstractions.TestingHelpers
             mockFileDataAccessor.AddDirectory(path);
             mockFileDataAccessor.GetFile(path).LinkTarget = pathToTarget;
 
-            return new MockDirectoryInfo(mockFileDataAccessor, path);
+            var directoryInfo = new MockDirectoryInfo(mockFileDataAccessor, path);
+            directoryInfo.Attributes |= FileAttributes.ReparsePoint;
+            return directoryInfo;
         }
 #endif
 

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -195,7 +195,9 @@ namespace System.IO.Abstractions.TestingHelpers
             destFileData.LinkTarget = pathToTarget;
             mockFileDataAccessor.AddFile(path, destFileData);
 
-            return new MockFileInfo(mockFileDataAccessor, path);
+            var mockFileInfo = new MockFileInfo(mockFileDataAccessor, path);
+            mockFileInfo.Attributes |= FileAttributes.ReparsePoint;
+            return mockFileInfo;
         }
 #endif
         /// <inheritdoc />

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectorySymlinkTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectorySymlinkTests.cs
@@ -199,6 +199,20 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockDirectory_CreateSymbolicLink_ShouldSetReparsePointAttribute()
+        {
+            var path = "foo";
+            var pathToTarget = "bar";
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory(pathToTarget);
+
+            fileSystem.Directory.CreateSymbolicLink(path, pathToTarget);
+
+            var attributes = fileSystem.DirectoryInfo.New(path).Attributes;
+            Assert.IsTrue(attributes.HasFlag(FileAttributes.ReparsePoint));
+        }
+
+        [Test]
         public void MockDirectory_ResolveLinkTarget_ShouldReturnPathOfTargetLink()
         {
             var fileSystem = new MockFileSystem();

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSymlinkTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSymlinkTests.cs
@@ -229,6 +229,20 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockFile_CreateSymbolicLink_ShouldSetReparsePointAttribute()
+        {
+            var path = "foo.txt";
+            var pathToTarget = "bar.txt";
+            var fileSystem = new MockFileSystem();
+            fileSystem.File.WriteAllText(pathToTarget, "some content");
+
+            fileSystem.File.CreateSymbolicLink(path, pathToTarget);
+
+            var attributes = fileSystem.FileInfo.New(path).Attributes;
+            Assert.IsTrue(attributes.HasFlag(FileAttributes.ReparsePoint));
+        }
+
+        [Test]
         public void MockFile_ResolveLinkTarget_ShouldReturnPathOfTargetLink()
         {
             var fileSystem = new MockFileSystem();


### PR DESCRIPTION
Files or directories which are a symbolic link should have the `ReparsePoint` attribute set.