### PR TITLE
fix: incorrectly thrown exception in `Directory.CreateSymbolicLink`

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -98,12 +98,6 @@ namespace System.IO.Abstractions.TestingHelpers
                 throw CommonExceptions.FileAlreadyExists(nameof(path));
             }
 
-            var targetExists = Exists(pathToTarget);
-            if (!targetExists)
-            {
-                throw CommonExceptions.FileNotFound(pathToTarget);
-            }
-
             mockFileDataAccessor.AddDirectory(path);
             mockFileDataAccessor.GetFile(path).LinkTarget = pathToTarget;
 

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectorySymlinkTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectorySymlinkTests.cs
@@ -184,7 +184,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockDirectory_CreateSymbolicLink_ShouldFailIfTargetDoesNotExist()
+        public void MockDirectory_CreateSymbolicLink_ShouldNotFailIfTargetDoesNotExist()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -192,10 +192,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             string pathToTarget = XFS.Path(@"C:\Target");
 
             // Act
-            var ex = Assert.Throws<FileNotFoundException>(() => fileSystem.Directory.CreateSymbolicLink(path, pathToTarget));
+            var fileSystemInfo = fileSystem.Directory.CreateSymbolicLink(path, pathToTarget);
 
             // Assert
-            Assert.That(ex.Message.Contains(pathToTarget));
+            Assert.IsTrue(fileSystemInfo.Exists);
         }
 
         [Test]


### PR DESCRIPTION
Remove incorrectly thrown exception when the target does not exist in Directory.CreateSymbolicLink. The real file system does not throw an exception in this case.
> [See here for a succeeding test against the real file system](https://github.com/Testably/Testably.Abstractions/blob/main/Tests/Testably.Abstractions.Tests/FileSystem/Directory/CreateSymbolicLinkTests.cs#L50).