### PR TITLE
refactor: use `CommonExceptions` to create exceptions

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/CommonExceptions.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/CommonExceptions.cs
@@ -5,7 +5,7 @@ namespace System.IO.Abstractions.TestingHelpers
     internal static class CommonExceptions
     {
         private const int _fileLockHResult = unchecked((int)0x80070020);
-
+        
         public static FileNotFoundException FileNotFound(string path) =>
             new FileNotFoundException(
                 string.Format(
@@ -34,10 +34,10 @@ namespace System.IO.Abstractions.TestingHelpers
                 )
             );
 
-        public static Exception InvalidUseOfVolumeSeparator() =>
+        public static NotSupportedException InvalidUseOfVolumeSeparator() =>
             new NotSupportedException(StringResources.Manager.GetString("THE_PATH_IS_NOT_OF_A_LEGAL_FORM"));
 
-        public static Exception PathIsNotOfALegalForm(string paramName) =>
+        public static ArgumentException PathIsNotOfALegalForm(string paramName) =>
             new ArgumentException(
                 StringResources.Manager.GetString("THE_PATH_IS_NOT_OF_A_LEGAL_FORM"),
                 paramName
@@ -54,7 +54,7 @@ namespace System.IO.Abstractions.TestingHelpers
                 ? new ArgumentException(StringResources.Manager.GetString("ILLEGAL_CHARACTERS_IN_PATH_EXCEPTION"), paramName)
                 : new ArgumentException(StringResources.Manager.GetString("ILLEGAL_CHARACTERS_IN_PATH_EXCEPTION"));
 
-        public static Exception InvalidUncPath(string paramName) =>
+        public static ArgumentException InvalidUncPath(string paramName) =>
             new ArgumentException(@"The UNC path should be of the form \\server\share.", paramName);
 
         public static IOException ProcessCannotAccessFileInUse(string paramName = null) =>
@@ -73,5 +73,32 @@ namespace System.IO.Abstractions.TestingHelpers
 
         public static NotImplementedException NotImplemented() =>
             new NotImplementedException(StringResources.Manager.GetString("NOT_IMPLEMENTED_EXCEPTION"));
+
+        public static IOException CannotCreateBecauseSameNameAlreadyExists(string path) =>
+            new IOException(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    StringResources.Manager.GetString("CANNOT_CREATE_BECAUSE_SAME_NAME_ALREADY_EXISTS"),
+                    path
+                )
+            );
+
+        public static IOException NameCannotBeResolvedByTheSystem(string path) =>
+            new IOException(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    StringResources.Manager.GetString("NAME_CANNOT_BE_RESOLVED_BY_THE_SYSTEM"),
+                    path
+                )
+            );
+
+        public static DirectoryNotFoundException PathDoesNotExistOrCouldNotBeFound(string path) =>
+            new DirectoryNotFoundException(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    StringResources.Manager.GetString("PATH_DOES_NOT_EXIST_OR_COULD_NOT_BE_FOUND"),
+                    path
+                )
+            );
     }
 }

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -153,7 +153,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
             if (!affectedPaths.Any())
             {
-                throw new DirectoryNotFoundException(path + " does not exist or could not be found.");
+                throw CommonExceptions.PathDoesNotExistOrCouldNotBeFound(path);
             }
 
             if (!recursive && affectedPaths.Count > 1)
@@ -526,18 +526,17 @@ namespace System.IO.Abstractions.TestingHelpers
 
             if (!mockFileDataAccessor.Directory.Exists(fullSourcePath))
             {
-                throw new DirectoryNotFoundException($"Could not find a part of the path '{sourceDirName}'.");
+                throw CommonExceptions.CouldNotFindPartOfPath(sourceDirName);
             }
 
             if (!mockFileDataAccessor.Directory.GetParent(fullDestPath).Exists)
             {
-                throw new DirectoryNotFoundException($"Could not find a part of the path.");
+                throw CommonExceptions.CouldNotFindPartOfPath(destDirName);
             }
 
             if (mockFileDataAccessor.Directory.Exists(fullDestPath) || mockFileDataAccessor.File.Exists(fullDestPath))
             {
-                throw new IOException(
-                    $"Cannot create '{fullDestPath}' because a file or directory with the same name already exists.");
+                throw CommonExceptions.CannotCreateBecauseSameNameAlreadyExists(fullDestPath);
             }
 
             mockFileDataAccessor.MoveDirectory(fullSourcePath, fullDestPath);
@@ -570,7 +569,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
                     if (nextContainer.LinkTarget != null)
                     {
-                        throw new IOException($"The name of the file cannot be resolved by the system. : '{linkPath}'");
+                        throw CommonExceptions.NameCannotBeResolvedByTheSystem(linkPath);
                     }
                 }
 
@@ -583,7 +582,7 @@ namespace System.IO.Abstractions.TestingHelpers
                     return new MockFileInfo(mockFileDataAccessor, nextLocation);
                 }
             }
-            throw new IOException($"The name of the file cannot be resolved by the system. : '{linkPath}'");
+            throw CommonExceptions.NameCannotBeResolvedByTheSystem(linkPath);
         }
     
 #endif

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -117,7 +117,7 @@ namespace System.IO.Abstractions.TestingHelpers
             {
                 if (!overwrite)
                 {
-                    throw new IOException(string.Format(CultureInfo.InvariantCulture, "The file {0} already exists.", destFileName));
+                    throw CommonExceptions.FileAlreadyExists(destFileName);
                 }
 
                 mockFileDataAccessor.RemoveFile(destFileName);
@@ -581,7 +581,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
             if (mode == FileMode.CreateNew && exists)
             {
-                throw new IOException(string.Format(CultureInfo.InvariantCulture, "The file '{0}' already exists.", path));
+                throw CommonExceptions.FileAlreadyExists(path);
             }
 
             if ((mode == FileMode.Open || mode == FileMode.Truncate) && !exists)
@@ -802,7 +802,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
                     if (nextContainer.LinkTarget != null)
                     {
-                        throw new IOException($"The name of the file cannot be resolved by the system. : '{linkPath}'");
+                        throw CommonExceptions.NameCannotBeResolvedByTheSystem(linkPath);
                     }
                 }
 
@@ -815,7 +815,7 @@ namespace System.IO.Abstractions.TestingHelpers
                     return new MockFileInfo(mockFileDataAccessor, nextLocation);
                 }
             }
-            throw new IOException($"The name of the file cannot be resolved by the system. : '{linkPath}'");
+            throw CommonExceptions.NameCannotBeResolvedByTheSystem(linkPath);
         }
 #endif
 

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/Properties/Resources.resx
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/Properties/Resources.resx
@@ -162,4 +162,13 @@
   <data name="INVALID_ACCESS_COMBINATION" xml:space="preserve">
     <value>Combining FileMode: {0} with FileAccess: {1} is invalid.</value>
   </data>
+  <data name="CANNOT_CREATE_BECAUSE_SAME_NAME_ALREADY_EXISTS" xml:space="preserve">
+    <value>Cannot create '{0}' because a file or directory with the same name already exists.</value>
+  </data>
+  <data name="NAME_CANNOT_BE_RESOLVED_BY_THE_SYSTEM" xml:space="preserve">
+    <value>The name of the file cannot be resolved by the system. : '{0}'</value>
+  </data>
+  <data name="PATH_DOES_NOT_EXIST_OR_COULD_NOT_BE_FOUND" xml:space="preserve">
+    <value>'{0}' does not exist or could not be found.</value>
+  </data>
 </root>

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -982,7 +982,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var ex = Assert.Throws<DirectoryNotFoundException>(() => fileSystem.Directory.Delete(XFS.Path(@"c:\baz")));
 
-            Assert.That(ex.Message, Is.EqualTo(XFS.Path("c:\\baz") + " does not exist or could not be found."));
+            Assert.That(ex.Message, Is.EqualTo($"'{XFS.Path("c:\\baz")}' does not exist or could not be found."));
         }
 
         [Test]


### PR DESCRIPTION
Replace the creation of exceptions to throw from a couple of places to the static `CommonExceptions` helper class.