### PR TITLE
fix: use full path in `Directory.SetCurrentDirectory`

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -603,7 +603,7 @@ namespace System.IO.Abstractions.TestingHelpers
         /// <inheritdoc />
         public override void SetCurrentDirectory(string path)
         {
-            currentDirectory = path;
+            currentDirectory = mockFileDataAccessor.Path.GetFullPath(path);
         }
 
         /// <inheritdoc />

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -1662,6 +1662,17 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockDirectory_SetCurrentDirectory_WithRelativePath_ShouldUseFullPath()
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.SetCurrentDirectory(".");
+
+            var result = fileSystem.Directory.GetCurrentDirectory();
+
+            Assert.IsTrue(fileSystem.Path.IsPathRooted(result));
+        }
+
+        [Test]
         public void MockDirectory_GetParent_ShouldThrowArgumentNullExceptionIfPathIsNull()
         {
             // Arrange


### PR DESCRIPTION
The current directory should always be a rooted path, even if the directory is set to a relative directory.