### PR TITLE
fix: incorrect thrown exception when calling `Path.GetFullPath` with white-space

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockPath.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockPath.cs
@@ -39,7 +39,7 @@ namespace System.IO.Abstractions.TestingHelpers
                 throw new ArgumentNullException(nameof(path), StringResources.Manager.GetString("VALUE_CANNOT_BE_NULL"));
             }
 
-            if (path.Length == 0)
+            if (string.IsNullOrWhiteSpace(path))
             {
                 throw CommonExceptions.PathIsNotOfALegalForm(nameof(path));
             }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockPathTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockPathTests.cs
@@ -267,6 +267,16 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void GetFullPath_WithWhiteSpace_ShouldThrowArgumentException()
+        {
+            var mockFileSystem = new MockFileSystem();
+
+            TestDelegate action = () => mockFileSystem.Path.GetFullPath("  ");
+
+            Assert.Throws<ArgumentException>(action);
+        }
+
+        [Test]
         public void GetFullPath_WithMultipleDirectorySeparators_ShouldReturnTheNormalizedForm()
         {
             //Arrange


### PR DESCRIPTION
Throw the correct `ArgumentException` instead of a `NullReferenceException` when calling Path.GetFullPath with a WhiteSpace string.