### PR TITLE
refactor: prepare serialization infrastructure for .NET 8+

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,6 +15,7 @@
     <DefineConstants Condition="'$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net5.0'">$(DefineConstants);FEATURE_FILE_MOVE_WITH_OVERWRITE;FEATURE_SUPPORTED_OS_ATTRIBUTE;FEATURE_FILE_SYSTEM_WATCHER_FILTERS;FEATURE_ENDS_IN_DIRECTORY_SEPARATOR;FEATURE_PATH_JOIN_WITH_PARAMS;FEATURE_PATH_JOIN_WITH_FOUR_PATHS</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net6.0'">$(DefineConstants);FEATURE_FILE_SYSTEM_INFO_LINK_TARGET;FEATURE_CREATE_SYMBOLIC_LINK;FEATURE_FILESTREAM_OPTIONS</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' == 'net7.0'">$(DefineConstants);FEATURE_PATH_EXISTS;FEATURE_FILE_SYSTEM_WATCHER_WAIT_WITH_TIMESPAN;FEATURE_FILE_ATTRIBUTES_VIA_HANDLE;FEATURE_CREATE_TEMP_SUBDIRECTORY;FEATURE_READ_LINES_ASYNC;FEATURE_UNIX_FILE_MODE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133">

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -10,7 +10,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
 
     /// <inheritdoc />
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public class MockDirectory : DirectoryBase

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -10,8 +10,9 @@ namespace System.IO.Abstractions.TestingHelpers
 
 
     /// <inheritdoc />
-
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public class MockDirectory : DirectoryBase
     {
         private readonly IMockFileDataAccessor mockFileDataAccessor;

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectoryData.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectoryData.cs
@@ -4,12 +4,12 @@ using System.Security.AccessControl;
 namespace System.IO.Abstractions.TestingHelpers
 {
     /// <inheritdoc />
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public class MockDirectoryData : MockFileData
     {
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
         [NonSerialized]
 #endif
         private DirectorySecurity accessControl;

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectoryData.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectoryData.cs
@@ -4,11 +4,14 @@ using System.Security.AccessControl;
 namespace System.IO.Abstractions.TestingHelpers
 {
     /// <inheritdoc />
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public class MockDirectoryData : MockFileData
     {
-
+#if !NET8_0_OR_GREATER
         [NonSerialized]
+#endif
         private DirectorySecurity accessControl;
 
         /// <inheritdoc />

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
@@ -8,7 +8,9 @@ namespace System.IO.Abstractions.TestingHelpers
     using XFS = MockUnixSupport;
 
     /// <inheritdoc />
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public class MockDirectoryInfo : DirectoryInfoBase, IFileSystemAclSupport
     {
         private readonly IMockFileDataAccessor mockFileDataAccessor;

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectoryInfo.cs
@@ -8,7 +8,7 @@ namespace System.IO.Abstractions.TestingHelpers
     using XFS = MockUnixSupport;
 
     /// <inheritdoc />
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public class MockDirectoryInfo : DirectoryInfoBase, IFileSystemAclSupport

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectoryInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectoryInfoFactory.cs
@@ -1,7 +1,9 @@
 namespace System.IO.Abstractions.TestingHelpers
 {
     /// <inheritdoc />
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public class MockDirectoryInfoFactory : IDirectoryInfoFactory
     {
         readonly IMockFileDataAccessor mockFileSystem;

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectoryInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectoryInfoFactory.cs
@@ -1,7 +1,7 @@
 namespace System.IO.Abstractions.TestingHelpers
 {
     /// <inheritdoc />
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public class MockDirectoryInfoFactory : IDirectoryInfoFactory

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDriveInfo.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDriveInfo.cs
@@ -1,7 +1,7 @@
 ﻿namespace System.IO.Abstractions.TestingHelpers
 {
     /// <inheritdoc />
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public class MockDriveInfo : DriveInfoBase

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDriveInfo.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDriveInfo.cs
@@ -1,7 +1,9 @@
 ﻿namespace System.IO.Abstractions.TestingHelpers
 {
     /// <inheritdoc />
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public class MockDriveInfo : DriveInfoBase
     {
         private readonly IMockFileDataAccessor mockFileDataAccessor;

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDriveInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDriveInfoFactory.cs
@@ -3,7 +3,7 @@
 namespace System.IO.Abstractions.TestingHelpers
 {
     /// <inheritdoc />
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public class MockDriveInfoFactory : IDriveInfoFactory

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDriveInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDriveInfoFactory.cs
@@ -3,7 +3,9 @@
 namespace System.IO.Abstractions.TestingHelpers
 {
     /// <inheritdoc />
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public class MockDriveInfoFactory : IDriveInfoFactory
     {
         private readonly IMockFileDataAccessor mockFileSystem;

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -9,7 +9,7 @@ namespace System.IO.Abstractions.TestingHelpers
     using XFS = MockUnixSupport;
 
     /// <inheritdoc />
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public partial class MockFile : FileBase

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -9,7 +9,9 @@ namespace System.IO.Abstractions.TestingHelpers
     using XFS = MockUnixSupport;
 
     /// <inheritdoc />
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public partial class MockFile : FileBase
     {
         private readonly IMockFileDataAccessor mockFileDataAccessor;

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileData.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileData.cs
@@ -8,7 +8,9 @@ namespace System.IO.Abstractions.TestingHelpers
     /// <summary>
     /// The class represents the associated data of a file.
     /// </summary>
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public class MockFileData
     {
         /// <summary>
@@ -36,7 +38,9 @@ namespace System.IO.Abstractions.TestingHelpers
         /// <summary>
         /// The access control of the <see cref="MockFileData"/>.
         /// </summary>
+#if !NET8_0_OR_GREATER
         [NonSerialized]
+#endif
         private FileSecurity accessControl;
 
         /// <summary>

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileData.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileData.cs
@@ -8,7 +8,7 @@ namespace System.IO.Abstractions.TestingHelpers
     /// <summary>
     /// The class represents the associated data of a file.
     /// </summary>
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public class MockFileData
@@ -38,7 +38,7 @@ namespace System.IO.Abstractions.TestingHelpers
         /// <summary>
         /// The access control of the <see cref="MockFileData"/>.
         /// </summary>
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
         [NonSerialized]
 #endif
         private FileSecurity accessControl;

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
@@ -4,7 +4,9 @@ using System.Security.AccessControl;
 namespace System.IO.Abstractions.TestingHelpers
 {
     /// <inheritdoc />
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public class MockFileInfo : FileInfoBase, IFileSystemAclSupport
     {
         private readonly IMockFileDataAccessor mockFileSystem;

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileInfo.cs
@@ -4,7 +4,7 @@ using System.Security.AccessControl;
 namespace System.IO.Abstractions.TestingHelpers
 {
     /// <inheritdoc />
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public class MockFileInfo : FileInfoBase, IFileSystemAclSupport

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileInfoFactory.cs
@@ -1,7 +1,7 @@
 ﻿namespace System.IO.Abstractions.TestingHelpers
 {
     /// <inheritdoc />
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public class MockFileInfoFactory : IFileInfoFactory

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileInfoFactory.cs
@@ -1,7 +1,9 @@
 ﻿namespace System.IO.Abstractions.TestingHelpers
 {
     /// <inheritdoc />
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public class MockFileInfoFactory : IFileInfoFactory
     {
         private readonly IMockFileDataAccessor mockFileSystem;

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileStream.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileStream.cs
@@ -6,7 +6,7 @@ using System.Security.AccessControl;
 namespace System.IO.Abstractions.TestingHelpers
 {
     /// <inheritdoc />
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public class MockFileStream : FileSystemStream, IFileSystemAclSupport

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileStream.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileStream.cs
@@ -6,7 +6,9 @@ using System.Security.AccessControl;
 namespace System.IO.Abstractions.TestingHelpers
 {
     /// <inheritdoc />
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public class MockFileStream : FileSystemStream, IFileSystemAclSupport
     {
         /// <summary>

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileStreamFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileStreamFactory.cs
@@ -4,7 +4,7 @@ using Microsoft.Win32.SafeHandles;
 namespace System.IO.Abstractions.TestingHelpers
 {
     /// <inheritdoc />
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public class MockFileStreamFactory : IFileStreamFactory

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileStreamFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileStreamFactory.cs
@@ -4,7 +4,9 @@ using Microsoft.Win32.SafeHandles;
 namespace System.IO.Abstractions.TestingHelpers
 {
     /// <inheritdoc />
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public class MockFileStreamFactory : IFileStreamFactory
     {
         private readonly IMockFileDataAccessor mockFileSystem;

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
@@ -8,7 +8,7 @@ namespace System.IO.Abstractions.TestingHelpers
     using XFS = MockUnixSupport;
 
     /// <inheritdoc />
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public class MockFileSystem : FileSystemBase, IMockFileDataAccessor
@@ -18,7 +18,7 @@ namespace System.IO.Abstractions.TestingHelpers
 
         private readonly IDictionary<string, FileSystemEntry> files;
         private readonly PathVerifier pathVerifier;
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
         [NonSerialized]
 #endif
         private Func<DateTime> dateTimeProvider = defaultDateTimeProvider;
@@ -520,7 +520,7 @@ namespace System.IO.Abstractions.TestingHelpers
             return (GetFile(path).Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly;
         }
 
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
         private class FileSystemEntry

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
@@ -8,7 +8,9 @@ namespace System.IO.Abstractions.TestingHelpers
     using XFS = MockUnixSupport;
 
     /// <inheritdoc />
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public class MockFileSystem : FileSystemBase, IMockFileDataAccessor
     {
         private const string DEFAULT_CURRENT_DIRECTORY = @"C:\";
@@ -16,7 +18,9 @@ namespace System.IO.Abstractions.TestingHelpers
 
         private readonly IDictionary<string, FileSystemEntry> files;
         private readonly PathVerifier pathVerifier;
+#if !NET8_0_OR_GREATER
         [NonSerialized]
+#endif
         private Func<DateTime> dateTimeProvider = defaultDateTimeProvider;
         private static Func<DateTime> defaultDateTimeProvider = () => DateTime.UtcNow;
 
@@ -516,7 +520,9 @@ namespace System.IO.Abstractions.TestingHelpers
             return (GetFile(path).Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly;
         }
 
-        [Serializable]
+#if !NET8_0_OR_GREATER
+    [Serializable]
+#endif
         private class FileSystemEntry
         {
             public string Path { get; set; }

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileSystemWatcherFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileSystemWatcherFactory.cs
@@ -1,7 +1,9 @@
 ﻿namespace System.IO.Abstractions.TestingHelpers
 {
     /// <inheritdoc />
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public class MockFileSystemWatcherFactory : IFileSystemWatcherFactory
     {
 

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileSystemWatcherFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileSystemWatcherFactory.cs
@@ -1,7 +1,7 @@
 ﻿namespace System.IO.Abstractions.TestingHelpers
 {
     /// <inheritdoc />
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public class MockFileSystemWatcherFactory : IFileSystemWatcherFactory

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockPath.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockPath.cs
@@ -7,7 +7,7 @@ namespace System.IO.Abstractions.TestingHelpers
     /// <summary>
     /// PathWrapper calls direct to Path but all this does is string manipulation so we can inherit directly from PathWrapper as no IO is done
     /// </summary>
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public class MockPath : PathWrapper

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockPath.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockPath.cs
@@ -7,7 +7,9 @@ namespace System.IO.Abstractions.TestingHelpers
     /// <summary>
     /// PathWrapper calls direct to Path but all this does is string manipulation so we can inherit directly from PathWrapper as no IO is done
     /// </summary>
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public class MockPath : PathWrapper
     {
         private readonly IMockFileDataAccessor mockFileDataAccessor;

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/PathVerifier.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/PathVerifier.cs
@@ -7,7 +7,9 @@ namespace System.IO.Abstractions.TestingHelpers
     /// <summary>
     /// Provides helper methods for verifying paths.
     /// </summary>
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public class PathVerifier
     {
         private static readonly char[] AdditionalInvalidPathChars = { '*', '?' };

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/PathVerifier.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/PathVerifier.cs
@@ -7,7 +7,7 @@ namespace System.IO.Abstractions.TestingHelpers
     /// <summary>
     /// Provides helper methods for verifying paths.
     /// </summary>
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public class PathVerifier

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/StringOperations.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/StringOperations.cs
@@ -4,7 +4,9 @@
     /// <summary>
     /// Provides operations against path strings dependeing on the case-senstivity of the runtime platform.
     /// </summary>
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public class StringOperations
     {
         private readonly bool caseSensitive;

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/StringOperations.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/StringOperations.cs
@@ -4,7 +4,7 @@
     /// <summary>
     /// Provides operations against path strings dependeing on the case-senstivity of the runtime platform.
     /// </summary>
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public class StringOperations

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryBase.cs
@@ -5,7 +5,7 @@ using System.Security.AccessControl;
 namespace System.IO.Abstractions
 {
     /// <inheritdoc cref="Directory"/>
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public abstract class DirectoryBase : IDirectory

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryBase.cs
@@ -5,7 +5,9 @@ using System.Security.AccessControl;
 namespace System.IO.Abstractions
 {
     /// <inheritdoc cref="Directory"/>
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public abstract class DirectoryBase : IDirectory
     {
         /// <inheritdoc />

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryInfoBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryInfoBase.cs
@@ -4,7 +4,9 @@ using System.Security.AccessControl;
 namespace System.IO.Abstractions
 {
     /// <inheritdoc cref="IDirectoryInfo"/>
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public abstract class DirectoryInfoBase : FileSystemInfoBase, IDirectoryInfo
     {
         /// <inheritdoc />

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryInfoBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryInfoBase.cs
@@ -4,7 +4,7 @@ using System.Security.AccessControl;
 namespace System.IO.Abstractions
 {
     /// <inheritdoc cref="IDirectoryInfo"/>
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public abstract class DirectoryInfoBase : FileSystemInfoBase, IDirectoryInfo

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryInfoFactory.cs
@@ -1,6 +1,6 @@
 namespace System.IO.Abstractions
 {
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     internal class DirectoryInfoFactory : IDirectoryInfoFactory

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryInfoFactory.cs
@@ -1,6 +1,8 @@
 namespace System.IO.Abstractions
 {
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     internal class DirectoryInfoFactory : IDirectoryInfoFactory
     {
         private readonly IFileSystem fileSystem;

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryInfoWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryInfoWrapper.cs
@@ -7,7 +7,9 @@ using System.Security.AccessControl;
 namespace System.IO.Abstractions
 {
     /// <inheritdoc />
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public class DirectoryInfoWrapper : DirectoryInfoBase, IFileSystemAclSupport
     {
         private readonly DirectoryInfo instance;

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryInfoWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryInfoWrapper.cs
@@ -7,7 +7,7 @@ using System.Security.AccessControl;
 namespace System.IO.Abstractions
 {
     /// <inheritdoc />
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public class DirectoryInfoWrapper : DirectoryInfoBase, IFileSystemAclSupport

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryWrapper.cs
@@ -4,7 +4,9 @@ using System.Runtime.Versioning;
 namespace System.IO.Abstractions
 {
     /// <inheritdoc />
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public class DirectoryWrapper : DirectoryBase
     {
         /// <inheritdoc />

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryWrapper.cs
@@ -4,7 +4,7 @@ using System.Runtime.Versioning;
 namespace System.IO.Abstractions
 {
     /// <inheritdoc />
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public class DirectoryWrapper : DirectoryBase

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DriveInfoBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DriveInfoBase.cs
@@ -1,7 +1,9 @@
 ﻿namespace System.IO.Abstractions
 {
     /// <inheritdoc />
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public abstract class DriveInfoBase : IDriveInfo
     {
         /// <inheritdoc />

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DriveInfoBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DriveInfoBase.cs
@@ -1,7 +1,7 @@
 ﻿namespace System.IO.Abstractions
 {
     /// <inheritdoc />
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public abstract class DriveInfoBase : IDriveInfo

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DriveInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DriveInfoFactory.cs
@@ -1,6 +1,6 @@
 ﻿namespace System.IO.Abstractions
 {
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     internal class DriveInfoFactory : IDriveInfoFactory

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DriveInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DriveInfoFactory.cs
@@ -1,6 +1,8 @@
 ﻿namespace System.IO.Abstractions
 {
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     internal class DriveInfoFactory : IDriveInfoFactory
     {
         private readonly IFileSystem fileSystem;

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DriveInfoWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DriveInfoWrapper.cs
@@ -5,7 +5,9 @@ namespace System.IO.Abstractions
     /// <summary>
     /// The wrapper for a <see cref="DriveInfo"/>.
     /// </summary>
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public class DriveInfoWrapper : DriveInfoBase
     {
         /// <summary>

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DriveInfoWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DriveInfoWrapper.cs
@@ -5,7 +5,7 @@ namespace System.IO.Abstractions
     /// <summary>
     /// The wrapper for a <see cref="DriveInfo"/>.
     /// </summary>
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public class DriveInfoWrapper : DriveInfoBase

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileBase.cs
@@ -5,7 +5,9 @@ using Microsoft.Win32.SafeHandles;
 namespace System.IO.Abstractions
 {
     /// <inheritdoc cref="File"/>
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public abstract partial class FileBase : IFile
     {
         ///

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileBase.cs
@@ -5,7 +5,7 @@ using Microsoft.Win32.SafeHandles;
 namespace System.IO.Abstractions
 {
     /// <inheritdoc cref="File"/>
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public abstract partial class FileBase : IFile

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileInfoBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileInfoBase.cs
@@ -3,7 +3,9 @@
 namespace System.IO.Abstractions
 {
     /// <inheritdoc cref="FileInfo"/>
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public abstract class FileInfoBase : FileSystemInfoBase, IFileInfo
     {
         /// <inheritdoc />

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileInfoBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileInfoBase.cs
@@ -3,7 +3,7 @@
 namespace System.IO.Abstractions
 {
     /// <inheritdoc cref="FileInfo"/>
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public abstract class FileInfoBase : FileSystemInfoBase, IFileInfo

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileInfoFactory.cs
@@ -1,6 +1,8 @@
 ﻿namespace System.IO.Abstractions
 {
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     internal class FileInfoFactory : IFileInfoFactory
     {
         private readonly IFileSystem fileSystem;

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileInfoFactory.cs
@@ -1,6 +1,6 @@
 ﻿namespace System.IO.Abstractions
 {
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     internal class FileInfoFactory : IFileInfoFactory

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileInfoWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileInfoWrapper.cs
@@ -4,7 +4,7 @@ using System.Security.AccessControl;
 namespace System.IO.Abstractions
 {
     /// <inheritdoc />
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public class FileInfoWrapper : FileInfoBase, IFileSystemAclSupport

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileInfoWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileInfoWrapper.cs
@@ -4,7 +4,9 @@ using System.Security.AccessControl;
 namespace System.IO.Abstractions
 {
     /// <inheritdoc />
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public class FileInfoWrapper : FileInfoBase, IFileSystemAclSupport
     {
         private readonly FileInfo instance;

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileStreamFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileStreamFactory.cs
@@ -2,7 +2,7 @@
 
 namespace System.IO.Abstractions
 {
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     internal sealed class FileStreamFactory : IFileStreamFactory

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileStreamFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileStreamFactory.cs
@@ -2,7 +2,9 @@
 
 namespace System.IO.Abstractions
 {
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     internal sealed class FileStreamFactory : IFileStreamFactory
     {
         public FileStreamFactory(IFileSystem fileSystem)

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystem.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystem.cs
@@ -1,7 +1,9 @@
 ﻿namespace System.IO.Abstractions
 {
     /// <inheritdoc />
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public class FileSystem : FileSystemBase
     {
         /// <inheritdoc />

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystem.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystem.cs
@@ -1,7 +1,7 @@
 ﻿namespace System.IO.Abstractions
 {
     /// <inheritdoc />
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public class FileSystem : FileSystemBase

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemBase.cs
@@ -1,7 +1,7 @@
 ﻿namespace System.IO.Abstractions
 {
     /// <inheritdoc />
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public abstract class FileSystemBase : IFileSystem

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemBase.cs
@@ -1,7 +1,9 @@
 ﻿namespace System.IO.Abstractions
 {
     /// <inheritdoc />
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public abstract class FileSystemBase : IFileSystem
     {
         /// <inheritdoc />

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemInfoBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemInfoBase.cs
@@ -3,7 +3,9 @@
 namespace System.IO.Abstractions
 {
     /// <inheritdoc cref="FileSystemInfo"/>
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public abstract class FileSystemInfoBase : IFileSystemInfo
     {
         ///

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemInfoBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemInfoBase.cs
@@ -3,7 +3,7 @@
 namespace System.IO.Abstractions
 {
     /// <inheritdoc cref="FileSystemInfo"/>
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public abstract class FileSystemInfoBase : IFileSystemInfo

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemWatcherBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemWatcherBase.cs
@@ -3,7 +3,7 @@
 namespace System.IO.Abstractions
 {
     /// <inheritdoc cref="FileSystemWatcher"/>
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public abstract class FileSystemWatcherBase : IFileSystemWatcher

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemWatcherBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemWatcherBase.cs
@@ -3,7 +3,9 @@
 namespace System.IO.Abstractions
 {
     /// <inheritdoc cref="FileSystemWatcher"/>
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public abstract class FileSystemWatcherBase : IFileSystemWatcher
     {
         /// <inheritdoc />

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemWatcherFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemWatcherFactory.cs
@@ -1,7 +1,9 @@
 ﻿namespace System.IO.Abstractions
 {
     /// <inheritdoc />
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public class FileSystemWatcherFactory : IFileSystemWatcherFactory
     {
         ///

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemWatcherFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemWatcherFactory.cs
@@ -1,7 +1,7 @@
 ﻿namespace System.IO.Abstractions
 {
     /// <inheritdoc />
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public class FileSystemWatcherFactory : IFileSystemWatcherFactory

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemWatcherWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemWatcherWrapper.cs
@@ -3,12 +3,12 @@
 namespace System.IO.Abstractions
 {
     /// <inheritdoc />
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public class FileSystemWatcherWrapper : FileSystemWatcherBase
     {
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
         [NonSerialized]
 #endif
         private readonly FileSystemWatcher watcher;

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemWatcherWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemWatcherWrapper.cs
@@ -3,10 +3,14 @@
 namespace System.IO.Abstractions
 {
     /// <inheritdoc />
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public class FileSystemWatcherWrapper : FileSystemWatcherBase
     {
+#if !NET8_0_OR_GREATER
         [NonSerialized]
+#endif
         private readonly FileSystemWatcher watcher;
 
         /// <inheritdoc />

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileWrapper.cs
@@ -6,7 +6,7 @@ using Microsoft.Win32.SafeHandles;
 namespace System.IO.Abstractions
 {
     /// <inheritdoc />
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public partial class FileWrapper : FileBase

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileWrapper.cs
@@ -6,7 +6,9 @@ using Microsoft.Win32.SafeHandles;
 namespace System.IO.Abstractions
 {
     /// <inheritdoc />
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public partial class FileWrapper : FileBase
     {
         /// <inheritdoc />

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/PathBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/PathBase.cs
@@ -3,7 +3,9 @@
 namespace System.IO.Abstractions
 {
     /// <inheritdoc cref="Path"/>
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public abstract class PathBase : IPath
     {
         /// <inheritdoc />

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/PathBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/PathBase.cs
@@ -3,7 +3,7 @@
 namespace System.IO.Abstractions
 {
     /// <inheritdoc cref="Path"/>
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public abstract class PathBase : IPath

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/PathWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/PathWrapper.cs
@@ -3,7 +3,9 @@
 namespace System.IO.Abstractions
 {
     /// <inheritdoc />
+#if !NET8_0_OR_GREATER
     [Serializable]
+#endif
     public class PathWrapper : PathBase
     {
         /// <inheritdoc />

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/PathWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/PathWrapper.cs
@@ -3,7 +3,7 @@
 namespace System.IO.Abstractions
 {
     /// <inheritdoc />
-#if !NET8_0_OR_GREATER
+#if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
     public class PathWrapper : PathBase

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemSerializationTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemSerializationTests.cs
@@ -1,3 +1,4 @@
+#if !NET8_0_OR_GREATER
 namespace System.IO.Abstractions.TestingHelpers.Tests
 {
     using NUnit.Framework;
@@ -42,3 +43,4 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
     }
 }
+#endif

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemSerializationTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemSerializationTests.cs
@@ -1,4 +1,3 @@
-#if !NET8_0_OR_GREATER
 namespace System.IO.Abstractions.TestingHelpers.Tests
 {
     using NUnit.Framework;
@@ -43,4 +42,3 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
     }
 }
-#endif

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -163,6 +163,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(path.Exists, Is.True);
         }
 
+#if !NET8_0_OR_GREATER
         [Test]
         public void MockFileSystem_ByDefault_IsSerializable()
         {
@@ -182,6 +183,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.That(memoryStream.Length > 0, "Length didn't increase after serialization task.");
         }
+#endif
 
         [Test]
         public void MockFileSystem_AddDirectory_ShouldCreateDirectory()

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -163,7 +163,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(path.Exists, Is.True);
         }
 
-#if !NET8_0_OR_GREATER
         [Test]
         public void MockFileSystem_ByDefault_IsSerializable()
         {
@@ -183,7 +182,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.That(memoryStream.Length > 0, "Length didn't increase after serialization task.");
         }
-#endif
 
         [Test]
         public void MockFileSystem_AddDirectory_ShouldCreateDirectory()

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
@@ -534,6 +534,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(filesystem.FileExists(filepath));
         }
 
+#if !NET8_0_OR_GREATER
         [Test]
         public void Serializable_works()
         {
@@ -574,6 +575,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             //Assert
             Assert.That(deserialized.TextContents, Is.EqualTo(textContentStr));
         }
+#endif
 
         [Test]
         public void MockFile_Encrypt_ShouldSetEncryptedAttribute()

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
@@ -534,7 +534,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(filesystem.FileExists(filepath));
         }
 
-#if !NET8_0_OR_GREATER
         [Test]
         public void Serializable_works()
         {
@@ -575,7 +574,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             //Assert
             Assert.That(deserialized.TextContents, Is.EqualTo(textContentStr));
         }
-#endif
 
         [Test]
         public void MockFile_Encrypt_ShouldSetEncryptedAttribute()

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests.csproj
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests.csproj
@@ -40,4 +40,10 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
+  <PropertyGroup>
+    <!--
+      Allow deprecated binary formatter functionality on .NET 8 so that we can test it
+    -->
+    <EnableUnsafeBinaryFormatterSerialization Condition="'$(TargetFramework)' == 'net8.0'">true</EnableUnsafeBinaryFormatterSerialization>
+  </PropertyGroup>
 </Project>

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/FileSystemTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/FileSystemTests.cs
@@ -6,7 +6,6 @@ namespace System.IO.Abstractions.Tests
     [TestFixture]
     public class FileSystemTests
     {
-#if !NET8_0_OR_GREATER
         [Test]
         public void Is_Serializable()
         {
@@ -21,7 +20,6 @@ namespace System.IO.Abstractions.Tests
 
             Assert.That(memoryStream.Length > 0, "Length didn't increase after serialization task.");
         }
-#endif
 
         [Test]
         public void Mock_File_Succeeds()

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/FileSystemTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/FileSystemTests.cs
@@ -6,6 +6,7 @@ namespace System.IO.Abstractions.Tests
     [TestFixture]
     public class FileSystemTests
     {
+#if !NET8_0_OR_GREATER
         [Test]
         public void Is_Serializable()
         {
@@ -20,6 +21,7 @@ namespace System.IO.Abstractions.Tests
 
             Assert.That(memoryStream.Length > 0, "Length didn't increase after serialization task.");
         }
+#endif
 
         [Test]
         public void Mock_File_Succeeds()

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/TestableIO.System.IO.Abstractions.Wrappers.Tests.csproj
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/TestableIO.System.IO.Abstractions.Wrappers.Tests.csproj
@@ -23,4 +23,10 @@
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Snapshooter.NUnit" Version="0.13.0" />
   </ItemGroup>
+  <PropertyGroup>
+    <!--
+      Allow deprecated binary formatter functionality on .NET 8 so that we can test it
+    -->
+    <EnableUnsafeBinaryFormatterSerialization Condition="'$(TargetFramework)' == 'net8.0'">true</EnableUnsafeBinaryFormatterSerialization>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
This fixes #1033:
As [BinaryFormatter becomes obsolete](https://github.com/dotnet/designs/blob/main/accepted/2020/better-obsoletion/binaryformatter-obsoletion.md), remove the tests for serialization on .NET8.0 or greater. Also move the `Serialization` attribute behind a feature flag, which is currently always active, but will be disabled with .NET9.