### PR TITLE
fix: use correct paramName in Path.GetRelativePath

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockPath.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockPath.cs
@@ -165,7 +165,7 @@ namespace System.IO.Abstractions.TestingHelpers
                 throw new ArgumentNullException(nameof(relativeTo), StringResources.Manager.GetString("VALUE_CANNOT_BE_NULL"));
             }
 
-            if (relativeTo.Length == 0)
+            if (string.IsNullOrWhiteSpace(relativeTo))
             {
                 throw CommonExceptions.PathIsNotOfALegalForm(nameof(relativeTo));
             }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockPathTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockPathTests.cs
@@ -494,8 +494,6 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.IsFalse(result);
         }
 
-
-
         [Test]
         public void GetRelativePath_Works()
         {
@@ -507,6 +505,58 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             //Assert
             Assert.AreEqual(XFS.Path("e\\f.txt"), result);
+        }
+
+        [Test]
+        public void GetRelativePath_WhenPathIsNull_ShouldThrowArgumentNullException()
+        {
+            var mockPath = new MockFileSystem().Path;
+
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+            {
+                mockPath.GetRelativePath("foo", null);
+            });
+
+            Assert.AreEqual("path", exception.ParamName);
+        }
+
+        [Test]
+        public void GetRelativePath_WhenPathIsWhitespace_ShouldThrowArgumentException()
+        {
+            var mockPath = new MockFileSystem().Path;
+
+            var exception = Assert.Throws<ArgumentException>(() =>
+            {
+                mockPath.GetRelativePath("foo", " ");
+            });
+
+            Assert.AreEqual("path", exception.ParamName);
+        }
+
+        [Test]
+        public void GetRelativePath_WhenRelativeToNull_ShouldThrowArgumentNullException()
+        {
+            var mockPath = new MockFileSystem().Path;
+
+            var exception = Assert.Throws<ArgumentNullException>(() =>
+            {
+                mockPath.GetRelativePath(null, "foo");
+            });
+
+            Assert.AreEqual("relativeTo", exception.ParamName);
+        }
+
+        [Test]
+        public void GetRelativePath_WhenRelativeToIsWhitespace_ShouldThrowArgumentException()
+        {
+            var mockPath = new MockFileSystem().Path;
+
+            var exception = Assert.Throws<ArgumentException>(() =>
+            {
+                mockPath.GetRelativePath(" ", "foo");
+            });
+
+            Assert.AreEqual("relativeTo", exception.ParamName);
         }
 #endif
 


### PR DESCRIPTION
When calling `Path.GetRelativePath` with an incorrect `relativeTo` parameter (with whitespace), the ParamName of the exception was incorrectly set to `path` instead of `relativeTo`.