### PR TITLE
fix: prefix bug in MockDirectory.EnumerateDirectories (#815)

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -651,7 +651,9 @@ namespace System.IO.Abstractions.TestingHelpers
         private string FixPrefix(string path, string originalPath)
         {
             var normalizedOriginalPath = mockFileDataAccessor.Path.GetFullPath(originalPath);
-            return originalPath + path.Substring(normalizedOriginalPath.Length);
+            var pathWithoutOriginalPath = path.Substring(normalizedOriginalPath.Length)
+                .TrimStart(mockFileDataAccessor.Path.DirectorySeparatorChar);
+            return mockFileDataAccessor.Path.Combine(originalPath, pathWithoutOriginalPath);
         }
         
 #if FEATURE_ENUMERATION_OPTIONS

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -1321,7 +1321,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             CollectionAssert.AreEqual(
-                new[] { XFS.Path(currentDirectory + @"\" + relativeDirPath + @"\child") },
+                new[] { XFS.Path(relativeDirPath + @"\child") },
                 actualResult
             );
         }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -1487,10 +1487,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.Throws<DirectoryNotFoundException>(action);
         }
         
-        
-        [TestCase("Folder", @"Folder\SubFolder")]
-        [TestCase(@"Folder\", @"Folder\SubFolder")]
-        [TestCase(@"Folder\..\.\Folder", @"Folder\..\.\Folder\SubFolder")]
+        [TestCaseSource(nameof(GetPrefixTestPaths))]
         public void MockDirectory_EnumerateDirectories_ShouldReturnPathsPrefixedWithQueryPath(
             string queryPath, string expectedPath)
         {
@@ -1500,6 +1497,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = fileSystem.Directory.EnumerateDirectories(queryPath);
             
             CollectionAssert.AreEqual(new[] { expectedPath }, actualResult);
+        }
+        
+        private static IEnumerable<object[]> GetPrefixTestPaths()
+        {
+            var sep = Path.DirectorySeparatorChar;
+            yield return new object[] { "Folder", $"Folder{sep}SubFolder" };
+            yield return new object[] { $"Folder{sep}", $"Folder{sep}SubFolder" };
+            yield return new object[] { $"Folder{sep}..{sep}.{sep}Folder", $"Folder{sep}..{sep}.{sep}Folder{sep}SubFolder" };
         }
 
         public static IEnumerable<object[]> GetPathsForMoving()

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -1488,10 +1488,9 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
         
         
-        [TestCase("Folder", "Folder/SubFolder")]
-        [TestCase("/Folder", "/Folder/SubFolder")]
-        [TestCase("Folder/", "Folder/SubFolder")]
-        [TestCase("Folder/.././Folder", "Folder/.././Folder/SubFolder")]
+        [TestCase("Folder", @"Folder\SubFolder")]
+        [TestCase(@"Folder\", @"Folder\SubFolder")]
+        [TestCase(@"Folder\..\.\Folder", @"Folder\..\.\Folder\SubFolder")]
         public void MockDirectory_EnumerateDirectories_ShouldReturnPathsPrefixedWithQueryPath(
             string queryPath, string expectedPath)
         {

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -1271,7 +1271,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddFile(XFS.Path(@"C:\Folder\.foo\bar"), new MockFileData(string.Empty));
 
             // Act
-            var actualResult = fileSystem.Directory.GetDirectories(XFS.Path(@"c:\Folder\"), "*.foo");
+            var actualResult = fileSystem.Directory.GetDirectories(XFS.Path(@"C:\Folder\"), "*.foo");
 
             // Assert
             Assert.That(actualResult, Is.EquivalentTo(new[] { XFS.Path(@"C:\Folder\.foo"), XFS.Path(@"C:\Folder\foo.foo") }));
@@ -1353,7 +1353,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddFile(XFS.Path(@"C:\Folder\.foo\bar"), new MockFileData(string.Empty));
 
             // Act
-            var actualResult = fileSystem.Directory.GetDirectories(XFS.Path(@"c:\Folder\"), "*.foo", SearchOption.AllDirectories);
+            var actualResult = fileSystem.Directory.GetDirectories(XFS.Path(@"C:\Folder\"), "*.foo", SearchOption.AllDirectories);
 
             // Assert
             Assert.That(actualResult, Is.EquivalentTo(new[] { XFS.Path(@"C:\Folder\.foo"), XFS.Path(@"C:\Folder\foo.foo"), XFS.Path(@"C:\Folder\.foo\.foo") }));
@@ -1415,7 +1415,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddFile(XFS.Path(@"C:\Folder\.foo\bar"), new MockFileData(string.Empty));
 
             // Act
-            var actualResult = fileSystem.Directory.EnumerateDirectories(XFS.Path(@"c:\Folder\"), "*.foo");
+            var actualResult = fileSystem.Directory.EnumerateDirectories(XFS.Path(@"C:\Folder\"), "*.foo");
 
             // Assert
             Assert.That(actualResult, Is.EquivalentTo(new[] { XFS.Path(@"C:\Folder\.foo"), XFS.Path(@"C:\Folder\foo.foo") }));
@@ -1439,7 +1439,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             };
 
             // Act
-            var actualResult = fileSystem.Directory.EnumerateDirectories(XFS.Path(@"c:\Folder\"), "*.foo", enumerationOptions);
+            var actualResult = fileSystem.Directory.EnumerateDirectories(XFS.Path(@"C:\Folder\"), "*.foo", enumerationOptions);
 
             // Assert
             Assert.That(actualResult, Is.EquivalentTo(new[] { XFS.Path(@"C:\Folder\.foo"), XFS.Path(@"C:\Folder\foo.foo") }));
@@ -1457,7 +1457,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddFile(XFS.Path(@"C:\Folder\.foo\bar"), new MockFileData(string.Empty));
 
             // Act
-            var actualResult = fileSystem.Directory.EnumerateDirectories(XFS.Path(@"c:\Folder\"), "*.foo", SearchOption.AllDirectories);
+            var actualResult = fileSystem.Directory.EnumerateDirectories(XFS.Path(@"C:\Folder\"), "*.foo", SearchOption.AllDirectories);
 
             // Assert
             Assert.That(actualResult, Is.EquivalentTo(new[] { XFS.Path(@"C:\Folder\.foo"), XFS.Path(@"C:\Folder\foo.foo"), XFS.Path(@"C:\Folder\.foo\.foo") }));

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -1486,6 +1486,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Assert
             Assert.Throws<DirectoryNotFoundException>(action);
         }
+        
+        
+        [TestCase("Folder", "Folder/SubFolder")]
+        [TestCase("/Folder", "/Folder/SubFolder")]
+        [TestCase("Folder/", "Folder/SubFolder")]
+        [TestCase("Folder/.././Folder", "Folder/.././Folder/SubFolder")]
+        public void MockDirectory_EnumerateDirectories_ShouldReturnPathsPrefixedWithQueryPath(
+            string queryPath, string expectedPath)
+        {
+            var fileSystem = new MockFileSystem();
+            fileSystem.Directory.CreateDirectory("Folder/SubFolder");
+            
+            var actualResult = fileSystem.Directory.EnumerateDirectories(queryPath);
+            
+            CollectionAssert.AreEqual(new[] { expectedPath }, actualResult);
+        }
 
         public static IEnumerable<object[]> GetPathsForMoving()
         {


### PR DESCRIPTION
Fixes #815 

`System.IO.Directory.EnumerateDirectories(path)` guarantees that returned paths are always prefixed with the value provided in the `path` parameter. However, `MockDirectory.EnumerateDirectories` always returned absolute paths, leading to an inconsistent behavior (e.g. when using relative paths).

We now check returned paths from `MockDirectory.EnumerateDirectories` and provide the proper prefix path.