### PR TITLE
refactor: Convert Classic Assert to Constraint Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ public void MyComponent_Validate_ShouldThrowNotSupportedExceptionIfTestingIsNotA
     catch (NotSupportedException ex)
     {
         // Assert
-        Assert.AreEqual("We can't go on together. It's not me, it's you.", ex.Message);
+        Assert.That(ex.Message, Is.EqualTo("We can't go on together. It's not me, it's you."));
         return;
     }
 

--- a/src/System.IO.Abstractions.TestingHelpers/System.IO.Abstractions.TestingHelpers.csproj
+++ b/src/System.IO.Abstractions.TestingHelpers/System.IO.Abstractions.TestingHelpers.csproj
@@ -10,6 +10,7 @@
     <ProjectReference Include="..\TestableIO.System.IO.Abstractions.TestingHelpers\TestableIO.System.IO.Abstractions.TestingHelpers.csproj" />
 </ItemGroup>
   <ItemGroup>
+    <None Include="..\..\.editorconfig" Link=".editorconfig" />
     <None Include="..\..\images\icon_256x256.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>

--- a/src/System.IO.Abstractions.TestingHelpers/System.IO.Abstractions.TestingHelpers.csproj
+++ b/src/System.IO.Abstractions.TestingHelpers/System.IO.Abstractions.TestingHelpers.csproj
@@ -10,7 +10,6 @@
     <ProjectReference Include="..\TestableIO.System.IO.Abstractions.TestingHelpers\TestableIO.System.IO.Abstractions.TestingHelpers.csproj" />
 </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\.editorconfig" Link=".editorconfig" />
     <None Include="..\..\images\icon_256x256.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryArgumentPathTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryArgumentPathTests.cs
@@ -39,7 +39,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             var exception = Assert.Throws<ArgumentNullException>(wrapped);
-            Assert.AreEqual("path", exception.ParamName);
+            Assert.That(exception.ParamName, Is.EqualTo("path"));
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoFactoryTests.cs
@@ -12,7 +12,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.DirectoryInfo.Wrap(null);
             
-            Assert.IsNull(result);
+            Assert.That(result, Is.Null);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoSymlinkTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoSymlinkTests.cs
@@ -23,7 +23,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.DirectoryInfo.New("foo").ResolveLinkTarget(false);
 
-            Assert.AreEqual("bar", result.Name);
+            Assert.That(result.Name, Is.EqualTo("bar"));
         }
 
         [Test]
@@ -36,7 +36,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.DirectoryInfo.New("foo1").ResolveLinkTarget(true);
 
-            Assert.AreEqual("bar", result.Name);
+            Assert.That(result.Name, Is.EqualTo("bar"));
         }
 
         [Test]
@@ -49,7 +49,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.DirectoryInfo.New("foo1").ResolveLinkTarget(false);
 
-            Assert.AreEqual("foo", result.Name);
+            Assert.That(result.Name, Is.EqualTo("foo"));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
@@ -493,7 +493,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             directoryInfo.Refresh();
 
             // Assert
-            Assert.IsTrue(directoryInfo.Exists);
+            Assert.That(directoryInfo.Exists, Is.True);
         }
 
         [Test]
@@ -507,7 +507,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             directoryInfo.Create();
 
             // Assert
-            Assert.IsTrue(directoryInfo.Exists);
+            Assert.That(directoryInfo.Exists, Is.True);
         }
 
         [Test, WindowsOnly(WindowsSpecifics.AccessControlLists)]
@@ -521,7 +521,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             directoryInfo.Create(new DirectorySecurity());
 
             // Assert
-            Assert.IsTrue(directoryInfo.Exists);
+            Assert.That(directoryInfo.Exists, Is.True);
         }
 
         [Test]
@@ -563,7 +563,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             directoryInfo.MoveTo(XFS.Path(@"c:\abc2"));
 
             // Assert
-            Assert.IsTrue(directoryInfo.Exists);
+            Assert.That(directoryInfo.Exists, Is.True);
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
@@ -19,7 +19,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             }
         }
 
-        [TestCaseSource("MockDirectoryInfo_GetExtension_Cases")]
+        [TestCaseSource(nameof(MockDirectoryInfo_GetExtension_Cases))]
         public void MockDirectoryInfo_GetExtension_ShouldReturnEmptyString(string directoryPath)
         {
             // Arrange
@@ -42,7 +42,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             }
         }
 
-        [TestCaseSource("MockDirectoryInfo_Exists_Cases")]
+        [TestCaseSource(nameof(MockDirectoryInfo_Exists_Cases))]
         public void MockDirectoryInfo_Exists(string path, bool expected)
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
@@ -30,7 +30,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = directoryInfo.Extension;
 
             // Assert
-            Assert.AreEqual(string.Empty, result);
+            Assert.That(result, Is.Empty);
         }
 
         public static IEnumerable<object[]> MockDirectoryInfo_Exists_Cases
@@ -106,7 +106,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var files = directoryInfo.GetFiles();
 
             // Assert
-            Assert.AreEqual(fileName, files[0].FullName);
+            Assert.That(files[0].FullName, Is.EqualTo(fileName));
         }
 
         [Test]
@@ -129,7 +129,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var files = directoryInfo.GetFiles();
 
             // Assert
-            Assert.AreEqual(fileName, files[0].FullName);
+            Assert.That(files[0].FullName, Is.EqualTo(fileName));
         }
 
         [Test]
@@ -263,7 +263,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = directoryInfo.Parent;
 
             // Assert
-            Assert.AreEqual(XFS.Path(@"c:\a\b"), result.FullName);
+            Assert.That(result.FullName, Is.EqualTo(XFS.Path(@"c:\a\b")));
         }
 
         [Test]
@@ -287,7 +287,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\temp\folder"));
 
             // Assert
-            Assert.AreEqual(new[] { "b.txt", "c.txt" }, directoryInfo.EnumerateFiles().ToList().Select(x => x.Name).ToArray());
+            Assert.That(directoryInfo.EnumerateFiles().ToList().Select(x => x.Name).ToArray(), Is.EqualTo(new[] { "b.txt", "c.txt" }));
         }
 
         [Test]
@@ -309,7 +309,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var directories = directoryInfo.EnumerateDirectories().Select(a => a.Name).ToArray();
 
             // Assert
-            Assert.AreEqual(new[] { "b", "c" }, directories);
+            Assert.That(directories, Is.EqualTo(new[] { "b", "c" }));
         }
 
         [TestCase(@"\\unc\folder", @"\\unc\folder")]
@@ -327,7 +327,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualFullName = directoryInfo.FullName;
 
             // Assert
-            Assert.AreEqual(expectedFullName, actualFullName);
+            Assert.That(actualFullName, Is.EqualTo(expectedFullName));
         }
 
         [TestCase(@"c:\temp\\folder", @"c:\temp\folder")]
@@ -345,7 +345,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualFullName = directoryInfo.FullName;
 
             // Assert
-            Assert.AreEqual(expectedFullName, actualFullName);
+            Assert.That(actualFullName, Is.EqualTo(expectedFullName));
         }
 
         [TestCase(@"c:\temp\folder  ", @"c:\temp\folder")]
@@ -360,7 +360,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualFullName = directoryInfo.FullName;
 
             // Assert
-            Assert.AreEqual(expectedFullName, actualFullName);
+            Assert.That(actualFullName, Is.EqualTo(expectedFullName));
         }
 
         [Test]
@@ -377,7 +377,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             directoryInfo.MoveTo(destination);
 
             // Assert
-            Assert.AreEqual(destination, directoryInfo.FullName);
+            Assert.That(directoryInfo.FullName, Is.EqualTo(destination));
         }
 
         [TestCase(@"c:\temp\\folder ", @"folder")]
@@ -392,7 +392,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualName = directoryInfo.Name;
 
             // Assert
-            Assert.AreEqual(expectedName, actualName);
+            Assert.That(actualName, Is.EqualTo(expectedName));
         }
 
         [TestCase(@"c:\", @"c:\")]
@@ -407,7 +407,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualName = directoryInfo.Name;
 
             // Assert
-            Assert.AreEqual(expectedName, actualName);
+            Assert.That(actualName, Is.EqualTo(expectedName));
         }
 
         [Test]
@@ -462,7 +462,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var mockDirectoryInfo = new MockDirectoryInfo(new MockFileSystem(), directoryPath);
 
             // Assert
-            Assert.AreEqual(directoryPath, mockDirectoryInfo.ToString());
+            Assert.That(mockDirectoryInfo.ToString(), Is.EqualTo(directoryPath));
         }
 
         [Test]
@@ -582,7 +582,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             directoryInfo.LastAccessTime = lastAccessTime;
 
             // Assert
-            Assert.AreEqual(lastAccessTime, directoryInfo.LastAccessTime);
+            Assert.That(directoryInfo.LastAccessTime, Is.EqualTo(lastAccessTime));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
@@ -477,7 +477,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(path);
 
             // Assert
-            Assert.IsFalse(directoryInfo.Exists);
+            Assert.That(directoryInfo.Exists, Is.False);
         }
 
         [Test]
@@ -535,7 +535,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             directoryInfo.Delete();
 
             // Assert
-            Assert.IsFalse(directoryInfo.Exists);
+            Assert.That(directoryInfo.Exists, Is.False);
         }
 
         [Test]
@@ -549,7 +549,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             directoryInfo.Delete(true);
 
             // Assert
-            Assert.IsFalse(directoryInfo.Exists);
+            Assert.That(directoryInfo.Exists, Is.False);
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectorySymlinkTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectorySymlinkTests.cs
@@ -23,8 +23,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             IFileSystemInfo fileSystemInfo = fileSystem.Directory.CreateSymbolicLink(path, pathToTarget);
 
             // Assert
-            Assert.AreEqual(path, fileSystemInfo.FullName);
-            Assert.AreEqual(pathToTarget, fileSystemInfo.LinkTarget);
+            Assert.That(fileSystemInfo.FullName, Is.EqualTo(path));
+            Assert.That(fileSystemInfo.LinkTarget, Is.EqualTo(pathToTarget));
         }
 
         [Test]
@@ -41,8 +41,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             IDirectoryInfo directoryInfo = fileSystem.DirectoryInfo.New(path);
 
             // Assert
-            Assert.AreEqual(path, directoryInfo.FullName);
-            Assert.AreEqual(pathToTarget, directoryInfo.LinkTarget);
+            Assert.That(directoryInfo.FullName, Is.EqualTo(path));
+            Assert.That(directoryInfo.LinkTarget, Is.EqualTo(pathToTarget));
         }
 
         [Test]
@@ -221,7 +221,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.Directory.ResolveLinkTarget("foo", false);
 
-            Assert.AreEqual("bar", result.Name);
+            Assert.That(result.Name, Is.EqualTo("bar"));
         }
 
         [Test]
@@ -242,7 +242,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.Directory.ResolveLinkTarget(previousPath, true);
 
-            Assert.AreEqual("bar", result.Name);
+            Assert.That(result.Name, Is.EqualTo("bar"));
         }
 
         [Test]
@@ -275,7 +275,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.Directory.ResolveLinkTarget("foo1", false);
 
-            Assert.AreEqual("foo", result.Name);
+            Assert.That(result.Name, Is.EqualTo("foo"));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectorySymlinkTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectorySymlinkTests.cs
@@ -195,7 +195,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSystemInfo = fileSystem.Directory.CreateSymbolicLink(path, pathToTarget);
 
             // Assert
-            Assert.IsTrue(fileSystemInfo.Exists);
+            Assert.That(fileSystemInfo.Exists, Is.True);
         }
 
         [Test]
@@ -209,7 +209,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.CreateSymbolicLink(path, pathToTarget);
 
             var attributes = fileSystem.DirectoryInfo.New(path).Attributes;
-            Assert.IsTrue(attributes.HasFlag(FileAttributes.ReparsePoint));
+            Assert.That(attributes.HasFlag(FileAttributes.ReparsePoint), Is.True);
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -1753,7 +1753,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = fileSystem.Directory.GetParent(XFS.Path(@"c:\"));
 
             // Assert
-            Assert.IsNull(actualResult);
+            Assert.That(actualResult, Is.Null);
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -1320,10 +1320,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = fileSystem.Directory.GetDirectories(XFS.Path(relativeDirPath));
 
             // Assert
-            CollectionAssert.AreEqual(
-                new[] { XFS.Path(relativeDirPath + @"\child") },
-                actualResult
-            );
+            Assert.That(actualResult, Is.EqualTo(new[] { XFS.Path(relativeDirPath + @"\child") }));
         }
 
         [Test]
@@ -1496,7 +1493,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             
             var actualResult = fileSystem.Directory.EnumerateDirectories(queryPath);
             
-            CollectionAssert.AreEqual(new[] { expectedPath }, actualResult);
+            Assert.That(actualResult, Is.EqualTo(new[] { expectedPath }));
         }
         
         private static IEnumerable<object[]> GetPrefixTestPaths()

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -1671,7 +1671,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSystem = new MockFileSystem();
 
             // Precondition
-            Assert.AreNotEqual(directory, fileSystem.Directory.GetCurrentDirectory());
+            Assert.That(fileSystem.Directory.GetCurrentDirectory(), Is.Not.EqualTo(directory));
 
             fileSystem.Directory.SetCurrentDirectory(directory);
 

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -1533,7 +1533,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.IsTrue(fileSystem.File.Exists(XFS.Path(@"C:\NewLocation\Data\someFile.txt")));
         }
 
-        [TestCaseSource("GetPathsForMoving")]
+        [TestCaseSource(nameof(GetPathsForMoving))]
         public void MockDirectory_Move_ShouldMoveDirectories(string sourceDirName, string destDirName, string filePathOne, string filePathTwo)
         {
             // Arrange

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -1030,9 +1030,9 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             });
 
             var entries = fileSystem.Directory.GetFileSystemEntries(XFS.Path(@"c:\foo")).OrderBy(k => k);
-            Assert.AreEqual(2, entries.Count());
-            Assert.AreEqual(testDir, entries.First());
-            Assert.AreEqual(testPath, entries.Last());
+            Assert.That(entries.Count(), Is.EqualTo(2));
+            Assert.That(entries.First(), Is.EqualTo(testDir));
+            Assert.That(entries.Last(), Is.EqualTo(testPath));
         }
 
         [Test]
@@ -1048,9 +1048,9 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             });
 
             var entries = fileSystem.Directory.GetFileSystemEntries(XFS.Path(@"c:\foo"), "*", SearchOption.TopDirectoryOnly).OrderBy(k => k);
-            Assert.AreEqual(2, entries.Count());
-            Assert.AreEqual(testDir, entries.First());
-            Assert.AreEqual(testPath, entries.Last());
+            Assert.That(entries.Count(), Is.EqualTo(2));
+            Assert.That(entries.First(), Is.EqualTo(testDir));
+            Assert.That(entries.Last(), Is.EqualTo(testPath));
         }
 
         [Test]
@@ -1087,8 +1087,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             });
 
             var entries = fileSystem.Directory.GetFiles(XFS.Path(@"c:\foo")).OrderBy(k => k);
-            Assert.AreEqual(1, entries.Count());
-            Assert.AreEqual(testPath, entries.First());
+            Assert.That(entries.Count(), Is.EqualTo(1));
+            Assert.That(entries.First(), Is.EqualTo(testPath));
         }
 
         [Test]
@@ -1102,7 +1102,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.SetCurrentDirectory(directory);
             fileSystem.AddFile(XFS.Path(@"C:\test.txt"), new MockFileData("Some ASCII text."));
 
-            Assert.AreEqual(fileSystem.Directory.GetFiles(XFS.Path(@"..\")).Length, 1); // Assert with relative path
+            Assert.That(fileSystem.Directory.GetFiles(XFS.Path(@"..\")).Length, Is.EqualTo(1)); // Assert with relative path
         }
 
         [Test]
@@ -1211,7 +1211,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 { testDir,  new MockDirectoryData() }
             });
 
-            Assert.AreEqual(XFS.Path("C:\\"), fileSystem.Directory.GetDirectoryRoot(XFS.Path(@"C:\foo\bar")));
+            Assert.That(fileSystem.Directory.GetDirectoryRoot(XFS.Path(@"C:\foo\bar")), Is.EqualTo(XFS.Path("C:\\")));
         }
 
         [Test]
@@ -1228,12 +1228,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             if (XFS.IsUnixPlatform())
             {
-                Assert.AreEqual(1, drives.Length);
+                Assert.That(drives.Length, Is.EqualTo(1));
                 Assert.IsTrue(drives.Contains("/"));
             }
             else
             {
-                Assert.AreEqual(2, drives.Length);
+                Assert.That(drives.Length, Is.EqualTo(2));
                 Assert.IsTrue(drives.Contains(@"C:\"));
                 Assert.IsTrue(drives.Contains(@"D:\"));
             }
@@ -1254,7 +1254,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.IsFalse(directories.Contains(XFS.Path(@"A:\folder1")));
 
             //Check that it correctly returns all child directories
-            Assert.AreEqual(2, directories.Count());
+            Assert.That(directories.Count(), Is.EqualTo(2));
             Assert.IsTrue(directories.Contains(XFS.Path(@"A:\folder1\folder2")));
             Assert.IsTrue(directories.Contains(XFS.Path(@"A:\folder1\folder4")));
         }
@@ -1398,7 +1398,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.IsFalse(directories.Contains(XFS.Path(@"A:\folder1")));
 
             //Check that it correctly returns all child directories
-            Assert.AreEqual(2, directories.Count());
+            Assert.That(directories.Count(), Is.EqualTo(2));
             Assert.IsTrue(directories.Contains(XFS.Path(@"A:\folder1\folder2")));
             Assert.IsTrue(directories.Contains(XFS.Path(@"A:\folder1\folder4")));
         }
@@ -1652,7 +1652,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var actual = fileSystem.Directory.GetCurrentDirectory();
 
-            Assert.AreEqual(directory, actual);
+            Assert.That(actual, Is.EqualTo(directory));
         }
 
         [Test]
@@ -1664,7 +1664,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var actual = fileSystem.Directory.GetCurrentDirectory();
 
-            Assert.AreEqual(directory, actual);
+            Assert.That(actual, Is.EqualTo(directory));
         }
 
         [Test]
@@ -1678,7 +1678,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileSystem.Directory.SetCurrentDirectory(directory);
 
-            Assert.AreEqual(directory, fileSystem.Directory.GetCurrentDirectory());
+            Assert.That(fileSystem.Directory.GetCurrentDirectory(), Is.EqualTo(directory));
         }
 
         [Test]
@@ -1771,7 +1771,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var parent = fileSystem.Directory.GetParent("/bar");
 
             // Assert
-            Assert.AreEqual("/", parent.FullName);
+            Assert.That(parent.FullName, Is.EqualTo("/"));
         }
 
         public static IEnumerable<string[]> MockDirectory_GetParent_Cases
@@ -1794,7 +1794,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = fileSystem.Directory.GetParent(path);
 
             // Assert
-            Assert.AreEqual(expectedResult, actualResult.FullName);
+            Assert.That(actualResult.FullName, Is.EqualTo(expectedResult));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -604,7 +604,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.Exists(XFS.Path(@"c:\baz"));
 
             // Assert
-            Assert.IsFalse(result);
+            Assert.That(result, Is.False);
         }
 
         [Test]
@@ -620,7 +620,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.Exists(XFS.Path(@"c:\baz\"));
 
             // Assert
-            Assert.IsFalse(result);
+            Assert.That(result, Is.False);
         }
 
         [Test]
@@ -637,7 +637,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.Exists(XFS.Path(@"c:\baz"));
 
             // Assert
-            Assert.IsFalse(result);
+            Assert.That(result, Is.False);
         }
 
         [Test]
@@ -683,7 +683,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.Exists(path);
 
             // Assert
-            Assert.IsFalse(result);
+            Assert.That(result, Is.False);
         }
 
         [Test]
@@ -710,7 +710,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.Exists(XFS.Path(@"c:\foo\bar.txt"));
 
             // Assert
-            Assert.IsFalse(result);
+            Assert.That(result, Is.False);
         }
 
         [Test]
@@ -894,7 +894,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.Delete(XFS.Path(@"c:\bar"), true);
 
             // Assert
-            Assert.IsFalse(fileSystem.Directory.Exists(XFS.Path(@"c:\bar")));
+            Assert.That(fileSystem.Directory.Exists(XFS.Path(@"c:\bar")), Is.False);
         }
 
         [Test]
@@ -915,8 +915,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.Delete(folder1Path, recursive: true);
 
             // Assert
-            Assert.IsFalse(fileSystem.Directory.Exists(folder1Path));
-            Assert.IsFalse(fileSystem.Directory.Exists(folder1SubFolderPath));
+            Assert.That(fileSystem.Directory.Exists(folder1Path), Is.False);
+            Assert.That(fileSystem.Directory.Exists(folder1SubFolderPath), Is.False);
             Assert.IsTrue(fileSystem.Directory.Exists(folder2Path));
         }
 
@@ -934,7 +934,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.Delete(XFS.Path(@"c:\BAR"), true);
 
             // Assert
-            Assert.IsFalse(fileSystem.Directory.Exists(XFS.Path(@"c:\bar")));
+            Assert.That(fileSystem.Directory.Exists(XFS.Path(@"c:\bar")), Is.False);
         }
 
         [Test]
@@ -968,7 +968,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.Delete("/bar", true);
 
             // Assert
-            Assert.IsFalse(fileSystem.Directory.Exists("/bar"));
+            Assert.That(fileSystem.Directory.Exists("/bar"), Is.False);
         }
 
         [Test]
@@ -1014,8 +1014,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.DirectoryInfo.New(XFS.Path(@"c:\bar")).Delete(true);
 
             // Assert
-            Assert.IsFalse(fileSystem.Directory.Exists(XFS.Path(@"c:\bar")));
-            Assert.IsFalse(fileSystem.Directory.Exists(XFS.Path(@"c:\bar\bar2")));
+            Assert.That(fileSystem.Directory.Exists(XFS.Path(@"c:\bar")), Is.False);
+            Assert.That(fileSystem.Directory.Exists(XFS.Path(@"c:\bar\bar2")), Is.False);
         }
 
         [Test]
@@ -1251,7 +1251,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var directories = fileSystem.Directory.GetDirectories(XFS.Path(@"A:\folder1")).ToArray();
 
             //Check that it does not returns itself
-            Assert.IsFalse(directories.Contains(XFS.Path(@"A:\folder1")));
+            Assert.That(directories.Contains(XFS.Path(@"A:\folder1")), Is.False);
 
             //Check that it correctly returns all child directories
             Assert.That(directories.Count(), Is.EqualTo(2));
@@ -1392,7 +1392,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var directories = fileSystem.Directory.EnumerateDirectories(XFS.Path(@"A:\folder1")).ToArray();
 
             //Check that it does not returns itself
-            Assert.IsFalse(directories.Contains(XFS.Path(@"A:\folder1")));
+            Assert.That(directories.Contains(XFS.Path(@"A:\folder1")), Is.False);
 
             //Check that it correctly returns all child directories
             Assert.That(directories.Count(), Is.EqualTo(2));
@@ -1544,7 +1544,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.DirectoryInfo.New(sourceDirName).MoveTo(destDirName);
 
             // Assert
-            Assert.IsFalse(fileSystem.Directory.Exists(sourceDirName));
+            Assert.That(fileSystem.Directory.Exists(sourceDirName), Is.False);
             Assert.IsTrue(fileSystem.File.Exists(XFS.Path(destDirName + filePathOne)));
             Assert.IsTrue(fileSystem.File.Exists(XFS.Path(destDirName + filePathTwo)));
         }
@@ -1616,7 +1616,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.DirectoryInfo.New(sourceDirName).MoveTo(destDirName);
 
             // Assert
-            Assert.IsFalse(fileSystem.Directory.Exists(sourceSubDirName));
+            Assert.That(fileSystem.Directory.Exists(sourceSubDirName), Is.False);
             Assert.IsTrue(fileSystem.FileExists(destSubDirName));
         }
 
@@ -2133,7 +2133,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 fileSystem.Directory.Move(sourceDirName, targetDirName));
 
             // Assert
-            Assert.IsFalse(fileSystem.Directory.Exists(targetDirName));
+            Assert.That(fileSystem.Directory.Exists(targetDirName), Is.False);
             Assert.IsTrue(fileSystem.Directory.Exists(sourceDirName));
         }
 
@@ -2172,7 +2172,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             Assert.IsTrue(fileSystem.Directory.Exists(targetDirName));
-            Assert.IsFalse(fileSystem.Directory.Exists(sourceDirName));
+            Assert.That(fileSystem.Directory.Exists(sourceDirName), Is.False);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -774,7 +774,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\bar"));
 
             // Assert
-            Assert.IsNotNull(result);
+            Assert.That(result, Is.Not.Null);
         }
 
         [Test]
@@ -804,7 +804,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\foo\"));
 
             // Assert
-            Assert.IsNotNull(result);
+            Assert.That(result, Is.Not.Null);
         }
 
         [Test]
@@ -1725,7 +1725,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = fileSystem.Directory.GetParent(XFS.Path(@"c:\directory\does\not\exist"));
 
             // Assert
-            Assert.IsNotNull(actualResult);
+            Assert.That(actualResult, Is.Not.Null);
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -832,7 +832,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var ex = Assert.Throws<ArgumentException>(() => fileSystem.Directory.CreateDirectory(@"\\server"));
 
             // Assert
-            StringAssert.StartsWith("The UNC path should be of the form \\\\server\\share.", ex.Message);
+            Assert.That(ex.Message, Does.StartWith("The UNC path should be of the form \\\\server\\share."));
             Assert.That(ex.ParamName, Is.EqualTo("path"));
         }
 

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -572,7 +572,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.Exists(XFS.Path(@"c:\foo"));
 
             // Assert
-            Assert.IsTrue(result);
+            Assert.That(result, Is.True);
         }
 
         [Test]
@@ -588,7 +588,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.Exists(XFS.Path(@"c:\foo\"));
 
             // Assert
-            Assert.IsTrue(result);
+            Assert.That(result, Is.True);
         }
 
         [Test]
@@ -654,7 +654,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.Exists(XFS.Path(@"c:\bar"));
 
             // Assert
-            Assert.IsTrue(result);
+            Assert.That(result, Is.True);
         }
 
         [Test]
@@ -668,7 +668,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.Exists(XFS.Path(@"c:\foo\"));
 
             // Assert
-            Assert.IsTrue(result);
+            Assert.That(result, Is.True);
         }
 
         [TestCase(@"\\s")]
@@ -726,8 +726,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\bar"));
 
             // Assert
-            Assert.IsTrue(fileSystem.FileExists(XFS.Path(@"c:\bar\")));
-            Assert.IsTrue(fileSystem.AllDirectories.Any(d => d == XFS.Path(@"c:\bar")));
+            Assert.That(fileSystem.FileExists(XFS.Path(@"c:\bar\")), Is.True);
+            Assert.That(fileSystem.AllDirectories.Any(d => d == XFS.Path(@"c:\bar")), Is.True);
         }
 
         [Test]
@@ -788,7 +788,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\temp\folder "));
 
             // Assert
-            Assert.IsTrue(fileSystem.Directory.Exists(XFS.Path(@"c:\temp\folder")));
+            Assert.That(fileSystem.Directory.Exists(XFS.Path(@"c:\temp\folder")), Is.True);
         }
 
         [Test]
@@ -818,7 +818,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.CreateDirectory(@"\\server\share\path\to\create");
 
             // Assert
-            Assert.IsTrue(fileSystem.Directory.Exists(@"\\server\share\path\to\create\"));
+            Assert.That(fileSystem.Directory.Exists(@"\\server\share\path\to\create\"), Is.True);
         }
 
         [Test]
@@ -847,7 +847,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.CreateDirectory(@"\\server\share");
 
             // Assert
-            Assert.IsTrue(fileSystem.Directory.Exists(@"\\server\share\"));
+            Assert.That(fileSystem.Directory.Exists(@"\\server\share\"), Is.True);
         }
 
 #if FEATURE_CREATE_TEMP_SUBDIRECTORY
@@ -861,8 +861,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.CreateTempSubdirectory();
 
             // Assert
-            Assert.IsTrue(fileSystem.Directory.Exists(result.FullName));
-            Assert.IsTrue(result.FullName.Contains(Path.GetTempPath()));
+            Assert.That(fileSystem.Directory.Exists(result.FullName), Is.True);
+            Assert.That(result.FullName.Contains(Path.GetTempPath()), Is.True);
         }
 
         [Test]
@@ -875,9 +875,9 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.CreateTempSubdirectory("foo-");
 
             // Assert
-            Assert.IsTrue(fileSystem.Directory.Exists(result.FullName));
-            Assert.IsTrue(Path.GetFileName(result.FullName).StartsWith("foo-"));
-            Assert.IsTrue(result.FullName.Contains(Path.GetTempPath()));
+            Assert.That(fileSystem.Directory.Exists(result.FullName), Is.True);
+            Assert.That(Path.GetFileName(result.FullName).StartsWith("foo-"), Is.True);
+            Assert.That(result.FullName.Contains(Path.GetTempPath()), Is.True);
         }
 #endif
 
@@ -917,7 +917,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Assert
             Assert.That(fileSystem.Directory.Exists(folder1Path), Is.False);
             Assert.That(fileSystem.Directory.Exists(folder1SubFolderPath), Is.False);
-            Assert.IsTrue(fileSystem.Directory.Exists(folder2Path));
+            Assert.That(fileSystem.Directory.Exists(folder2Path), Is.True);
         }
 
         [Test]
@@ -1229,13 +1229,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             if (XFS.IsUnixPlatform())
             {
                 Assert.That(drives.Length, Is.EqualTo(1));
-                Assert.IsTrue(drives.Contains("/"));
+                Assert.That(drives.Contains("/"), Is.True);
             }
             else
             {
                 Assert.That(drives.Length, Is.EqualTo(2));
-                Assert.IsTrue(drives.Contains(@"C:\"));
-                Assert.IsTrue(drives.Contains(@"D:\"));
+                Assert.That(drives.Contains(@"C:\"), Is.True);
+                Assert.That(drives.Contains(@"D:\"), Is.True);
             }
         }
 
@@ -1255,8 +1255,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             //Check that it correctly returns all child directories
             Assert.That(directories.Count(), Is.EqualTo(2));
-            Assert.IsTrue(directories.Contains(XFS.Path(@"A:\folder1\folder2")));
-            Assert.IsTrue(directories.Contains(XFS.Path(@"A:\folder1\folder4")));
+            Assert.That(directories.Contains(XFS.Path(@"A:\folder1\folder2")), Is.True);
+            Assert.That(directories.Contains(XFS.Path(@"A:\folder1\folder4")), Is.True);
         }
 
         [Test]
@@ -1396,8 +1396,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             //Check that it correctly returns all child directories
             Assert.That(directories.Count(), Is.EqualTo(2));
-            Assert.IsTrue(directories.Contains(XFS.Path(@"A:\folder1\folder2")));
-            Assert.IsTrue(directories.Contains(XFS.Path(@"A:\folder1\folder4")));
+            Assert.That(directories.Contains(XFS.Path(@"A:\folder1\folder2")), Is.True);
+            Assert.That(directories.Contains(XFS.Path(@"A:\folder1\folder4")), Is.True);
         }
 
         [Test]
@@ -1527,7 +1527,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.Move(XFS.Path(@"C:\old_location"), XFS.Path(@"C:\NewLocation\"));
 
             // Assert
-            Assert.IsTrue(fileSystem.File.Exists(XFS.Path(@"C:\NewLocation\Data\someFile.txt")));
+            Assert.That(fileSystem.File.Exists(XFS.Path(@"C:\NewLocation\Data\someFile.txt")), Is.True);
         }
 
         [TestCaseSource(nameof(GetPathsForMoving))]
@@ -1545,8 +1545,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             Assert.That(fileSystem.Directory.Exists(sourceDirName), Is.False);
-            Assert.IsTrue(fileSystem.File.Exists(XFS.Path(destDirName + filePathOne)));
-            Assert.IsTrue(fileSystem.File.Exists(XFS.Path(destDirName + filePathTwo)));
+            Assert.That(fileSystem.File.Exists(XFS.Path(destDirName + filePathOne)), Is.True);
+            Assert.That(fileSystem.File.Exists(XFS.Path(destDirName + filePathTwo)), Is.True);
         }
 
         [Test]
@@ -1591,7 +1591,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             var destDirectoryInfo = fileSystem.DirectoryInfo.New(destDirName);
-            Assert.IsTrue(destDirectoryInfo.Attributes.HasFlag(FileAttributes.System));
+            Assert.That(destDirectoryInfo.Attributes.HasFlag(FileAttributes.System), Is.True);
         }
 
         [Test]
@@ -1617,7 +1617,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             Assert.That(fileSystem.Directory.Exists(sourceSubDirName), Is.False);
-            Assert.IsTrue(fileSystem.FileExists(destSubDirName));
+            Assert.That(fileSystem.FileExists(destSubDirName), Is.True);
         }
 
         [Test]
@@ -1686,7 +1686,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.Directory.GetCurrentDirectory();
 
-            Assert.IsTrue(fileSystem.Path.IsPathRooted(result));
+            Assert.That(fileSystem.Path.IsPathRooted(result), Is.True);
         }
 
         [Test]
@@ -2134,7 +2134,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             Assert.That(fileSystem.Directory.Exists(targetDirName), Is.False);
-            Assert.IsTrue(fileSystem.Directory.Exists(sourceDirName));
+            Assert.That(fileSystem.Directory.Exists(sourceDirName), Is.True);
         }
 
         private static IEnumerable<TestCaseData> Success_DirectoryMoveFromToPaths
@@ -2171,7 +2171,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 fileSystem.Directory.Move(sourceDirName, targetDirName));
 
             // Assert
-            Assert.IsTrue(fileSystem.Directory.Exists(targetDirName));
+            Assert.That(fileSystem.Directory.Exists(targetDirName), Is.True);
             Assert.That(fileSystem.Directory.Exists(sourceDirName), Is.False);
         }
     }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDriveInfoFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDriveInfoFactoryTests.cs
@@ -105,7 +105,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.DriveInfo.Wrap(null);
 
-            Assert.IsNull(result);
+            Assert.That(result, Is.Null);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDriveInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDriveInfoTests.cs
@@ -21,7 +21,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var driveInfo = new MockDriveInfo(fileSystem, path);
 
             // Assert
-            Assert.AreEqual(@"c:\", driveInfo.Name);
+            Assert.That(driveInfo.Name, Is.EqualTo(@"c:\"));
         }
 
         [Test]
@@ -35,7 +35,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var driveInfo = new MockDriveInfo(fileSystem, "c");
 
             // Assert
-            Assert.AreEqual(@"c:\", driveInfo.Name);
+            Assert.That(driveInfo.Name, Is.EqualTo(@"c:\"));
         }
 
         [TestCase(@"\\unc\share")]
@@ -65,7 +65,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualDirectory = driveInfo.RootDirectory;
 
             // Assert
-            Assert.AreEqual(expectedDirectory, actualDirectory.FullName);
+            Assert.That(actualDirectory.FullName, Is.EqualTo(expectedDirectory));
         }
 
         [TestCase("c:", "c:\\")]
@@ -82,7 +82,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var mockDriveInfo = new MockDriveInfo(new MockFileSystem(), directoryPath);
 
             // Assert
-            Assert.AreEqual(expectedPath, mockDriveInfo.ToString());
+            Assert.That(mockDriveInfo.ToString(), Is.EqualTo(expectedPath));
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileAppendAllLinesTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileAppendAllLinesTests.cs
@@ -24,9 +24,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             file.AppendAllLines(path, new[] { "line 1", "line 2", "line 3" });
 
             // Assert
-            Assert.AreEqual(
-                "Demo text contentline 1" + Environment.NewLine + "line 2" + Environment.NewLine + "line 3" + Environment.NewLine,
-                file.ReadAllText(path));
+            Assert.That(file.ReadAllText(path),
+              Is.EqualTo("Demo text contentline 1" + Environment.NewLine + "line 2" + Environment.NewLine + "line 3" + Environment.NewLine));
         }
 
         [Test]
@@ -44,9 +43,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             file.AppendAllLines(path, new[] { "line 1", "line 2", "line 3" });
 
             // Assert
-            Assert.AreEqual(
-                "line 1" + Environment.NewLine + "line 2" + Environment.NewLine + "line 3" + Environment.NewLine,
-                file.ReadAllText(path));
+            Assert.That(file.ReadAllText(path),
+              Is.EqualTo("line 1" + Environment.NewLine + "line 2" + Environment.NewLine + "line 3" + Environment.NewLine));
         }
 
         [Test]
@@ -138,9 +136,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             await file.AppendAllLinesAsync(path, new[] { "line 1", "line 2", "line 3" });
 
             // Assert
-            Assert.AreEqual(
-                "Demo text contentline 1" + Environment.NewLine + "line 2" + Environment.NewLine + "line 3" + Environment.NewLine,
-                file.ReadAllText(path));
+            Assert.That(file.ReadAllText(path),
+              Is.EqualTo("Demo text contentline 1" + Environment.NewLine + "line 2" + Environment.NewLine + "line 3" + Environment.NewLine));
         }
 
         [Test]
@@ -158,10 +155,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             await file.AppendAllLinesAsync(path, new[] { "line 1", "line 2", "line 3" });
 
             // Assert
-            Assert.AreEqual(
-                "line 1" + Environment.NewLine + "line 2" + Environment.NewLine + "line 3" + Environment.NewLine,
-                file.ReadAllText(path)
-            );
+            Assert.That(file.ReadAllText(path),
+              Is.EqualTo("line 1" + Environment.NewLine + "line 2" + Environment.NewLine + "line 3" + Environment.NewLine));
         }
 
         [Test]
@@ -183,7 +178,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             );
 
             // Assert
-            Assert.AreEqual("line 1", fileSystem.File.ReadAllText(path));
+            Assert.That(fileSystem.File.ReadAllText(path), Is.EqualTo("line 1"));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileAppendAllTextTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileAppendAllTextTests.cs
@@ -30,9 +30,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             file.AppendAllText(path, "+ some text");
 
             // Assert
-            Assert.AreEqual(
-                "Demo text content+ some text",
-                file.ReadAllText(path));
+            Assert.That(file.ReadAllText(path),
+              Is.EqualTo("Demo text content+ some text"));
         }
 
         [Test]
@@ -70,9 +69,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.File.AppendAllText(path, " some text");
 
             // Assert
-            Assert.AreEqual(
-                "Demo text content some text",
-                fileSystem.File.ReadAllText(path));
+            Assert.That(fileSystem.File.ReadAllText(path),
+              Is.EqualTo("Demo text content some text"));
         }
 
         [Test]
@@ -174,9 +172,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             await file.AppendAllTextAsync(path, "+ some text");
 
             // Assert
-            Assert.AreEqual(
-                "Demo text content+ some text",
-                file.ReadAllText(path));
+            Assert.That(file.ReadAllText(path),
+              Is.EqualTo("Demo text content+ some text"));
         }
 
         [Test]
@@ -198,7 +195,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             );
 
             // Assert
-            Assert.AreEqual("line 1", fileSystem.File.ReadAllText(path));
+            Assert.That(fileSystem.File.ReadAllText(path), Is.EqualTo("line 1"));
         }
 
         [Test]
@@ -236,9 +233,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             await fileSystem.File.AppendAllTextAsync(path, " some text");
 
             // Assert
-            Assert.AreEqual(
-                "Demo text content some text",
-                fileSystem.File.ReadAllText(path));
+            Assert.That(fileSystem.File.ReadAllText(path),
+              Is.EqualTo("Demo text content some text"));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileAppendAllTextTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileAppendAllTextTests.cs
@@ -50,9 +50,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             file.AppendAllText(Path, "BB", Encoding.UTF8);
 
             // Assert
-            CollectionAssert.AreEqual(
-                new byte[] { 255, 254, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0, 66, 66 },
-                fileSystem.GetFile(Path).Contents);
+            Assert.That(fileSystem.GetFile(Path).Contents,
+                Is.EqualTo(new byte[] { 255, 254, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0, 66, 66 }));
         }
 
         [Test]
@@ -85,9 +84,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.File.AppendAllText(path, "AA", Encoding.UTF32);
 
             // Assert
-            CollectionAssert.AreEqual(
-                new byte[] { 255, 254, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0 },
-                fileSystem.GetFile(path).Contents);
+            Assert.That(fileSystem.GetFile(path).Contents,
+                Is.EqualTo(new byte[] { 255, 254, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0 }));
         }
 
         [Test]
@@ -139,9 +137,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 0, 32, 0, 116, 0, 101, 0, 120, 0, 116
             };
 
-            CollectionAssert.AreEqual(
-                expected,
-                file.ReadAllBytes(path));
+            Assert.That(file.ReadAllBytes(path), Is.EqualTo(expected));
         }
 
         [Test]
@@ -214,9 +210,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             await file.AppendAllTextAsync(Path, "BB", Encoding.UTF8);
 
             // Assert
-            CollectionAssert.AreEqual(
-                new byte[] { 255, 254, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0, 66, 66 },
-                fileSystem.GetFile(Path).Contents);
+            Assert.That(fileSystem.GetFile(Path).Contents,
+                Is.EqualTo(new byte[] { 255, 254, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0, 66, 66 }));
         }
 
         [Test]
@@ -249,9 +244,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             await fileSystem.File.AppendAllTextAsync(path, "AA", Encoding.UTF32);
 
             // Assert
-            CollectionAssert.AreEqual(
-                new byte[] { 255, 254, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0 },
-                fileSystem.GetFile(path).Contents);
+            Assert.That(fileSystem.GetFile(path).Contents,
+                Is.EqualTo(new byte[] { 255, 254, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0 }));
         }
 
         [Test]
@@ -303,9 +297,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 0, 32, 0, 116, 0, 101, 0, 120, 0, 116
             };
 
-            CollectionAssert.AreEqual(
-                expected,
-                file.ReadAllBytes(path));
+            Assert.That(file.ReadAllBytes(path), Is.EqualTo(expected));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileArgumentPathTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileArgumentPathTests.cs
@@ -55,7 +55,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             yield return fs => fs.Encrypt(null);
         }
 
-        [TestCaseSource("GetFileSystemActionsForArgumentNullException")]
+        [TestCaseSource(nameof(GetFileSystemActionsForArgumentNullException))]
         public void Operations_ShouldThrowArgumentNullExceptionIfPathIsNull(Action<IFile> action)
         {
             // Arrange

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileArgumentPathTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileArgumentPathTests.cs
@@ -66,7 +66,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             var exception = Assert.Throws<ArgumentNullException>(wrapped);
-            Assert.AreEqual("path", exception.ParamName);
+            Assert.That(exception.ParamName, Is.EqualTo("path"));
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileCopyTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileCopyTests.cs
@@ -40,7 +40,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var sourceFileInfo = mockFileSystem.FileInfo.New(sourceFileName);
             var destFileInfo = mockFileSystem.FileInfo.New(destFileName);
             Assert.That(destFileInfo.LastWriteTime, Is.EqualTo(sourceFileInfo.LastWriteTime));
-            Assert.LessOrEqual(DateTime.Now - destFileInfo.CreationTime, TimeSpan.FromSeconds(1));
+            Assert.That(DateTime.Now - destFileInfo.CreationTime, Is.LessThanOrEqualTo( TimeSpan.FromSeconds(1)));
             Assert.That(destFileInfo.LastAccessTime, Is.EqualTo(destFileInfo.CreationTime));
         }
 

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileCopyTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileCopyTests.cs
@@ -24,7 +24,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.File.Copy(sourceFileName, destFileName, true);
 
             var copyResult = fileSystem.GetFile(destFileName);
-            Assert.AreEqual(copyResult.Contents, sourceContents.Contents);
+            Assert.That(sourceContents.Contents, Is.EqualTo(copyResult.Contents));
         }
 
         [Test]
@@ -39,9 +39,9 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var sourceFileInfo = mockFileSystem.FileInfo.New(sourceFileName);
             var destFileInfo = mockFileSystem.FileInfo.New(destFileName);
-            Assert.AreEqual(sourceFileInfo.LastWriteTime, destFileInfo.LastWriteTime);
+            Assert.That(destFileInfo.LastWriteTime, Is.EqualTo(sourceFileInfo.LastWriteTime));
             Assert.LessOrEqual(DateTime.Now - destFileInfo.CreationTime, TimeSpan.FromSeconds(1));
-            Assert.AreEqual(destFileInfo.CreationTime, destFileInfo.LastAccessTime);
+            Assert.That(destFileInfo.LastAccessTime, Is.EqualTo(destFileInfo.CreationTime));
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 binaryWriter.Write("Modified");
             }
 
-            Assert.AreEqual("Original", mockFileSystem.File.ReadAllText(destFileName));
+            Assert.That(mockFileSystem.File.ReadAllText(destFileName), Is.EqualTo("Original"));
         }
 
         [Test]
@@ -101,7 +101,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.File.Copy(sourceFileName, destFileName, false);
 
             var copyResult = fileSystem.GetFile(destFileName);
-            Assert.AreEqual(copyResult.Contents, sourceContents.Contents);
+            Assert.That(sourceContents.Contents, Is.EqualTo(copyResult.Contents));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileCopyTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileCopyTests.cs
@@ -84,7 +84,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 binaryWriter.Write("Modified");
             }
 
-            CollectionAssert.AreEqual(original, mockFileSystem.File.ReadAllBytes(destFileName));
+            Assert.That(mockFileSystem.File.ReadAllBytes(destFileName), Is.EqualTo(original));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileCreateTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileCreateTests.cs
@@ -244,7 +244,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             {
             }
 
-            Assert.IsFalse(fileSystem.File.Exists(filePath));
+            Assert.That(fileSystem.File.Exists(filePath), Is.False);
         }
 
         [Test]
@@ -258,7 +258,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             using (var stream = fileSystem.File.Create(filePath, 4096, FileOptions.Encrypted))
             {
                 var fileInfo = fileSystem.FileInfo.New(filePath);
-                Assert.IsFalse(fileInfo.Attributes.HasFlag(FileAttributes.Encrypted));
+                Assert.That(fileInfo.Attributes.HasFlag(FileAttributes.Encrypted), Is.False);
             }
         }
 

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileCreateTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileCreateTests.cs
@@ -228,7 +228,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             using (fileSystem.File.Create(filePath, 4096, FileOptions.DeleteOnClose))
             {
-                Assert.IsTrue(fileSystem.File.Exists(filePath));
+                Assert.That(fileSystem.File.Exists(filePath), Is.True);
             }
         }
 
@@ -275,7 +275,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             }
 
             var fileInfo = fileSystem.FileInfo.New(filePath);
-            Assert.IsTrue(fileInfo.Attributes.HasFlag(FileAttributes.Encrypted));
+            Assert.That(fileInfo.Attributes.HasFlag(FileAttributes.Encrypted), Is.True);
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileDeleteTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileDeleteTests.cs
@@ -19,8 +19,8 @@
             fileSystem.File.Delete(path);
             var fileCount2 = fileSystem.Directory.GetFiles(directory, "*").Length;
 
-            Assert.AreEqual(1, fileCount1, "File should have existed");
-            Assert.AreEqual(0, fileCount2, "File should have been deleted");
+            Assert.That(fileCount1, Is.EqualTo(1), "File should have existed");
+            Assert.That(fileCount2, Is.EqualTo(0), "File should have been deleted");
         }
 
         [TestCase(" ")]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileExistsTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileExistsTests.cs
@@ -55,7 +55,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.File.Exists("/SomeThing/DEMO.txt");
 
             // Assert
-            Assert.IsFalse(result);
+            Assert.That(result, Is.False);
         }
 
         [Test]
@@ -72,7 +72,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.File.Exists(XFS.Path(@"C:\SomeThing\DoesNotExist.gif"));
 
             // Assert
-            Assert.IsFalse(result);
+            Assert.That(result, Is.False);
         }
 
         [Test]
@@ -85,7 +85,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.File.Exists(null);
 
             // Assert
-            Assert.IsFalse(result);
+            Assert.That(result, Is.False);
         }
 
         [Test]
@@ -98,7 +98,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.File.Exists(string.Empty);
 
             // Assert
-            Assert.IsFalse(result);
+            Assert.That(result, Is.False);
         }
 
         [Test]
@@ -111,7 +111,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.File.Exists(@"C:""*/:<>?|abc");
 
             // Assert
-            Assert.IsFalse(result);
+            Assert.That(result, Is.False);
         }
 
         [Test]
@@ -128,7 +128,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.File.Exists(XFS.Path(@"C:\something\"));
 
             // Assert
-            Assert.IsFalse(result);
+            Assert.That(result, Is.False);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileExistsTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileExistsTests.cs
@@ -21,7 +21,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.File.Exists(XFS.Path(@"C:\something\other.gif"));
 
             // Assert
-            Assert.IsTrue(result);
+            Assert.That(result, Is.True);
         }
 
         [Test]
@@ -38,7 +38,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.File.Exists(@"C:\SomeThing\DEMO.txt");
 
             // Assert
-            Assert.IsTrue(result);
+            Assert.That(result, Is.True);
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetCreationTimeTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetCreationTimeTests.cs
@@ -30,7 +30,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualCreationTime = fileSystem.File.GetCreationTime(@"c:\does\not\exist.txt");
 
             // Assert
-            Assert.AreEqual(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc).ToLocalTime(), actualCreationTime);
+            Assert.That(actualCreationTime, Is.EqualTo(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc).ToLocalTime()));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetCreationTimeUtcTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetCreationTimeUtcTests.cs
@@ -30,7 +30,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualCreationTime = fileSystem.File.GetCreationTimeUtc(@"c:\does\not\exist.txt");
 
             // Assert
-            Assert.AreEqual(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc), actualCreationTime);
+            Assert.That(actualCreationTime, Is.EqualTo(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc)));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetLastAccessTimeTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetLastAccessTimeTests.cs
@@ -30,7 +30,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualLastAccessTime = fileSystem.File.GetLastAccessTime(@"c:\does\not\exist.txt");
 
             // Assert
-            Assert.AreEqual(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc).ToLocalTime(), actualLastAccessTime);
+            Assert.That(actualLastAccessTime, Is.EqualTo(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc).ToLocalTime()));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetLastAccessTimeUtcTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetLastAccessTimeUtcTests.cs
@@ -30,7 +30,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualLastAccessTime = fileSystem.File.GetLastAccessTimeUtc(@"c:\does\not\exist.txt");
 
             // Assert
-            Assert.AreEqual(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc), actualLastAccessTime);
+            Assert.That(actualLastAccessTime, Is.EqualTo(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc)));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetLastWriteTimeTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetLastWriteTimeTests.cs
@@ -30,7 +30,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualLastWriteTime = fileSystem.File.GetLastWriteTime(@"c:\does\not\exist.txt");
 
             // Assert
-            Assert.AreEqual(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc).ToLocalTime(), actualLastWriteTime);
+            Assert.That(actualLastWriteTime, Is.EqualTo(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc).ToLocalTime()));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetLastWriteTimeUtcTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetLastWriteTimeUtcTests.cs
@@ -29,7 +29,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualLastWriteTime = fileSystem.File.GetLastWriteTimeUtc(@"c:\does\not\exist.txt");
 
             // Assert
-            Assert.AreEqual(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc), actualLastWriteTime);
+            Assert.That(actualLastWriteTime, Is.EqualTo(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc)));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoFactoryTests.cs
@@ -49,7 +49,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.FileInfo.Wrap(null);
 
-            Assert.IsNull(result);
+            Assert.That(result, Is.Null);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoFactoryTests.cs
@@ -21,7 +21,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileInfoFactory.New(@"c:\a.txt");
 
             // Assert
-            Assert.IsNotNull(result);
+            Assert.That(result, Is.Not.Null);
         }
 
         [Test]
@@ -39,7 +39,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileInfoFactory.New(@"c:\foo.txt");
 
             // Assert
-            Assert.IsNotNull(result);
+            Assert.That(result, Is.Not.Null);
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoSymlinkTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoSymlinkTests.cs
@@ -23,7 +23,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.FileInfo.New("foo").ResolveLinkTarget(false);
 
-            Assert.AreEqual("bar", result.Name);
+            Assert.That(result.Name, Is.EqualTo("bar"));
         }
 
         [Test]
@@ -36,7 +36,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.FileInfo.New("foo1").ResolveLinkTarget(true);
 
-            Assert.AreEqual("bar", result.Name);
+            Assert.That(result.Name, Is.EqualTo("bar"));
         }
 
         [Test]
@@ -49,7 +49,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.FileInfo.New("foo1").ResolveLinkTarget(false);
 
-            Assert.AreEqual("foo", result.Name);
+            Assert.That(result.Name, Is.EqualTo("foo"));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
@@ -47,7 +47,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.Exists;
 
-            Assert.IsFalse(result);
+            Assert.That(result, Is.False);
         }
 
         [Test]
@@ -61,7 +61,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.Exists;
 
-            Assert.IsFalse(result);
+            Assert.That(result, Is.False);
         }
 
         [Test]
@@ -805,7 +805,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddFile(path1, new MockFileData("1"));
 
             // Assert
-            Assert.IsFalse(fileInfo.Exists);
+            Assert.That(fileInfo.Exists, Is.False);
         }
 
         [Test]
@@ -864,7 +864,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileInfo.Delete();
 
             // Assert
-            Assert.IsFalse(fileInfo.Exists);
+            Assert.That(fileInfo.Exists, Is.False);
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
@@ -32,7 +32,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.Exists;
 
-            Assert.IsTrue(result);
+            Assert.That(result, Is.True);
         }
 
         [Test]
@@ -574,7 +574,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileInfo.MoveTo(destination);
 
             Assert.That(fileInfo.FullName, Is.EqualTo(destination));
-            Assert.True(fileInfo.Exists);
+            Assert.That(fileInfo.Exists, Is.True);
         }
 
         [Test]
@@ -636,7 +636,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileInfo.MoveTo(destFilePath);
 
             Assert.That(fileInfo.FullName, Is.EqualTo(destFilePath));
-            Assert.True(fileInfo.Exists);
+            Assert.That(fileInfo.Exists, Is.True);
         }
 
         [Test]
@@ -821,7 +821,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileInfo.Refresh();
 
             // Assert
-            Assert.IsTrue(fileInfo.Exists);
+            Assert.That(fileInfo.Exists, Is.True);
         }
 
         [Test]
@@ -836,7 +836,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             var result = fileInfo.Exists;
-            Assert.IsTrue(result);
+            Assert.That(result, Is.True);
         }
 
         [Test]
@@ -850,7 +850,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileInfo.CreateText().Dispose();
 
             // Assert
-            Assert.IsTrue(fileInfo.Exists);
+            Assert.That(fileInfo.Exists, Is.True);
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
@@ -246,7 +246,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileInfo.IsReadOnly = false;
 
-            Assert.AreNotEqual(FileAttributes.ReadOnly, fileData.Attributes & FileAttributes.ReadOnly);
+            Assert.That(fileData.Attributes & FileAttributes.ReadOnly, Is.Not.EqualTo(FileAttributes.ReadOnly));
         }
 
         [Test]
@@ -345,7 +345,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileInfo.Decrypt();
 
-            Assert.AreNotEqual(FileAttributes.Encrypted, fileData.Attributes & FileAttributes.Encrypted);
+            Assert.That(fileData.Attributes & FileAttributes.Encrypted, Is.Not.EqualTo(FileAttributes.Encrypted));
         }
 
         [Test]
@@ -893,7 +893,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             };
 
             Assert.That(fileInfo.LastAccessTimeUtc, Is.EqualTo(date));
-            Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.LastAccessTimeUtc.Kind);
+            Assert.That(fileInfo.LastAccessTimeUtc.Kind, Is.Not.EqualTo(DateTimeKind.Unspecified));
         }
 
         [Test]
@@ -909,7 +909,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             };
 
             Assert.That(fileInfo.LastAccessTime, Is.EqualTo(date));
-            Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.LastAccessTime.Kind);
+            Assert.That(fileInfo.LastAccessTime.Kind, Is.Not.EqualTo(DateTimeKind.Unspecified));
         }
 
         [Test]
@@ -925,7 +925,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             };
 
             Assert.That(fileInfo.CreationTimeUtc, Is.EqualTo(date));
-            Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.CreationTimeUtc.Kind);
+            Assert.That(fileInfo.CreationTimeUtc.Kind, Is.Not.EqualTo(DateTimeKind.Unspecified));
         }
 
         [Test]
@@ -941,7 +941,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             };
 
             Assert.That(fileInfo.CreationTime, Is.EqualTo(date));
-            Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.CreationTime.Kind);
+            Assert.That(fileInfo.CreationTime.Kind, Is.Not.EqualTo(DateTimeKind.Unspecified));
         }
 
         [Test]
@@ -957,7 +957,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             };
 
             Assert.That(fileInfo.LastWriteTimeUtc, Is.EqualTo(date));
-            Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.LastWriteTimeUtc.Kind);
+            Assert.That(fileInfo.LastWriteTimeUtc.Kind, Is.Not.EqualTo(DateTimeKind.Unspecified));
         }
 
         [Test]
@@ -973,7 +973,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             };
 
             Assert.That(fileInfo.LastWriteTime, Is.EqualTo(date));
-            Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.LastWriteTime.Kind);
+            Assert.That(fileInfo.LastWriteTime.Kind, Is.Not.EqualTo(DateTimeKind.Unspecified));
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
@@ -893,7 +893,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             };
 
             Assert.AreEqual(date, fileInfo.LastAccessTimeUtc);
-            Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.LastAccessTimeUtc);
+            Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.LastAccessTimeUtc.Kind);
         }
 
         [Test]
@@ -909,7 +909,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             };
 
             Assert.AreEqual(date, fileInfo.LastAccessTime);
-            Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.LastAccessTime);
+            Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.LastAccessTime.Kind);
         }
 
         [Test]
@@ -925,7 +925,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             };
 
             Assert.AreEqual(date, fileInfo.CreationTimeUtc);
-            Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.CreationTimeUtc);
+            Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.CreationTimeUtc.Kind);
         }
 
         [Test]
@@ -941,7 +941,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             };
 
             Assert.AreEqual(date, fileInfo.CreationTime);
-            Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.CreationTime);
+            Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.CreationTime.Kind);
         }
 
         [Test]
@@ -957,7 +957,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             };
 
             Assert.AreEqual(date, fileInfo.LastWriteTimeUtc);
-            Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.LastWriteTimeUtc);
+            Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.LastWriteTimeUtc.Kind);
         }
 
         [Test]
@@ -973,7 +973,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             };
 
             Assert.AreEqual(date, fileInfo.LastWriteTime);
-            Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.LastWriteTime);
+            Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.LastWriteTime.Kind);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
@@ -77,7 +77,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.Length;
 
-            Assert.AreEqual(fileContent.Length, result);
+            Assert.That(result, Is.EqualTo(fileContent.Length));
         }
 
         [Test]
@@ -93,7 +93,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var ex = Assert.Throws<FileNotFoundException>(() => fileInfo.Length.ToString(CultureInfo.InvariantCulture));
 
-            Assert.AreEqual(XFS.Path(@"c:\foo.txt"), ex.FileName);
+            Assert.That(ex.FileName, Is.EqualTo(XFS.Path(@"c:\foo.txt")));
         }
 
         [Test]
@@ -108,7 +108,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var ex = Assert.Throws<FileNotFoundException>(() => fileInfo.Length.ToString(CultureInfo.InvariantCulture));
 
-            Assert.AreEqual(XFS.Path(@"c:\a\b"), ex.FileName);
+            Assert.That(ex.FileName, Is.EqualTo(XFS.Path(@"c:\a\b")));
         }
 
         [Test]
@@ -124,7 +124,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.CreationTimeUtc;
 
-            Assert.AreEqual(creationTime.ToUniversalTime(), result);
+            Assert.That(result, Is.EqualTo(creationTime.ToUniversalTime()));
         }
 
         [Test]
@@ -135,7 +135,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.CreationTimeUtc;
 
-            Assert.AreEqual(MockFileData.DefaultDateTimeOffset.UtcDateTime, result);
+            Assert.That(result, Is.EqualTo(MockFileData.DefaultDateTimeOffset.UtcDateTime));
         }
 
         [Test]
@@ -152,7 +152,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var newUtcTime = DateTime.UtcNow;
             fileInfo.CreationTimeUtc = newUtcTime;
 
-            Assert.AreEqual(newUtcTime, fileInfo.CreationTimeUtc);
+            Assert.That(fileInfo.CreationTimeUtc, Is.EqualTo(newUtcTime));
         }
 
 
@@ -169,7 +169,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.CreationTime;
 
-            Assert.AreEqual(creationTime, result);
+            Assert.That(result, Is.EqualTo(creationTime));
         }
 
         [Test]
@@ -180,7 +180,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.CreationTime;
 
-            Assert.AreEqual(MockFileData.DefaultDateTimeOffset.LocalDateTime, result);
+            Assert.That(result, Is.EqualTo(MockFileData.DefaultDateTimeOffset.LocalDateTime));
         }
 
         [Test]
@@ -197,7 +197,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileInfo.CreationTime = newTime;
 
-            Assert.AreEqual(newTime, fileInfo.CreationTime);
+            Assert.That(fileInfo.CreationTime, Is.EqualTo(newTime));
         }
 
         [Test]
@@ -231,7 +231,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileInfo.IsReadOnly = true;
 
-            Assert.AreEqual(FileAttributes.ReadOnly, fileData.Attributes & FileAttributes.ReadOnly);
+            Assert.That(fileData.Attributes & FileAttributes.ReadOnly, Is.EqualTo(FileAttributes.ReadOnly));
         }
 
         [Test]
@@ -268,7 +268,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 newcontents = newfile.ReadToEnd();
             }
 
-            Assert.AreEqual($"Demo text contentThis should be at the end{Environment.NewLine}", newcontents);
+            Assert.That(newcontents, Is.EqualTo($"Demo text contentThis should be at the end{Environment.NewLine}"));
         }
 
         [Test]
@@ -288,7 +288,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             }
 
             Assert.That(fileSystem.File.Exists(targetFile), Is.True);
-            Assert.AreEqual($"This should be the contents{Environment.NewLine}", newcontents);
+            Assert.That(newcontents, Is.EqualTo($"This should be the contents{Environment.NewLine}"));
         }
 
         [Test]
@@ -314,7 +314,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 newcontents = newfile.ReadToEnd();
             }
 
-            Assert.AreEqual("ABCDEtext content", newcontents);
+            Assert.That(newcontents, Is.EqualTo("ABCDEtext content"));
         }
 
         [Test]
@@ -329,7 +329,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileInfo.Encrypt();
 
-            Assert.AreEqual(FileAttributes.Encrypted, fileData.Attributes & FileAttributes.Encrypted);
+            Assert.That(fileData.Attributes & FileAttributes.Encrypted, Is.EqualTo(FileAttributes.Encrypted));
         }
 
         [Test]
@@ -361,7 +361,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.LastAccessTimeUtc;
 
-            Assert.AreEqual(lastAccessTime.ToUniversalTime(), result);
+            Assert.That(result, Is.EqualTo(lastAccessTime.ToUniversalTime()));
         }
 
         [Test]
@@ -372,7 +372,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.LastAccessTimeUtc;
 
-            Assert.AreEqual(MockFileData.DefaultDateTimeOffset.UtcDateTime, result);
+            Assert.That(result, Is.EqualTo(MockFileData.DefaultDateTimeOffset.UtcDateTime));
         }
 
         [Test]
@@ -389,7 +389,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var newUtcTime = DateTime.UtcNow;
             fileInfo.LastAccessTimeUtc = newUtcTime;
 
-            Assert.AreEqual(newUtcTime, fileInfo.LastAccessTimeUtc);
+            Assert.That(fileInfo.LastAccessTimeUtc, Is.EqualTo(newUtcTime));
         }
 
         [Test]
@@ -400,7 +400,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.LastWriteTime;
 
-            Assert.AreEqual(MockFileData.DefaultDateTimeOffset.LocalDateTime, result);
+            Assert.That(result, Is.EqualTo(MockFileData.DefaultDateTimeOffset.LocalDateTime));
         }
 
         [Test]
@@ -416,7 +416,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.LastWriteTimeUtc;
 
-            Assert.AreEqual(lastWriteTime.ToUniversalTime(), result);
+            Assert.That(result, Is.EqualTo(lastWriteTime.ToUniversalTime()));
         }
 
         [Test]
@@ -427,7 +427,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.LastWriteTimeUtc;
 
-            Assert.AreEqual(MockFileData.DefaultDateTimeOffset.UtcDateTime, result);
+            Assert.That(result, Is.EqualTo(MockFileData.DefaultDateTimeOffset.UtcDateTime));
         }
 
         [Test]
@@ -444,7 +444,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var newUtcTime = DateTime.UtcNow;
             fileInfo.LastWriteTimeUtc = newUtcTime;
 
-            Assert.AreEqual(newUtcTime, fileInfo.LastWriteTimeUtc);
+            Assert.That(fileInfo.LastWriteTimeUtc, Is.EqualTo(newUtcTime));
         }
 
         [Test]
@@ -455,7 +455,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.Extension;
 
-            Assert.AreEqual(".txt", result);
+            Assert.That(result, Is.EqualTo(".txt"));
         }
 
         [Test]
@@ -466,7 +466,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.Extension;
 
-            Assert.AreEqual(string.Empty, result);
+            Assert.That(result, Is.Empty);
         }
 
         [Test]
@@ -476,7 +476,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.DirectoryName;
 
-            Assert.AreEqual(XFS.Path(@"c:\temp\level1\level2"), result);
+            Assert.That(result, Is.EqualTo(XFS.Path(@"c:\temp\level1\level2")));
         }
 
         [Test]
@@ -486,7 +486,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.Directory;
 
-            Assert.AreEqual(XFS.Path(@"c:\temp\level1\level2"), result.FullName);
+            Assert.That(result.FullName, Is.EqualTo(XFS.Path(@"c:\temp\level1\level2")));
         }
 
         [Test]
@@ -502,7 +502,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 stream.Read(result, 0, 2);
             }
 
-            Assert.AreEqual(new byte[] { 1, 2 }, result);
+            Assert.That(result, Is.EqualTo(new byte[] { 1, 2 }));
         }
 
         [Test]
@@ -518,7 +518,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 result = streamReader.ReadToEnd();
             }
 
-            Assert.AreEqual(@"line 1\r\nline 2", result);
+            Assert.That(result, Is.EqualTo(@"line 1\r\nline 2"));
         }
 
         [Test]
@@ -534,8 +534,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileInfo.MoveTo(destinationPath);
 
-            Assert.AreEqual(fileInfo.DirectoryName, destinationFolder);
-            Assert.AreEqual(fileInfo.FullName, destinationPath);
+            Assert.That(fileInfo.DirectoryName, Is.EqualTo(destinationFolder));
+            Assert.That(fileInfo.FullName, Is.EqualTo(destinationPath));
         }
 
         [Test]
@@ -573,7 +573,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileInfo.MoveTo(destination);
 
-            Assert.AreEqual(fileInfo.FullName, destination);
+            Assert.That(fileInfo.FullName, Is.EqualTo(destination));
             Assert.True(fileInfo.Exists);
         }
 
@@ -635,7 +635,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileInfo = fileSystem.FileInfo.New(sourceFilePath);
             fileInfo.MoveTo(destFilePath);
 
-            Assert.AreEqual(fileInfo.FullName, destFilePath);
+            Assert.That(fileInfo.FullName, Is.EqualTo(destFilePath));
             Assert.True(fileInfo.Exists);
         }
 
@@ -664,7 +664,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var mockFileInfo = new MockFileInfo(new MockFileSystem(), filePath);
 
             //Assert
-            Assert.AreEqual(filePath, mockFileInfo.ToString());
+            Assert.That(mockFileInfo.ToString(), Is.EqualTo(filePath));
         }
 
 
@@ -682,7 +682,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockFileInfo.FullName;
 
             // Assert
-            Assert.AreEqual(expected, result);
+            Assert.That(result, Is.EqualTo(expected));
         }
 
         public static IEnumerable<string[]> New_Paths_NormalizePaths_Cases
@@ -711,7 +711,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Act
             fileInfo1.Replace(path2, null);
 
-            Assert.AreEqual("1", fileInfo2.OpenText().ReadToEnd());
+            Assert.That(fileInfo2.OpenText().ReadToEnd(), Is.EqualTo("1"));
         }
 
         [Test]
@@ -730,7 +730,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Act
             fileInfo1.Replace(path2, path3);
 
-            Assert.AreEqual("2", fileInfo3.OpenText().ReadToEnd());
+            Assert.That(fileInfo3.OpenText().ReadToEnd(), Is.EqualTo("2"));
         }
 
         [Test]
@@ -764,7 +764,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Act
             var result = fileInfo1.Replace(path2, null);
 
-            Assert.AreEqual(fileInfo2.FullName, result.FullName);
+            Assert.That(result.FullName, Is.EqualTo(fileInfo2.FullName));
         }
 
         [Test]
@@ -892,7 +892,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 LastAccessTimeUtc = date
             };
 
-            Assert.AreEqual(date, fileInfo.LastAccessTimeUtc);
+            Assert.That(fileInfo.LastAccessTimeUtc, Is.EqualTo(date));
             Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.LastAccessTimeUtc.Kind);
         }
 
@@ -908,7 +908,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 LastAccessTime = date
             };
 
-            Assert.AreEqual(date, fileInfo.LastAccessTime);
+            Assert.That(fileInfo.LastAccessTime, Is.EqualTo(date));
             Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.LastAccessTime.Kind);
         }
 
@@ -924,7 +924,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 CreationTimeUtc = date
             };
 
-            Assert.AreEqual(date, fileInfo.CreationTimeUtc);
+            Assert.That(fileInfo.CreationTimeUtc, Is.EqualTo(date));
             Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.CreationTimeUtc.Kind);
         }
 
@@ -940,7 +940,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 CreationTime = date
             };
 
-            Assert.AreEqual(date, fileInfo.CreationTime);
+            Assert.That(fileInfo.CreationTime, Is.EqualTo(date));
             Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.CreationTime.Kind);
         }
 
@@ -956,7 +956,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 LastWriteTimeUtc = date
             };
 
-            Assert.AreEqual(date, fileInfo.LastWriteTimeUtc);
+            Assert.That(fileInfo.LastWriteTimeUtc, Is.EqualTo(date));
             Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.LastWriteTimeUtc.Kind);
         }
 
@@ -972,7 +972,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 LastWriteTime = date
             };
 
-            Assert.AreEqual(date, fileInfo.LastWriteTime);
+            Assert.That(fileInfo.LastWriteTime, Is.EqualTo(date));
             Assert.AreNotEqual(DateTimeKind.Unspecified, fileInfo.LastWriteTime.Kind);
         }
     }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileOpenTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileOpenTests.cs
@@ -228,7 +228,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             }
 
             // Assert
-            Assert.LessOrEqual(DateTime.Now - fs.FileInfo.New(filepath).LastAccessTime, TimeSpan.FromSeconds(1));
+            Assert.That(DateTime.Now - fs.FileInfo.New(filepath).LastAccessTime, Is.LessThanOrEqualTo(TimeSpan.FromSeconds(1)));
         }
 
         [Test]
@@ -251,7 +251,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fi.Refresh();
             // Assert
             Assert.That(fi.CreationTime, Is.EqualTo(creationTime));
-            Assert.LessOrEqual(DateTime.Now - fi.LastAccessTime, TimeSpan.FromSeconds(1));
+            Assert.That(DateTime.Now - fi.LastAccessTime, Is.LessThanOrEqualTo(TimeSpan.FromSeconds(1)));
         }
 
         [Test]
@@ -274,7 +274,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fi.Refresh();
             // Assert
             Assert.That(fi.CreationTime, Is.EqualTo(creationTime));
-            Assert.LessOrEqual(DateTime.Now - fi.LastAccessTime, TimeSpan.FromSeconds(1));
+            Assert.That(DateTime.Now - fi.LastAccessTime, Is.LessThanOrEqualTo(TimeSpan.FromSeconds(1)));
         }
 
         [Test]
@@ -297,8 +297,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fi.Refresh();
             // Assert
             Assert.That(fi.CreationTime, Is.EqualTo(creationTime));
-            Assert.LessOrEqual(DateTime.Now - fi.LastAccessTime, TimeSpan.FromSeconds(1));
-            Assert.LessOrEqual(DateTime.Now - fi.LastWriteTime, TimeSpan.FromSeconds(1));
+            Assert.That(DateTime.Now - fi.LastAccessTime, Is.LessThanOrEqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(DateTime.Now - fi.LastWriteTime, Is.LessThanOrEqualTo(TimeSpan.FromSeconds(1)));
         }
 
         [Test]
@@ -321,8 +321,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fi.Refresh();
             // Assert
             Assert.That(fi.CreationTime, Is.EqualTo(creationTime));
-            Assert.LessOrEqual(DateTime.Now - fi.LastAccessTime, TimeSpan.FromSeconds(1));
-            Assert.LessOrEqual(DateTime.Now - fi.LastWriteTime, TimeSpan.FromSeconds(1));
+            Assert.That(DateTime.Now - fi.LastAccessTime, Is.LessThanOrEqualTo(TimeSpan.FromSeconds(1)));
+            Assert.That(DateTime.Now - fi.LastWriteTime, Is.LessThanOrEqualTo(TimeSpan.FromSeconds(1)));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileOpenTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileOpenTests.cs
@@ -207,7 +207,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             }
 
             // Assert
-            Assert.AreEqual(lastWriteTime, fs.FileInfo.New(filepath).LastWriteTime);
+            Assert.That(fs.FileInfo.New(filepath).LastWriteTime, Is.EqualTo(lastWriteTime));
         }
 
         [Test]
@@ -250,7 +250,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             stream.Read(buffer, 0, buffer.Length);
             fi.Refresh();
             // Assert
-            Assert.AreEqual(creationTime, fi.CreationTime);
+            Assert.That(fi.CreationTime, Is.EqualTo(creationTime));
             Assert.LessOrEqual(DateTime.Now - fi.LastAccessTime, TimeSpan.FromSeconds(1));
         }
 
@@ -273,7 +273,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             await stream.ReadAsync(buffer, 0, buffer.Length);
             fi.Refresh();
             // Assert
-            Assert.AreEqual(creationTime, fi.CreationTime);
+            Assert.That(fi.CreationTime, Is.EqualTo(creationTime));
             Assert.LessOrEqual(DateTime.Now - fi.LastAccessTime, TimeSpan.FromSeconds(1));
         }
 
@@ -296,7 +296,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             stream.Write(buffer, 0, buffer.Length);
             fi.Refresh();
             // Assert
-            Assert.AreEqual(creationTime, fi.CreationTime);
+            Assert.That(fi.CreationTime, Is.EqualTo(creationTime));
             Assert.LessOrEqual(DateTime.Now - fi.LastAccessTime, TimeSpan.FromSeconds(1));
             Assert.LessOrEqual(DateTime.Now - fi.LastWriteTime, TimeSpan.FromSeconds(1));
         }
@@ -320,7 +320,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             await stream.WriteAsync(buffer, 0, buffer.Length);
             fi.Refresh();
             // Assert
-            Assert.AreEqual(creationTime, fi.CreationTime);
+            Assert.That(fi.CreationTime, Is.EqualTo(creationTime));
             Assert.LessOrEqual(DateTime.Now - fi.LastAccessTime, TimeSpan.FromSeconds(1));
             Assert.LessOrEqual(DateTime.Now - fi.LastWriteTime, TimeSpan.FromSeconds(1));
         }
@@ -343,7 +343,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             }
 
             // Assert
-            Assert.AreEqual(creationTime, fs.FileInfo.New(filepath).CreationTime);
+            Assert.That(fs.FileInfo.New(filepath).CreationTime, Is.EqualTo(creationTime));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileOpenTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileOpenTests.cs
@@ -133,7 +133,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             using (var br = new BinaryReader(stream))
                 data = br.ReadBytes((int)stream.Length);
 
-            CollectionAssert.AreEqual(file.Contents, data);
+            Assert.That(data, Is.EqualTo(file.Contents));
         }
 
         [Test]
@@ -155,7 +155,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             using (var br = new BinaryReader(stream))
                 data = br.ReadBytes((int)stream.Length);
 
-            CollectionAssert.AreEqual(file.Contents, data);
+            Assert.That(data, Is.EqualTo(file.Contents));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileOpenTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileOpenTests.cs
@@ -63,8 +63,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var stream = filesystem.File.Open(filepath, FileMode.Create);
 
-            Assert.True(stream.CanRead);
-            Assert.True(stream.CanWrite);
+            Assert.That(stream.CanRead, Is.True);
+            Assert.That(stream.CanWrite, Is.True);
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileReadAllBytesTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileReadAllBytesTests.cs
@@ -81,7 +81,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 firstRead[i] += 1;
             }
 
-            Assert.AreNotEqual(firstRead, secondRead);
+            Assert.That(firstRead, Is.Not.EqualTo(secondRead));
         }
 
 #if FEATURE_ASYNC_FILE

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileReadAllBytesTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileReadAllBytesTests.cs
@@ -36,7 +36,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileSystem.File.WriteAllBytes(path, fileContent);
 
-            Assert.AreEqual(fileContent, fileSystem.File.ReadAllBytes(path));
+            Assert.That(fileSystem.File.ReadAllBytes(path), Is.EqualTo(fileContent));
         }
 
         [Test]
@@ -60,7 +60,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileSystem.AddFile(path, new MockFileData(data));
 
-            Assert.AreEqual(data, fileSystem.File.ReadAllBytes(altPath));
+            Assert.That(fileSystem.File.ReadAllBytes(altPath), Is.EqualTo(data));
         }
 
         [Test]
@@ -113,7 +113,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileSystem.File.WriteAllBytes(path, fileContent);
 
-            Assert.AreEqual(fileContent, await fileSystem.File.ReadAllBytesAsync(path));
+            Assert.That(await fileSystem.File.ReadAllBytesAsync(path), Is.EqualTo(fileContent));
         }
 
         [Test]
@@ -148,7 +148,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileSystem.AddFile(path, new MockFileData(data));
 
-            Assert.AreEqual(data, await fileSystem.File.ReadAllBytesAsync(altPath));
+            Assert.That(await fileSystem.File.ReadAllBytesAsync(altPath), Is.EqualTo(data));
         }
 #endif
     }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileReadAllBytesTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileReadAllBytesTests.cs
@@ -21,9 +21,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = file.ReadAllBytes(XFS.Path(@"c:\something\other.gif"));
 
-            CollectionAssert.AreEqual(
-                new byte[] { 0x21, 0x58, 0x3f, 0xa9 },
-                result);
+            Assert.That(result,
+                Is.EqualTo(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }));
         }
 
         [Test]
@@ -98,9 +97,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = await file.ReadAllBytesAsync(XFS.Path(@"c:\something\other.gif"));
 
-            CollectionAssert.AreEqual(
-                new byte[] { 0x21, 0x58, 0x3f, 0xa9 },
-                result);
+            Assert.That(result,
+                Is.EqualTo(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileReadAllLinesTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileReadAllLinesTests.cs
@@ -29,9 +29,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.ReadAllLines(XFS.Path(@"c:\something\demo.txt"));
 
             // Assert
-            CollectionAssert.AreEqual(
-                new[] { "Demo", "text", "content", "value" },
-                result);
+            Assert.That(result,
+                Is.EqualTo(new[] { "Demo", "text", "content", "value" }));
         }
 
         [Test]
@@ -51,9 +50,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.ReadAllLines(XFS.Path(@"c:\something\demo.txt"), Encoding.BigEndianUnicode);
 
             // Assert
-            CollectionAssert.AreEqual(
-                new[] { "Hello", "there", "Bob", "Bob!" },
-                result);
+            Assert.That(result,
+                Is.EqualTo(new[] { "Hello", "there", "Bob", "Bob!" }));
         }
 
         [Test]
@@ -104,9 +102,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = await file.ReadAllLinesAsync(XFS.Path(@"c:\something\demo.txt"));
 
             // Assert
-            CollectionAssert.AreEqual(
-                new[] { "Demo", "text", "content", "value" },
-                result);
+            Assert.That(result, Is.EqualTo(new[] { "Demo", "text", "content", "value" }));
         }
 
         [Test]
@@ -126,9 +122,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = await file.ReadAllLinesAsync(XFS.Path(@"c:\something\demo.txt"), Encoding.BigEndianUnicode);
 
             // Assert
-            CollectionAssert.AreEqual(
-                new[] { "Hello", "there", "Bob", "Bob!" },
-                result);
+            Assert.That(result, Is.EqualTo(new[] { "Hello", "there", "Bob", "Bob!" }));
         }
 
         [Test]
@@ -177,9 +171,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 result.Add(line);
 
             // Assert
-            CollectionAssert.AreEqual(
-                new[] { "Demo", "text", "content", "value" },
-                result);
+            Assert.That(result, Is.EqualTo(new[] { "Demo", "text", "content", "value" }));
         }
 
         [Test]
@@ -202,9 +194,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 result.Add(line);
 
             // Assert
-            CollectionAssert.AreEqual(
-                new[] { "Hello", "there", "Bob", "Bob!" },
-                result);
+            Assert.That(result, Is.EqualTo(new[] { "Hello", "there", "Bob", "Bob!" }));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileReadLinesTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileReadLinesTests.cs
@@ -26,9 +26,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.ReadLines(XFS.Path(@"c:\something\demo.txt"));
 
             // Assert
-            CollectionAssert.AreEqual(
-                new[] { "Demo", "text", "content", "value" },
-                result);
+            Assert.That(result, Is.EqualTo(new[] { "Demo", "text", "content", "value" }));
         }
 
         [Test]
@@ -48,9 +46,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.ReadLines(XFS.Path(@"c:\something\demo.txt"), Encoding.BigEndianUnicode);
 
             // Assert
-            CollectionAssert.AreEqual(
-                new[] { "Hello", "there", "Bob", "Bob!" },
-                result);
+            Assert.That(result, Is.EqualTo(new[] { "Hello", "there", "Bob", "Bob!" }));
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamFactoryTests.cs
@@ -159,7 +159,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileStreamFactory.Create("some_random_file.txt", fileMode);
 
             // Assert
-            Assert.True(fileSystem.File.Exists(XFS.Path("./some_random_file.txt")));
+            Assert.That(fileSystem.File.Exists(XFS.Path("./some_random_file.txt")), Is.True);
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamFactoryTests.cs
@@ -172,7 +172,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileStream = fileSystem.FileStream.New("file.txt", FileMode.CreateNew, FileAccess.Write);
 
             // Assert
-            Assert.IsFalse(fileStream.CanRead);
+            Assert.That(fileStream.CanRead, Is.False);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamFactoryTests.cs
@@ -65,7 +65,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             }
 
             var text = fileSystem.File.ReadAllText(FilePath);
-            Assert.AreEqual("AAAAA", text);
+            Assert.That(text, Is.EqualTo("AAAAA"));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamFactoryTests.cs
@@ -26,7 +26,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileStreamFactory.Create(@"c:\existing.txt", fileMode, FileAccess.Write);
 
             // Assert
-            Assert.IsNotNull(result);
+            Assert.That(result, Is.Not.Null);
         }
 
         [Test]
@@ -42,7 +42,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileStreamFactory.Create(XFS.Path(@"c:\not_existing.txt"), fileMode, FileAccess.Write);
 
             // Assert
-            Assert.IsNotNull(result);
+            Assert.That(result, Is.Not.Null);
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
@@ -235,7 +235,7 @@
             var result1 = MockFileStream.Null;
             var result2 = MockFileStream.Null;
 
-            Assert.AreSame(result1, result2);
+            Assert.That(result1, Is.SameAs(result2));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
@@ -100,7 +100,7 @@
             // Act
             var stream = new MockFileStream(fileSystem, filePath, FileMode.Open, FileAccess.Read);
 
-            Assert.IsFalse(stream.CanWrite);
+            Assert.That(stream.CanWrite, Is.False);
             Assert.Throws<NotSupportedException>(() => stream.WriteByte(1));
         }
 

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
@@ -25,7 +25,8 @@
             cut.Flush();
 
             // Assert
-            CollectionAssert.AreEqual(new byte[] { 255 }, fileSystem.GetFile(filepath).Contents);
+            Assert.That(fileSystem.GetFile(filepath).Contents,
+                Is.EqualTo(new byte[] { 255 }));
         }
 
         [Test]
@@ -46,7 +47,8 @@
             await cut.FlushAsync();
 
             // Assert
-            CollectionAssert.AreEqual(new byte[] { 255 }, fileSystem.GetFile(filepath).Contents);
+            Assert.That(fileSystem.GetFile(filepath).Contents,
+                Is.EqualTo(new byte[] { 255 }));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
@@ -241,9 +241,9 @@
         {
             var result = MockFileStream.Null;
 
-            Assert.AreEqual(result.Name, ".");
-            Assert.AreEqual(result.Length, 0);
-            Assert.AreEqual(result.IsAsync, true);
+            Assert.That(result.Name, Is.EqualTo("."));
+            Assert.That(result.Length, Is.Zero);
+            Assert.That(result.IsAsync, Is.True);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
@@ -66,9 +66,9 @@
             stream.Dispose();
             var fileCount3 = fileSystem.Directory.GetFiles(directory, "*").Length;
 
-            Assert.AreEqual(1, fileCount1, "File should have existed");
-            Assert.AreEqual(0, fileCount2, "File should have been deleted");
-            Assert.AreEqual(0, fileCount3, "Disposing stream should not have resurrected the file");
+            Assert.That(fileCount1, Is.EqualTo(1), "File should have existed");
+            Assert.That(fileCount2, Is.EqualTo(0), "File should have been deleted");
+            Assert.That(fileCount3, Is.EqualTo(0), "Disposing stream should not have resurrected the file");
         }
 
         [Test]
@@ -203,7 +203,7 @@
                 stream.Flush();
 
                 // Assert
-                Assert.AreEqual(200, stream.Position);
+                Assert.That(stream.Position, Is.EqualTo(200));
             }
         }
 
@@ -223,7 +223,7 @@
                 stream.Flush(flushToDisk);
 
                 // Assert
-                Assert.AreEqual(200, stream.Position);
+                Assert.That(stream.Position, Is.EqualTo(200));
             }
         }
 

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSymlinkTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSymlinkTests.cs
@@ -24,8 +24,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             IFileSystemInfo fileSystemInfo = fileSystem.File.CreateSymbolicLink(path, pathToTarget);
 
             // Assert
-            Assert.AreEqual(path, fileSystemInfo.FullName);
-            Assert.AreEqual(pathToTarget, fileSystemInfo.LinkTarget);
+            Assert.That(fileSystemInfo.FullName, Is.EqualTo(path));
+            Assert.That(fileSystemInfo.LinkTarget, Is.EqualTo(pathToTarget));
         }
 
         [Test]
@@ -43,8 +43,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             IFileInfo directoryInfo = fileSystem.FileInfo.New(path);
 
             // Assert
-            Assert.AreEqual(path, directoryInfo.FullName);
-            Assert.AreEqual(pathToTarget, directoryInfo.LinkTarget);
+            Assert.That(directoryInfo.FullName, Is.EqualTo(path));
+            Assert.That(directoryInfo.LinkTarget, Is.EqualTo(pathToTarget));
         }
 
         [Test]
@@ -251,7 +251,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.File.ResolveLinkTarget("foo", false);
 
-            Assert.AreEqual("bar", result.Name);
+            Assert.That(result.Name, Is.EqualTo("bar"));
         }
 
         [Test]
@@ -272,7 +272,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.File.ResolveLinkTarget(previousPath, true);
 
-            Assert.AreEqual("bar", result.Name);
+            Assert.That(result.Name, Is.EqualTo("bar"));
         }
 
         [Test]
@@ -305,7 +305,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.File.ResolveLinkTarget("foo1", false);
 
-            Assert.AreEqual("foo", result.Name);
+            Assert.That(result.Name, Is.EqualTo("foo"));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSymlinkTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSymlinkTests.cs
@@ -239,7 +239,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.File.CreateSymbolicLink(path, pathToTarget);
 
             var attributes = fileSystem.FileInfo.New(path).Attributes;
-            Assert.IsTrue(attributes.HasFlag(FileAttributes.ReparsePoint));
+            Assert.That(attributes.HasFlag(FileAttributes.ReparsePoint), Is.True);
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemOptionTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemOptionTests.cs
@@ -18,7 +18,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.Directory.Exists(fileSystem.Path.GetTempPath());
 
-            Assert.AreEqual(createTempDir, result);
+            Assert.That(result, Is.EqualTo(createTempDir));
         }
 
         [Test]
@@ -34,7 +34,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.Directory.GetCurrentDirectory();
 
-            Assert.AreEqual(currentDirectory, result);
+            Assert.That(result, Is.EqualTo(currentDirectory));
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemSerializationTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemSerializationTests.cs
@@ -33,12 +33,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             memoryStream.Dispose();
 
             // Assert
-            Assert.AreEqual(
-                expected,
-                fileSystem.GetFile(path).Contents);
-            Assert.AreEqual(
-                content,
-                fileSystem.File.ReadAllBytes(path));
+            Assert.That(fileSystem.GetFile(path).Contents, Is.EqualTo(expected));
+            Assert.That(fileSystem.File.ReadAllBytes(path), Is.EqualTo(content));
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -215,7 +215,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var actualResults = fileSystem.DriveInfo.GetDrives();
 
-            Assert.IsNotNull(actualResults);
+            Assert.That(actualResults, Is.Not.Null);
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -38,7 +38,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.GetFile(@"c:\something\demo.txt");
 
-            Assert.AreEqual(file1, result);
+            Assert.That(result, Is.EqualTo(file1));
         }
 
         [Test]
@@ -54,7 +54,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.GetFile(@"c:\SomeThing\DEMO.txt");
 
-            Assert.AreEqual(file1, result);
+            Assert.That(result, Is.EqualTo(file1));
         }
 
         [Test]
@@ -84,7 +84,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileCount = fs.Directory.GetFiles(alternateParentPath).Length;
             var fileExists = fs.File.Exists(alternatePath);
 
-            Assert.AreEqual(1, fileCount);
+            Assert.That(fileCount, Is.EqualTo(1));
             Assert.IsTrue(fileExists);
         }
 
@@ -282,7 +282,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddFileFromEmbeddedResource(XFS.Path(@"C:\TestFile.txt"), Assembly.GetExecutingAssembly(), "System.IO.Abstractions.TestingHelpers.Tests.TestFiles.TestFile.txt");
             var result = fileSystem.GetFile(XFS.Path(@"C:\TestFile.txt"));
 
-            Assert.AreEqual(new UTF8Encoding().GetBytes("This is a test file."), result.Contents);
+            Assert.That(result.Contents, Is.EqualTo(new UTF8Encoding().GetBytes("This is a test file.")));
         }
 
         [Test]
@@ -372,7 +372,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.AllNodes;
 
-            Assert.AreEqual(expectedNodes, result);
+            Assert.That(result, Is.EqualTo(expectedNodes));
         }
 
         [Test]
@@ -421,7 +421,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var ae = Assert.Throws<ArgumentException>(() =>
                 new MockFileSystem(null, "non-rooted")
             );
-            Assert.AreEqual("currentDirectory", ae.ParamName);
+            Assert.That(ae.ParamName, Is.EqualTo("currentDirectory"));
         }
 
         [Test]
@@ -442,7 +442,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var path = XFS.Path(@"C:\root");
             var fileSystem = new TestFileSystem(new TestFileSystemWatcherFactory());
             var watcher = fileSystem.FileSystemWatcher.New(path);
-            Assert.AreEqual(path, watcher.Path);
+            Assert.That(watcher.Path, Is.EqualTo(path));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -23,7 +23,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.GetFile(@"c:\something\else.txt");
 
-            Assert.IsNull(result);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
@@ -69,7 +69,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.GetFile("/SomeThing/DEMO.txt");
 
-            Assert.IsNull(result);
+            Assert.That(result, Is.Null);
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -230,10 +230,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(XFS.Path(@"C:\test\SUBDirectory"));
             fileSystem.AddDirectory(XFS.Path(@"C:\LOUD\SUBDirectory"));
 
-            Assert.Contains(XFS.Path(@"C:\test\file.txt"), fileSystem.AllFiles.ToList());
-            Assert.Contains(XFS.Path(@"C:\LOUD\file.txt"), fileSystem.AllFiles.ToList());
-            Assert.Contains(XFS.Path(@"C:\test\SUBDirectory"), fileSystem.AllDirectories.ToList());
-            Assert.Contains(XFS.Path(@"C:\LOUD\SUBDirectory"), fileSystem.AllDirectories.ToList());
+            Assert.That(fileSystem.AllFiles.ToList(), Does.Contain(XFS.Path(@"C:\test\file.txt")));
+            Assert.That(fileSystem.AllFiles.ToList(), Does.Contain(XFS.Path(@"C:\LOUD\file.txt")));
+            Assert.That(fileSystem.AllDirectories.ToList(), Does.Contain(XFS.Path(@"C:\test\SUBDirectory")));
+            Assert.That(fileSystem.AllDirectories.ToList(), Does.Contain(XFS.Path(@"C:\LOUD\SUBDirectory")));
         }
 
         [Test]
@@ -249,10 +249,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(XFS.Path(@"C:\test\SUBTEST\SUBDirectory"));
             fileSystem.AddDirectory(XFS.Path(@"C:\LOUD\subloud\SUBDirectory"));
 
-            Assert.Contains(XFS.Path(@"C:\test\subtest\file.txt"), fileSystem.AllFiles.ToList());
-            Assert.Contains(XFS.Path(@"C:\LOUD\SUBLOUD\file.txt"), fileSystem.AllFiles.ToList());
-            Assert.Contains(XFS.Path(@"C:\test\subtest\SUBDirectory"), fileSystem.AllDirectories.ToList());
-            Assert.Contains(XFS.Path(@"C:\LOUD\SUBLOUD\SUBDirectory"), fileSystem.AllDirectories.ToList());
+            Assert.That(fileSystem.AllFiles.ToList(), Does.Contain(XFS.Path(@"C:\test\subtest\file.txt")));
+            Assert.That(fileSystem.AllFiles.ToList(), Does.Contain(XFS.Path(@"C:\LOUD\SUBLOUD\file.txt")));
+            Assert.That(fileSystem.AllDirectories.ToList(), Does.Contain(XFS.Path(@"C:\test\subtest\SUBDirectory")));
+            Assert.That(fileSystem.AllDirectories.ToList(), Does.Contain(XFS.Path(@"C:\LOUD\SUBLOUD\SUBDirectory")));
         }
 
         [Test]
@@ -268,10 +268,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(XFS.Path(@"C:\test\SUBTEST\new\SUBDirectory"));
             fileSystem.AddDirectory(XFS.Path(@"C:\LOUD\subloud\new\SUBDirectory"));
 
-            Assert.Contains(XFS.Path(@"C:\test\subtest\new\file.txt"), fileSystem.AllFiles.ToList());
-            Assert.Contains(XFS.Path(@"C:\LOUD\SUBLOUD\new\file.txt"), fileSystem.AllFiles.ToList());
-            Assert.Contains(XFS.Path(@"C:\test\subtest\new\SUBDirectory"), fileSystem.AllDirectories.ToList());
-            Assert.Contains(XFS.Path(@"C:\LOUD\SUBLOUD\new\SUBDirectory"), fileSystem.AllDirectories.ToList());
+            Assert.That(fileSystem.AllFiles.ToList(), Does.Contain(XFS.Path(@"C:\test\subtest\new\file.txt")));
+            Assert.That(fileSystem.AllFiles.ToList(), Does.Contain(XFS.Path(@"C:\LOUD\SUBLOUD\new\file.txt")));
+            Assert.That(fileSystem.AllDirectories.ToList(), Does.Contain(XFS.Path(@"C:\test\subtest\new\SUBDirectory")));
+            Assert.That(fileSystem.AllDirectories.ToList(), Does.Contain(XFS.Path(@"C:\LOUD\SUBLOUD\new\SUBDirectory")));
         }
 
         [Test]
@@ -292,8 +292,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileSystem.AddFilesFromEmbeddedNamespace(XFS.Path(@"C:\"), Assembly.GetExecutingAssembly(), "System.IO.Abstractions.TestingHelpers.Tests.TestFiles");
 
-            Assert.Contains(XFS.Path(@"C:\TestFile.txt"), fileSystem.AllFiles.ToList());
-            Assert.Contains(XFS.Path(@"C:\SecondTestFile.txt"), fileSystem.AllFiles.ToList());
+            Assert.That(fileSystem.AllFiles.ToList(), Does.Contain(XFS.Path(@"C:\TestFile.txt")));
+            Assert.That(fileSystem.AllFiles.ToList(), Does.Contain(XFS.Path(@"C:\SecondTestFile.txt")));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -99,7 +99,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.File.ReadAllText(path);
 
-            Assert.IsEmpty(result, "Null MockFileData should be allowed for and result in an empty file.");
+            Assert.That(result, Is.Empty, "Null MockFileData should be allowed for and result in an empty file.");
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -305,7 +305,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.MoveDirectory(XFS.Path(@"C:\dir1"), XFS.Path(@"C:\dir2"));
 
             var expected = new[] { XFS.Path(@"C:\dir2\dir1\dir1.txt") };
-            CollectionAssert.AreEquivalent(expected, fileSystem.AllFiles);
+            Assert.That(fileSystem.AllFiles, Is.EqualTo(expected));
         }
 
         [Test]
@@ -319,7 +319,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.File.Move(XFS.Path(@"C:\target\project.txt"), XFS.Path(@"C:\target\proj.txt"));
 
             var expected = new[] { XFS.Path(@"C:\target\proj.txt"), XFS.Path(@"C:\target\subdir\other.txt") };
-            CollectionAssert.AreEquivalent(expected, fileSystem.AllFiles);
+            Assert.That(fileSystem.AllFiles, Is.EqualTo(expected));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -330,7 +330,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileSystem.RemoveFile(@"C:\file.txt");
 
-            Assert.False(fileSystem.FileExists(@"C:\file.txt"));
+            Assert.That(fileSystem.FileExists(@"C:\file.txt"), Is.False);
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -85,7 +85,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileExists = fs.File.Exists(alternatePath);
 
             Assert.That(fileCount, Is.EqualTo(1));
-            Assert.IsTrue(fileExists);
+            Assert.That(fileExists, Is.True);
         }
 
         [Test]
@@ -191,7 +191,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileSystem.AddDirectory(baseDirectory);
 
-            Assert.IsTrue(fileSystem.Directory.Exists(baseDirectory));
+            Assert.That(fileSystem.Directory.Exists(baseDirectory), Is.True);
         }
 
         [Test]
@@ -385,7 +385,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileSystem.AddDirectory(path2);
 
-            Assert.IsTrue(fileSystem.FileExists(path2));
+            Assert.That(fileSystem.FileExists(path2), Is.True);
         }
 
         [Test]
@@ -412,7 +412,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var actualCurrentDirectory = fs.DirectoryInfo.New(".");
 
-            Assert.IsTrue(actualCurrentDirectory.Exists);
+            Assert.That(actualCurrentDirectory.Exists, Is.True);
         }
 
         [Test]
@@ -432,8 +432,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var mockFileSystem = new MockFileSystem();
             var mockFileSystemOverload = new MockFileSystem(null, string.Empty);
 
-            Assert.IsTrue(mockFileSystem.Directory.Exists(tempDirectory));
-            Assert.IsTrue(mockFileSystemOverload.Directory.Exists(tempDirectory));
+            Assert.That(mockFileSystem.Directory.Exists(tempDirectory), Is.True);
+            Assert.That(mockFileSystemOverload.Directory.Exists(tempDirectory), Is.True);
         }
 
         [Test]
@@ -459,8 +459,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             TestDelegate action = () => fileSystem.Directory.Delete(baseDirectory, true);
 
             Assert.Throws<UnauthorizedAccessException>(action);
-            Assert.True(fileSystem.File.Exists(textFile));
-            Assert.True(fileSystem.Directory.Exists(baseDirectory));
+            Assert.That(fileSystem.File.Exists(textFile), Is.True);
+            Assert.That(fileSystem.Directory.Exists(baseDirectory), Is.True);
         }
 
         private class TestFileSystem : MockFileSystem

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemWatcherFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemWatcherFactoryTests.cs
@@ -45,7 +45,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.FileSystemWatcher.Wrap(null);
 
-            Assert.IsNull(result);
+            Assert.That(result, Is.Null);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
@@ -610,7 +610,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var attributes = fileSystem.File.GetAttributes(filePath);
 
             // Assert
-            Assert.AreNotEqual(FileAttributes.Encrypted, attributes & FileAttributes.Encrypted);
+            Assert.That(attributes & FileAttributes.Encrypted, Is.Not.EqualTo(FileAttributes.Encrypted));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
@@ -392,7 +392,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             yield return new ASCIIEncoding();
         }
 
-        [TestCaseSource(typeof(MockFileTests), "GetEncodingsForReadAllText")]
+        [TestCaseSource(typeof(MockFileTests), nameof(GetEncodingsForReadAllText))]
         public void MockFile_ReadAllText_ShouldReturnTheOriginalContentWhenTheFileContainsDifferentEncodings(Encoding encoding)
         {
             // Arrange

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
@@ -701,7 +701,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var stream = fileSystem.File.OpenRead(filePath);
 
             // Assert
-            Assert.IsFalse(stream.CanWrite);
+            Assert.That(stream.CanWrite, Is.False);
             Assert.Throws<NotSupportedException>(() => stream.WriteByte(0));
         }
     }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
@@ -42,7 +42,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.GetCreationTime(path);
 
             // Assert
-            Assert.AreEqual(creationTime, result);
+            Assert.That(result, Is.EqualTo(creationTime));
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.GetCreationTime(path);
 
             // Assert
-            Assert.AreEqual(creationTime, result);
+            Assert.That(result, Is.EqualTo(creationTime));
         }
 
         [Test]
@@ -82,7 +82,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.GetCreationTimeUtc(path);
 
             // Assert
-            Assert.AreEqual(creationTime.ToUniversalTime(), result);
+            Assert.That(result, Is.EqualTo(creationTime.ToUniversalTime()));
         }
 
         [Test]
@@ -102,7 +102,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.GetLastAccessTime(path);
 
             // Assert
-            Assert.AreEqual(lastAccessTime, result);
+            Assert.That(result, Is.EqualTo(lastAccessTime));
         }
 
         [Test]
@@ -122,7 +122,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.GetLastAccessTime(path);
 
             // Assert
-            Assert.AreEqual(lastAccessTime, result);
+            Assert.That(result, Is.EqualTo(lastAccessTime));
         }
 
         [Test]
@@ -142,7 +142,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.GetLastAccessTimeUtc(path);
 
             // Assert
-            Assert.AreEqual(lastAccessTime.ToUniversalTime(), result);
+            Assert.That(result, Is.EqualTo(lastAccessTime.ToUniversalTime()));
         }
 
         [Test]
@@ -162,7 +162,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.GetLastWriteTime(path);
 
             // Assert
-            Assert.AreEqual(lastWriteTime, result);
+            Assert.That(result, Is.EqualTo(lastWriteTime));
         }
 
         static void ExecuteDefaultValueTest(Func<MockFile, string, DateTime> getDateValue)
@@ -316,7 +316,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.GetLastWriteTime(path);
 
             // Assert
-            Assert.AreEqual(lastWriteTime, result);
+            Assert.That(result, Is.EqualTo(lastWriteTime));
         }
 
         [Test]
@@ -336,7 +336,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.GetLastWriteTimeUtc(path);
 
             // Assert
-            Assert.AreEqual(lastWriteTime.ToUniversalTime(), result);
+            Assert.That(result, Is.EqualTo(lastWriteTime.ToUniversalTime()));
         }
 
         [Test]
@@ -355,9 +355,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.ReadAllText(XFS.Path(@"c:\something\demo.txt"));
 
             // Assert
-            Assert.AreEqual(
-                "Demo text content",
-                result);
+            Assert.That(result, Is.EqualTo("Demo text content"));
         }
 
         [Test]
@@ -377,7 +375,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.ReadAllText(XFS.Path(@"c:\something\demo.txt"), Encoding.BigEndianUnicode);
 
             // Assert
-            Assert.AreEqual(text, result);
+            Assert.That(result, Is.EqualTo(text));
         }
 
         public static IEnumerable<Encoding> GetEncodingsForReadAllText()
@@ -408,7 +406,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualText = fileSystem.File.ReadAllText(path);
 
             // Assert
-            Assert.AreEqual(text, actualText);
+            Assert.That(actualText, Is.EqualTo(text));
         }
 
         [Test]
@@ -479,9 +477,9 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             string filePath = XFS.Path(@"c:\something\demo.txt");
             string fileContent = "this is some content";
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData> { { filePath, new MockFileData(fileContent) } });
-            Assert.AreEqual(1, fileSystem.AllFiles.Count());
+            Assert.That(fileSystem.AllFiles.Count(), Is.EqualTo(1));
             fileSystem.File.Delete(filePath);
-            Assert.AreEqual(0, fileSystem.AllFiles.Count());
+            Assert.That(fileSystem.AllFiles.Count(), Is.EqualTo(0));
         }
 
         [Test]
@@ -591,7 +589,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var attributes = fileSystem.File.GetAttributes(filePath);
 
             // Assert
-            Assert.AreEqual(FileAttributes.Encrypted, attributes & FileAttributes.Encrypted);
+            Assert.That(attributes & FileAttributes.Encrypted, Is.EqualTo(FileAttributes.Encrypted));
         }
 
         [Test]
@@ -628,7 +626,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Act
             fileSystem.File.Replace(path1, path2, null);
 
-            Assert.AreEqual("1", fileSystem.File.ReadAllText(path2));
+            Assert.That(fileSystem.File.ReadAllText(path2), Is.EqualTo("1"));
         }
 
         [Test]
@@ -645,8 +643,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Act
             fileSystem.File.Replace(path1, path2, path3);
 
-            Assert.AreEqual("2", fileSystem.File.ReadAllText(path3));
-        }
+            Assert.That(fileSystem.File.ReadAllText(path3), Is.EqualTo("2"));
+        } 
 
         [Test]
         public void MockFile_Replace_ShouldThrowIfDirectoryOfBackupPathDoesNotExist()

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllBytesTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllBytesTests.cs
@@ -30,7 +30,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileSystem.File.WriteAllBytes(path, fileContent);
 
-            Assert.AreEqual(fileContent, fileSystem.GetFile(path).Contents);
+            Assert.That(fileSystem.GetFile(path).Contents, Is.EqualTo(fileContent));
         }
 
         [Test]
@@ -146,7 +146,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             await fileSystem.File.WriteAllBytesAsync(path, fileContent);
 
-            Assert.AreEqual(fileContent, fileSystem.GetFile(path).Contents);
+            Assert.That(fileSystem.GetFile(path).Contents, Is.EqualTo(fileContent));
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllBytesTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllBytesTests.cs
@@ -100,7 +100,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var readAgain = fileSystem.File.ReadAllBytes(path);
 
-            Assert.AreNotEqual(fileContent, readAgain);
+            Assert.That(fileContent, Is.Not.EqualTo(readAgain));
         }
 
 

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllBytesTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllBytesTests.cs
@@ -133,7 +133,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             );
 
             // Assert
-            Assert.IsFalse(fileSystem.File.Exists(path));
+            Assert.That(fileSystem.File.Exists(path), Is.False);
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllLinesTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllLinesTests.cs
@@ -401,7 +401,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
         }
 
-        [TestCaseSource(typeof(TestDataForWriteAllLines), "ForDifferentEncoding")]
+        [TestCaseSource(typeof(TestDataForWriteAllLines), nameof(TestDataForWriteAllLines.ForDifferentEncoding))]
         public void MockFile_WriteAllLinesGeneric_ShouldWriteTheCorrectContent(IMockFileDataAccessor fileSystem, Action action, string expectedContent)
         {
             // Arrange
@@ -415,7 +415,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(actualContent, Is.EqualTo(expectedContent));
         }
 
-        [TestCaseSource(typeof(TestDataForWriteAllLines), "ForNullPath")]
+        [TestCaseSource(typeof(TestDataForWriteAllLines), nameof(TestDataForWriteAllLines.ForNullPath))]
         public void MockFile_WriteAllLinesGeneric_ShouldThrowAnArgumentNullExceptionIfPathIsNull(TestDelegate action)
         {
             // Arrange
@@ -445,7 +445,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(exception.ParamName, Does.StartWith("encoding"));
         }
 
-        [TestCaseSource(typeof(TestDataForWriteAllLines), "ForIllegalPath")]
+        [TestCaseSource(typeof(TestDataForWriteAllLines), nameof(TestDataForWriteAllLines.ForIllegalPath))]
         [WindowsOnly(WindowsSpecifics.StrictPathRules)]
         public void MockFile_WriteAllLinesGeneric_ShouldThrowAnArgumentExceptionIfPathContainsIllegalCharacters(TestDelegate action)
         {
@@ -460,7 +460,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(exception.Message, Is.EqualTo("Illegal characters in path."));
         }
 
-        [TestCaseSource(typeof(TestDataForWriteAllLines), "ForPathIsDirectory")]
+        [TestCaseSource(typeof(TestDataForWriteAllLines), nameof(TestDataForWriteAllLines.ForPathIsDirectory))]
         public void MockFile_WriteAllLinesGeneric_ShouldThrowAnUnauthorizedAccessExceptionIfPathIsOneDirectory(TestDelegate action, string path)
         {
             // Arrange
@@ -475,7 +475,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(exception.Message, Is.EqualTo(expectedMessage));
         }
 
-        [TestCaseSource(typeof(TestDataForWriteAllLines), "ForFileIsReadOnly")]
+        [TestCaseSource(typeof(TestDataForWriteAllLines), nameof(TestDataForWriteAllLines.ForFileIsReadOnly))]
         public void MockFile_WriteAllLinesGeneric_ShouldThrowOneUnauthorizedAccessExceptionIfFileIsReadOnly(TestDelegate action, string path)
         {
             // Arrange
@@ -490,7 +490,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(exception.Message, Is.EqualTo(expectedMessage));
         }
 
-        [TestCaseSource(typeof(TestDataForWriteAllLines), "ForContentsIsNull")]
+        [TestCaseSource(typeof(TestDataForWriteAllLines), nameof(TestDataForWriteAllLines.ForContentsIsNull))]
         public void MockFile_WriteAllLinesGeneric_ShouldThrowAnArgumentNullExceptionIfContentsIsNull(TestDelegate action)
         {
             // Arrange
@@ -506,7 +506,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
 #if FEATURE_ASYNC_FILE
-        [TestCaseSource(typeof(TestDataForWriteAllLines), "ForDifferentEncodingAsync")]
+        [TestCaseSource(typeof(TestDataForWriteAllLines), nameof(TestDataForWriteAllLines.ForDifferentEncodingAsync))]
         public void MockFile_WriteAllLinesAsyncGeneric_ShouldWriteTheCorrectContent(IMockFileDataAccessor fileSystem, Action action, string expectedContent)
         {
             // Arrange
@@ -520,7 +520,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(actualContent, Is.EqualTo(expectedContent));
         }
 
-        [TestCaseSource(typeof(TestDataForWriteAllLines), "ForNullPathAsync")]
+        [TestCaseSource(typeof(TestDataForWriteAllLines), nameof(TestDataForWriteAllLines.ForNullPathAsync))]
         public void MockFile_WriteAllLinesAsyncGeneric_ShouldThrowAnArgumentNullExceptionIfPathIsNull(AsyncTestDelegate action)
         {
             // Arrange
@@ -550,7 +550,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(exception.ParamName, Does.StartWith("encoding"));
         }
 
-        [TestCaseSource(typeof(TestDataForWriteAllLines), "ForIllegalPathAsync")]
+        [TestCaseSource(typeof(TestDataForWriteAllLines), nameof(TestDataForWriteAllLines.ForIllegalPathAsync))]
         [WindowsOnly(WindowsSpecifics.StrictPathRules)]
         public void MockFile_WriteAllLinesAsyncGeneric_ShouldThrowAnArgumentExceptionIfPathContainsIllegalCharacters(AsyncTestDelegate action)
         {
@@ -565,7 +565,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(exception.Message, Is.EqualTo("Illegal characters in path."));
         }
 
-        [TestCaseSource(typeof(TestDataForWriteAllLines), "ForPathIsDirectoryAsync")]
+        [TestCaseSource(typeof(TestDataForWriteAllLines), nameof(TestDataForWriteAllLines.ForPathIsDirectoryAsync))]
         public void MockFile_WriteAllLinesAsyncGeneric_ShouldThrowAnUnauthorizedAccessExceptionIfPathIsOneDirectory(AsyncTestDelegate action, string path)
         {
             // Arrange
@@ -580,7 +580,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(exception.Message, Is.EqualTo(expectedMessage));
         }
 
-        [TestCaseSource(typeof(TestDataForWriteAllLines), "ForFileIsReadOnlyAsync")]
+        [TestCaseSource(typeof(TestDataForWriteAllLines), nameof(TestDataForWriteAllLines.ForFileIsReadOnlyAsync))]
         public void MockFile_WriteAllLinesAsyncGeneric_ShouldThrowOneUnauthorizedAccessExceptionIfFileIsReadOnly(AsyncTestDelegate action, string path)
         {
             // Arrange
@@ -595,7 +595,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(exception.Message, Is.EqualTo(expectedMessage));
         }
 
-        [TestCaseSource(typeof(TestDataForWriteAllLines), "ForContentsIsNullAsync")]
+        [TestCaseSource(typeof(TestDataForWriteAllLines), nameof(TestDataForWriteAllLines.ForContentsIsNullAsync))]
         public void MockFile_WriteAllLinesAsyncGeneric_ShouldThrowAnArgumentNullExceptionIfContentsIsNull(AsyncTestDelegate action)
         {
             // Arrange

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllLinesTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllLinesTests.cs
@@ -395,7 +395,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 );
 
                 // Assert
-                Assert.IsFalse(fileSystem.File.Exists(path));
+                Assert.That(fileSystem.File.Exists(path), Is.False);
             }
 #endif
 

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllTextTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllTextTests.cs
@@ -184,7 +184,7 @@
             };
         }
 
-        [TestCaseSource(typeof(MockFileWriteAllTextTests), "GetEncodingsWithExpectedBytes")]
+        [TestCaseSource(typeof(MockFileWriteAllTextTests), nameof(GetEncodingsWithExpectedBytes))]
         public void MockFile_WriteAllText_Encoding_ShouldWriteTextFileToMemoryFileSystem(KeyValuePair<Encoding, byte[]> encodingsWithContents)
         {
             // Arrange
@@ -375,7 +375,7 @@
             Assert.ThrowsAsync<DirectoryNotFoundException>(action);
         }
 
-        [TestCaseSource(typeof(MockFileWriteAllTextTests), "GetEncodingsWithExpectedBytes")]
+        [TestCaseSource(typeof(MockFileWriteAllTextTests), nameof(GetEncodingsWithExpectedBytes))]
         public async Task MockFile_WriteAllTextAsync_Encoding_ShouldWriteTextFileToMemoryFileSystem(KeyValuePair<Encoding, byte[]> encodingsWithContents)
         {
             // Arrange

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllTextTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllTextTests.cs
@@ -253,7 +253,7 @@
             );
 
             // Assert
-            Assert.IsFalse(fileSystem.File.Exists(path));
+            Assert.That(fileSystem.File.Exists(path), Is.False);
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllTextTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllTextTests.cs
@@ -26,9 +26,7 @@
             fileSystem.File.WriteAllText(path, fileContent);
 
             // Assert
-            Assert.AreEqual(
-                fileContent,
-                fileSystem.GetFile(path).TextContents);
+            Assert.That(fileSystem.GetFile(path).TextContents, Is.EqualTo(fileContent));
         }
 
         [Test]
@@ -46,7 +44,7 @@
             fileSystem.File.WriteAllText(path, "bar");
 
             // Assert
-            Assert.AreEqual("bar", fileSystem.GetFile(path).TextContents);
+            Assert.That(fileSystem.GetFile(path).TextContents, Is.EqualTo("bar"));
         }
 
         [Test]
@@ -200,7 +198,7 @@
 
             // Assert
             var actualBytes = fileSystem.GetFile(path).Contents;
-            Assert.AreEqual(expectedBytes, actualBytes);
+            Assert.That(actualBytes, Is.EqualTo(expectedBytes));
         }
 
         [Test]
@@ -219,9 +217,7 @@
             fileSystem.File.WriteAllLines(path, fileContent);
 
             // Assert
-            Assert.AreEqual(
-                expected,
-                fileSystem.GetFile(path).TextContents);
+            Assert.That(fileSystem.GetFile(path).TextContents, Is.EqualTo(expected));
         }
 
 #if FEATURE_ASYNC_FILE
@@ -238,9 +234,7 @@
             await fileSystem.File.WriteAllTextAsync(path, fileContent);
 
             // Assert
-            Assert.AreEqual(
-                fileContent,
-                fileSystem.GetFile(path).TextContents);
+            Assert.That(fileSystem.GetFile(path).TextContents, Is.EqualTo(fileContent));
         }
 
         [Test]
@@ -277,7 +271,7 @@
             await fileSystem.File.WriteAllTextAsync(path, "bar");
 
             // Assert
-            Assert.AreEqual("bar", fileSystem.GetFile(path).TextContents);
+            Assert.That(fileSystem.GetFile(path).TextContents, Is.EqualTo("bar"));
         }
 
         [Test]
@@ -391,7 +385,7 @@
 
             // Assert
             var actualBytes = fileSystem.GetFile(path).Contents;
-            Assert.AreEqual(expectedBytes, actualBytes);
+            Assert.That(actualBytes, Is.EqualTo(expectedBytes));
         }
 
         [Test]
@@ -410,9 +404,7 @@
             await fileSystem.File.WriteAllLinesAsync(path, fileContent);
 
             // Assert
-            Assert.AreEqual(
-                expected,
-                fileSystem.GetFile(path).TextContents);
+            Assert.That(fileSystem.GetFile(path).TextContents, Is.EqualTo(expected));
         }
 #endif
     }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockPathTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockPathTests.cs
@@ -478,7 +478,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.IsPathRooted(XFS.Path("directory\\file.txt"));
 
             //Assert
-            Assert.IsFalse(result);
+            Assert.That(result, Is.False);
         }
 
         [Test]
@@ -491,7 +491,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.IsPathRooted(XFS.Path("directory\\..\\file.txt"));
 
             //Assert
-            Assert.IsFalse(result);
+            Assert.That(result, Is.False);
         }
 
         [Test]
@@ -567,7 +567,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSystem = new MockFileSystem();
             bool result = fileSystem.Path.Exists(null);
 
-            Assert.IsFalse(result);
+            Assert.That(result, Is.False);
         }
 
         [Test]
@@ -614,7 +614,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             string path = "some-path";
             bool result = fileSystem.Path.Exists(path);
 
-            Assert.IsFalse(result);
+            Assert.That(result, Is.False);
         }
 #endif
 

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockPathTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockPathTests.cs
@@ -153,7 +153,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             }
         }
 
-        [TestCaseSource("GetFullPath_RelativePaths_Cases")]
+        [TestCaseSource(nameof(GetFullPath_RelativePaths_Cases))]
         public void GetFullPath_RelativePaths_ShouldReturnTheAbsolutePathWithCurrentDirectory(string currentDir, string relativePath, string expectedResult)
         {
             //Arrange
@@ -180,7 +180,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             }
         }
 
-        [TestCaseSource("GetFullPath_RootedPathWithRelativeSegments_Cases")]
+        [TestCaseSource(nameof(GetFullPath_RootedPathWithRelativeSegments_Cases))]
         public void GetFullPath_RootedPathWithRelativeSegments_ShouldReturnAnRootedAbsolutePath(string rootedPath, string expectedResult)
         {
             //Arrange
@@ -209,7 +209,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             }
         }
 
-        [TestCaseSource("GetFullPath_AbsolutePaths_Cases")]
+        [TestCaseSource(nameof(GetFullPath_AbsolutePaths_Cases))]
         public void GetFullPath_AbsolutePaths_ShouldReturnThePathWithTheRoot_Or_Unc(string currentDir, string absolutePath, string expectedResult)
         {
             //Arrange

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockPathTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockPathTests.cs
@@ -300,7 +300,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetInvalidFileNameChars();
 
             //Assert
-            Assert.IsTrue(result.Length > 0);
+            Assert.That(result.Length > 0, Is.True);
         }
 
         [Test]
@@ -313,7 +313,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetInvalidPathChars();
 
             //Assert
-            Assert.IsTrue(result.Length > 0);
+            Assert.That(result.Length > 0, Is.True);
         }
 
         [Test]
@@ -339,7 +339,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetRandomFileName();
 
             //Assert
-            Assert.IsTrue(result.Length > 0);
+            Assert.That(result.Length > 0, Is.True);
         }
 
         [Test]
@@ -352,7 +352,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetTempFileName();
 
             //Assert
-            Assert.IsTrue(result.Length > 0);
+            Assert.That(result.Length > 0, Is.True);
         }
 
         [Test]
@@ -365,7 +365,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             //Act
             var result = mockPath.GetTempFileName();
 
-            Assert.True(fileSystem.FileExists(result));
+            Assert.That(fileSystem.FileExists(result), Is.True);
             Assert.That(fileSystem.FileInfo.New(result).Length, Is.Zero);
         }
 
@@ -379,7 +379,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetTempPath();
 
             //Assert
-            Assert.IsTrue(result.Length > 0);
+            Assert.That(result.Length > 0, Is.True);
         }
 
         [Test]
@@ -395,7 +395,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetTempPath();
 
             //Assert
-            Assert.IsTrue(result.Length > 0);
+            Assert.That(result.Length > 0, Is.True);
         }
 
         [Test]
@@ -425,7 +425,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetTempPath();
 
             //Assert
-            Assert.IsTrue(result.Length > 0);
+            Assert.That(result.Length > 0, Is.True);
         }
 
         [Test]
@@ -465,7 +465,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.IsPathFullyQualified(XFS.Path("C:\\directory\\file.txt"));
 
             //Assert
-            Assert.IsTrue(result);
+            Assert.That(result, Is.True);
         }
 
         [Test]
@@ -580,7 +580,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             bool result = fileSystem.Path.Exists(absolutePath);
 
-            Assert.IsTrue(result);
+            Assert.That(result, Is.True);
         }
 
         [Test]
@@ -592,7 +592,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             bool result = fileSystem.Path.Exists(path);
 
-            Assert.IsTrue(result);
+            Assert.That(result, Is.True);
         }
 
         [Test]
@@ -604,7 +604,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             bool result = fileSystem.Path.Exists(path);
 
-            Assert.IsTrue(result);
+            Assert.That(result, Is.True);
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockPathTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockPathTests.cs
@@ -19,7 +19,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.ChangeExtension(TestPath, "doc");
 
             //Assert
-            Assert.AreEqual(XFS.Path("C:\\test\\test.doc"), result);
+            Assert.That(result, Is.EqualTo(XFS.Path("C:\\test\\test.doc")));
         }
 
         [Test]
@@ -32,7 +32,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.Combine(XFS.Path("C:\\test"), "test.bmp");
 
             //Assert
-            Assert.AreEqual(XFS.Path("C:\\test\\test.bmp"), result);
+            Assert.That(result, Is.EqualTo(XFS.Path("C:\\test\\test.bmp")));
         }
 
         [Test]
@@ -45,7 +45,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.Combine(XFS.Path("C:\\test"), "subdir1", "test.bmp");
 
             //Assert
-            Assert.AreEqual(XFS.Path("C:\\test\\subdir1\\test.bmp"), result);
+            Assert.That(result, Is.EqualTo(XFS.Path("C:\\test\\subdir1\\test.bmp")));
         }
 
         [Test]
@@ -58,7 +58,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.Combine(XFS.Path("C:\\test"), "subdir1", "subdir2", "test.bmp");
 
             //Assert
-            Assert.AreEqual(XFS.Path("C:\\test\\subdir1\\subdir2\\test.bmp"), result);
+            Assert.That(result, Is.EqualTo(XFS.Path("C:\\test\\subdir1\\subdir2\\test.bmp")));
         }
 
         [Test]
@@ -71,7 +71,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.Combine(XFS.Path("C:\\test"), "subdir1", "subdir2", "subdir3", "test.bmp");
 
             //Assert
-            Assert.AreEqual(XFS.Path("C:\\test\\subdir1\\subdir2\\subdir3\\test.bmp"), result);
+            Assert.That(result, Is.EqualTo(XFS.Path("C:\\test\\subdir1\\subdir2\\subdir3\\test.bmp")));
         }
 
         [Test]
@@ -84,7 +84,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetDirectoryName(TestPath);
 
             //Assert
-            Assert.AreEqual(XFS.Path("C:\\test"), result);
+            Assert.That(result, Is.EqualTo(XFS.Path("C:\\test")));
         }
 
         [Test]
@@ -97,7 +97,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetExtension(TestPath);
 
             //Assert
-            Assert.AreEqual(".bmp", result);
+            Assert.That(result, Is.EqualTo(".bmp"));
         }
 
         [Test]
@@ -110,7 +110,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetFileName(TestPath);
 
             //Assert
-            Assert.AreEqual("test.bmp", result);
+            Assert.That(result, Is.EqualTo("test.bmp"));
         }
 
         [Test]
@@ -123,7 +123,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetFileNameWithoutExtension(TestPath);
 
             //Assert
-            Assert.AreEqual("test", result);
+            Assert.That(result, Is.EqualTo("test"));
         }
 
         [Test]
@@ -136,7 +136,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetFullPath(TestPath);
 
             //Assert
-            Assert.AreEqual(TestPath, result);
+            Assert.That(result, Is.EqualTo(TestPath));
         }
 
         public static IEnumerable<string[]> GetFullPath_RelativePaths_Cases
@@ -165,7 +165,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = mockPath.GetFullPath(relativePath);
 
             //Assert
-            Assert.AreEqual(expectedResult, actualResult);
+            Assert.That(actualResult, Is.EqualTo(expectedResult));
         }
 
         public static IEnumerable<string[]> GetFullPath_RootedPathWithRelativeSegments_Cases
@@ -191,7 +191,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = mockPath.GetFullPath(rootedPath);
 
             //Assert
-            Assert.AreEqual(expectedResult, actualResult);
+            Assert.That(actualResult, Is.EqualTo(expectedResult));
         }
 
         public static IEnumerable<string[]> GetFullPath_AbsolutePaths_Cases
@@ -221,7 +221,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = mockPath.GetFullPath(absolutePath);
 
             //Assert
-            Assert.AreEqual(expectedResult, actualResult);
+            Assert.That(actualResult, Is.EqualTo(expectedResult));
         }
 
         [Test]
@@ -287,7 +287,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualFullPath = mockPath.GetFullPath(XFS.Path(@"c:\foo\\//bar\file.dat"));
 
             //Assert
-            Assert.AreEqual(XFS.Path(@"c:\foo\bar\file.dat"), actualFullPath);
+            Assert.That(actualFullPath, Is.EqualTo(XFS.Path(@"c:\foo\bar\file.dat")));
         }
 
         [Test]
@@ -326,7 +326,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetPathRoot(TestPath);
 
             //Assert
-            Assert.AreEqual(XFS.Path("C:\\"), result);
+            Assert.That(result, Is.EqualTo(XFS.Path("C:\\")));
         }
 
         [Test]
@@ -366,7 +366,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetTempFileName();
 
             Assert.True(fileSystem.FileExists(result));
-            Assert.AreEqual(0, fileSystem.FileInfo.New(result).Length);
+            Assert.That(fileSystem.FileInfo.New(result).Length, Is.Zero);
         }
 
         [Test]
@@ -410,7 +410,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetTempPath();
 
             //Assert
-            Assert.AreEqual(tempDirectory, result);
+            Assert.That(result, Is.EqualTo(tempDirectory));
         }
 
         [Test]
@@ -438,7 +438,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.HasExtension(TestPath);
 
             //Assert
-            Assert.AreEqual(true, result);
+            Assert.That(result, Is.True);
         }
 
         [Test]
@@ -451,7 +451,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.IsPathRooted(TestPath);
 
             //Assert
-            Assert.AreEqual(true, result);
+            Assert.That(result, Is.True);
         }
 
 #if FEATURE_ADVANCED_PATH_OPERATIONS
@@ -504,7 +504,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetRelativePath(XFS.Path("c:\\d"), XFS.Path("c:\\d\\e\\f.txt"));
 
             //Assert
-            Assert.AreEqual(XFS.Path("e\\f.txt"), result);
+            Assert.That(result, Is.EqualTo(XFS.Path("e\\f.txt")));
         }
 
         [Test]
@@ -517,7 +517,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 mockPath.GetRelativePath("foo", null);
             });
 
-            Assert.AreEqual("path", exception.ParamName);
+            Assert.That(exception.ParamName, Is.EqualTo("path"));
         }
 
         [Test]
@@ -530,7 +530,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 mockPath.GetRelativePath("foo", " ");
             });
 
-            Assert.AreEqual("path", exception.ParamName);
+            Assert.That(exception.ParamName, Is.EqualTo("path"));
         }
 
         [Test]
@@ -543,7 +543,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 mockPath.GetRelativePath(null, "foo");
             });
 
-            Assert.AreEqual("relativeTo", exception.ParamName);
+            Assert.That(exception.ParamName, Is.EqualTo("relativeTo"));
         }
 
         [Test]
@@ -556,7 +556,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 mockPath.GetRelativePath(" ", "foo");
             });
 
-            Assert.AreEqual("relativeTo", exception.ParamName);
+            Assert.That(exception.ParamName, Is.EqualTo("relativeTo"));
         }
 #endif
 
@@ -632,7 +632,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fs.Path.GetRelativePath("/input", "a.txt");
 
-            Assert.AreEqual("a.txt", result);
+            Assert.That(result, Is.EqualTo("a.txt"));
         }
 #endif
     }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockUnixSupportTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockUnixSupportTests.cs
@@ -11,14 +11,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [UnixOnly(UnixSpecifics.SlashRoot)]
         public void Should_Convert_Backslashes_To_Slashes_On_Unix()
         {
-            Assert.AreEqual("/test/", XFS.Path(@"\test\"));
+            Assert.That(XFS.Path(@"\test\"), Is.EqualTo("/test/"));
         }
 
         [Test]
         [UnixOnly(UnixSpecifics.SlashRoot)]
         public void Should_Remove_Drive_Letter_On_Unix()
         {
-            Assert.AreEqual("/test/", XFS.Path(@"c:\test\"));
+            Assert.That(XFS.Path(@"c:\test\"), Is.EqualTo("/test/"));
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/StringExtensionsTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/StringExtensionsTests.cs
@@ -66,55 +66,55 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [WindowsOnly(WindowsSpecifics.Drives)]
         public void TrimSlashes_DriveRoot_PreserveTrailingSlash()
         {
-            Assert.AreEqual(@"c:\", @"c:\".TrimSlashes());
+            Assert.That(@"c:\".TrimSlashes(), Is.EqualTo(@"c:\"));
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.Drives)]
         public void TrimSlashes_DriveRoot_AppendsTrailingSlash()
         {
-            Assert.AreEqual(@"c:\", @"c:".TrimSlashes());
+            Assert.That(@"c:".TrimSlashes(), Is.EqualTo(@"c:\"));
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.Drives)]
         public void TrimSlashes_DriveRoot_TrimsExcessTrailingSlash()
         {
-            Assert.AreEqual(@"c:\", @"c:\\".TrimSlashes());
+            Assert.That(@"c:\\".TrimSlashes(), Is.EqualTo(@"c:\"));
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.Drives)]
         public void TrimSlashes_DriveRoot_NormalizeAlternateSlash()
         {
-            Assert.AreEqual(@"c:\", @"c:/".TrimSlashes());
+            Assert.That(@"c:/".TrimSlashes(), Is.EqualTo(@"c:\"));
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.Drives)]
         public void TrimSlashes_RootedPath_TrimsAllTrailingSlashes()
         {
-            Assert.AreEqual(@"c:\x", @"c:\x\".TrimSlashes());
+            Assert.That(@"c:\x\".TrimSlashes(), Is.EqualTo(@"c:\x"));
         }
 
         [Test]
         public void TrimSlashes_RootedPath_DoNotAlterPathWithoutTrailingSlashes()
         {
-            Assert.AreEqual(XFS.Path(@"c:\x"), XFS.Path(@"c:\x").TrimSlashes());
+            Assert.That(XFS.Path(@"c:\x").TrimSlashes(), Is.EqualTo(XFS.Path(@"c:\x")));
         }
 
         [Test]
         [UnixOnly(UnixSpecifics.SlashRoot)]
         public void TrimSlashes_SlashRoot_TrimsExcessTrailingSlash()
         {
-            Assert.AreEqual("/", "//".TrimSlashes());
+            Assert.That("//".TrimSlashes(), Is.EqualTo("/"));
         }
 
         [Test]
         [UnixOnly(UnixSpecifics.SlashRoot)]
         public void TrimSlashes_SlashRoot_PreserveSlashRoot()
         {
-            Assert.AreEqual("/", "/".TrimSlashes());
+            Assert.That("/".TrimSlashes(), Is.EqualTo("/"));
         }
 
         [TestCase(@"\\unc\folder\file.txt", @"\\unc\folder\file.txt")]
@@ -122,7 +122,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [WindowsOnly(WindowsSpecifics.UNCPaths)]
         public void NormalizeSlashes_KeepsUNCPathPrefix(string path, string expectedValue)
         {
-            Assert.AreEqual(expectedValue, path.NormalizeSlashes());
+            Assert.That(path.NormalizeSlashes(), Is.EqualTo(expectedValue));
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests.csproj
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests.csproj
@@ -34,7 +34,8 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="nunit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.10.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests.csproj
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests.csproj
@@ -35,7 +35,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="NUnit" Version="3.14.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.10.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.10.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/ConvertersTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/ConvertersTests.cs
@@ -55,21 +55,21 @@ namespace System.IO.Abstractions.Tests
         [Test]
         public void WrapFileSystemInfo_handles_null_FileSystemInfo()
         {
-            Assert.IsNull(Converters.WrapFileSystemInfo(null, new FileSystem()));
+            Assert.That(Converters.WrapFileSystemInfo(null, new FileSystem()), Is.Null);
         }
 
         [Test]
         public void WrapDirectories_handles_null_DirectoryInfo()
         {
             List<DirectoryInfo> directoryInfos = new() { null };
-            Assert.IsNull(directoryInfos.WrapDirectories(new FileSystem()).Single());
+            Assert.That(directoryInfos.WrapDirectories(new FileSystem()).Single(), Is.Null);
         }
 
         [Test]
         public void WrapFiles_handles_null_FileInfo()
         {
             List<FileInfo> fileInfos = new() { null };
-            Assert.IsNull(fileInfos.WrapFiles(new FileSystem()).Single());
+            Assert.That(fileInfos.WrapFiles(new FileSystem()).Single(), Is.Null);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/DirectoryInfoFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/DirectoryInfoFactoryTests.cs
@@ -12,7 +12,7 @@ namespace System.IO.Abstractions.Tests
 
             var result = fileSystem.DirectoryInfo.Wrap(null);
             
-            Assert.IsNull(result);
+            Assert.That(result, Is.Null);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/DirectoryInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/DirectoryInfoTests.cs
@@ -13,7 +13,7 @@ namespace System.IO.Abstractions.Tests
             var current = wrapperFilesystem.Directory.GetCurrentDirectory();
             var root = wrapperFilesystem.DirectoryInfo.New(current).Root;
             var rootsParent = root.Parent;
-            Assert.IsNull(rootsParent);
+            Assert.That(rootsParent, Is.Null);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/DirectoryWrapperTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/DirectoryWrapperTests.cs
@@ -31,7 +31,7 @@ namespace System.IO.Abstractions.Tests
             var result = wrapperFilesystem.Directory.GetParent(subfolder);
 
             // Assert
-            Assert.AreEqual(root, result.FullName);
+            Assert.That(result.FullName, Is.EqualTo(root));
         }
 
         [Test]
@@ -47,7 +47,7 @@ namespace System.IO.Abstractions.Tests
             var result = wrapperFilesystem.Directory.GetParent(file);
 
             // Assert
-            Assert.AreEqual(subfolder, result.FullName);
+            Assert.That(result.FullName, Is.EqualTo(subfolder));
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/DirectoryWrapperTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/DirectoryWrapperTests.cs
@@ -16,7 +16,7 @@ namespace System.IO.Abstractions.Tests
             var result = wrapperFilesystem.Directory.GetParent(root);
 
             // Assert
-            Assert.IsNull(result);
+            Assert.That(result, Is.Null);
         }
 
         [Test]

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/DriveInfoFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/DriveInfoFactoryTests.cs
@@ -11,8 +11,8 @@ namespace System.IO.Abstractions.Tests
             var fileSystem = new FileSystem();
 
             var result = fileSystem.DriveInfo.Wrap(null);
-            
-            Assert.IsNull(result);
+
+            Assert.That(result, Is.Null);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/FileInfoBaseConversionTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/FileInfoBaseConversionTests.cs
@@ -20,7 +20,7 @@
             FileInfoBase actual = fileInfo;
 
             // Assert
-            Assert.IsNull(actual);
+            Assert.That(actual, Is.Null);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/FileInfoFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/FileInfoFactoryTests.cs
@@ -12,7 +12,7 @@ namespace System.IO.Abstractions.Tests
 
             var result = fileSystem.FileInfo.Wrap(null);
             
-            Assert.IsNull(result);
+            Assert.That(result, Is.Null);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/FileSystemWatcherFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/FileSystemWatcherFactoryTests.cs
@@ -12,7 +12,7 @@ namespace System.IO.Abstractions.Tests
 
             var result = fileSystem.FileSystemWatcher.Wrap(null);
             
-            Assert.IsNull(result);
+            Assert.That(result, Is.Null);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/TestableIO.System.IO.Abstractions.Wrappers.Tests.csproj
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/TestableIO.System.IO.Abstractions.Wrappers.Tests.csproj
@@ -19,7 +19,8 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="nunit" Version="3.14.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.10.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="Snapshooter.NUnit" Version="0.13.0" />
   </ItemGroup>


### PR DESCRIPTION
Convert NUnit asserts to the constraint model, to simplify the [migration to NUnit v4](https://docs.nunit.org/articles/nunit/release-notes/Nunit4.0-MigrationGuide.html)