### PR TITLE
fix: use correct path for wrapped `FileInfo` and `DirectoryInfo`

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectoryInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectoryInfoFactory.cs
@@ -40,7 +40,7 @@ namespace System.IO.Abstractions.TestingHelpers
                 return null;
             }
 
-            return new MockDirectoryInfo(mockFileSystem, directoryInfo.Name);
+            return new MockDirectoryInfo(mockFileSystem, directoryInfo.FullName);
         }
     }
 }

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileInfoFactory.cs
@@ -39,7 +39,7 @@
                 return null;
             }
 
-            return new MockFileInfo(mockFileSystem, fileInfo.Name);
+            return new MockFileInfo(mockFileSystem, fileInfo.FullName);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoFactoryTests.cs
@@ -14,5 +14,16 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             
             Assert.That(result, Is.Null);
         }
+
+        [Test]
+        public void MockDirectoryInfoFactory_Wrap_ShouldKeepNameAndFullName()
+        {
+            var fs = new MockFileSystem();
+            var directoryInfo = new DirectoryInfo(@"C:\subfolder\file");
+            var wrappedDirectoryInfo = fs.DirectoryInfo.Wrap(directoryInfo);
+
+            Assert.That(wrappedDirectoryInfo.FullName, Is.EqualTo(directoryInfo.FullName));
+            Assert.That(wrappedDirectoryInfo.Name, Is.EqualTo(directoryInfo.Name));
+        }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoFactoryTests.cs
@@ -51,5 +51,16 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.That(result, Is.Null);
         }
+
+        [Test]
+        public void MockFileInfoFactory_Wrap_ShouldKeepNameAndFullName()
+        {
+            var fs = new MockFileSystem();
+            var fileInfo = new FileInfo(@"C:\subfolder\file");
+            var wrappedFileInfo = fs.FileInfo.Wrap(fileInfo);
+
+            Assert.That(wrappedFileInfo.FullName, Is.EqualTo(fileInfo.FullName));
+            Assert.That(wrappedFileInfo.Name, Is.EqualTo(fileInfo.Name));
+        }
     }
 }


### PR DESCRIPTION
Use the full path when wrapping a `FileInfo` or `DirectoryInfo` to preserve the relevant information.

*Fixes #1049*