### PR TITLE
feat: add testability for `DriveInfo`

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/IMockFileDataAccessor.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/IMockFileDataAccessor.cs
@@ -24,12 +24,23 @@ namespace System.IO.Abstractions.TestingHelpers
         MockFileData GetFile(string path);
 
         /// <summary>
+        /// Gets a drive.
+        /// </summary>
+        /// <param name="name">The name of the drive to get.</param>
+        /// <returns>The drive. <see langword="null"/> if the drive does not exist.</returns>
+        MockDriveData GetDrive(string name);
+
+        /// <summary>
         /// </summary>
         void AddFile(string path, MockFileData mockFile);
 
         /// <summary>
         /// </summary>
         void AddDirectory(string path);
+
+        /// <summary>
+        /// </summary>
+        void AddDrive(string name, MockDriveData mockDrive);
 
         /// <summary>
         /// </summary>
@@ -73,6 +84,11 @@ namespace System.IO.Abstractions.TestingHelpers
         /// Gets the paths of all directories.
         /// </summary>
         IEnumerable<string> AllDirectories { get; }
+
+        /// <summary>
+        /// Gets the names of all drives.
+        /// </summary>
+        IEnumerable<string> AllDrives { get; }
 
         /// <summary>
         /// Gets a helper for string operations.

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDriveData.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDriveData.cs
@@ -1,0 +1,76 @@
+﻿
+namespace System.IO.Abstractions.TestingHelpers
+{
+    /// <summary>
+    /// The class represents the associated data of a drive.
+    /// </summary>
+#if FEATURE_SERIALIZABLE
+    [Serializable]
+#endif
+    public class MockDriveData
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MockDriveData"/> class.
+        /// </summary>
+        public MockDriveData()
+        {
+            IsReady = true;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MockDriveData"/> class by copying the given <see cref="MockDriveData"/>.
+        /// </summary>
+        /// <param name="template">The template instance.</param>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="template"/> is <see langword="null"/>.</exception>
+        public MockDriveData(MockDriveData template)
+        {
+            if (template == null)
+            {
+                throw new ArgumentNullException(nameof(template));
+            }
+
+            AvailableFreeSpace = template.AvailableFreeSpace;
+            DriveFormat = template.DriveFormat;
+            DriveType = template.DriveType;
+            IsReady = template.IsReady;
+            TotalFreeSpace = template.TotalFreeSpace;
+            TotalSize = template.TotalSize;
+            VolumeLabel = template.VolumeLabel;
+        }
+
+        /// <summary>
+        /// Gets or sets the amount of available free space of the <see cref="MockDriveData"/>, in bytes.
+        /// </summary>
+        public long AvailableFreeSpace { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the file system of the <see cref="MockDriveData"/>, such as NTFS or FAT32.
+        /// </summary>
+        public string DriveFormat { get; set; }
+
+        /// <summary>
+        /// Gets or sets the drive type of the <see cref="MockDriveData"/>, such as CD-ROM, removable, network, or fixed.
+        /// </summary>
+        public DriveType DriveType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value that indicates whether the <see cref="MockDriveData"/> is ready.
+        /// </summary>
+        public bool IsReady { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total amount of free space available on the <see cref="MockDriveData"/>, in bytes.
+        /// </summary>
+        public long TotalFreeSpace { get; set; }
+
+        /// <summary>
+        /// Gets or sets the total size of storage space on the <see cref="MockDriveData"/>, in bytes.
+        /// </summary>
+        public long TotalSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the volume label of the <see cref="MockDriveData"/>.
+        /// </summary>
+        public string VolumeLabel { get; set; }
+    }
+}

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDriveInfo.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDriveInfo.cs
@@ -7,51 +7,60 @@
     public class MockDriveInfo : DriveInfoBase
     {
         private readonly IMockFileDataAccessor mockFileDataAccessor;
+        private readonly string name;
 
         /// <inheritdoc />
         public MockDriveInfo(IMockFileDataAccessor mockFileDataAccessor, string name) : base(mockFileDataAccessor?.FileSystem)
         {
             this.mockFileDataAccessor = mockFileDataAccessor ?? throw new ArgumentNullException(nameof(mockFileDataAccessor));
-
-            if (name == null)
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
-
-            const string DRIVE_SEPARATOR = @":\";
-
-            if (name.Length == 1
-                || (name.Length == 2 && name[1] == ':')
-                || (name.Length == 3 && mockFileDataAccessor.StringOperations.EndsWith(name, DRIVE_SEPARATOR)))
-            {
-                name = name[0] + DRIVE_SEPARATOR;
-            }
-            else
-            {
-                mockFileDataAccessor.PathVerifier.CheckInvalidPathChars(name);
-                name = mockFileDataAccessor.Path.GetPathRoot(name);
-
-                if (string.IsNullOrEmpty(name) || mockFileDataAccessor.StringOperations.StartsWith(name, @"\\"))
-                {
-                    throw new ArgumentException(
-                        @"Object must be a root directory (""C:\"") or a drive letter (""C"").");
-                }
-            }
-
-            Name = name;
-            IsReady = true;
+            this.name = mockFileDataAccessor.PathVerifier.NormalizeDriveName(name);
         }
 
         /// <inheritdoc />
-        public new long AvailableFreeSpace { get; set; }
+        public override long AvailableFreeSpace
+        {
+            get
+            {
+                var mockDriveData = GetMockDriveData();
+                return mockDriveData.AvailableFreeSpace;
+            }
+        }
+
         /// <inheritdoc />
-        public new string DriveFormat { get; set; }
+        public override string DriveFormat
+        {
+            get
+            {
+                var mockDriveData = GetMockDriveData();
+                return mockDriveData.DriveFormat;
+            }
+        }
+
         /// <inheritdoc />
-        public new DriveType DriveType { get; set; }
+        public override DriveType DriveType
+        {
+            get
+            {
+                var mockDriveData = GetMockDriveData();
+                return mockDriveData.DriveType;
+            }
+        }
+
         /// <inheritdoc />
-        public new bool IsReady { get; protected set; }
+        public override bool IsReady
+        {
+            get
+            {
+                var mockDriveData = GetMockDriveData();
+                return mockDriveData.IsReady;
+            }
+        }
+
         /// <inheritdoc />
-        public override string Name { get; protected set; }
+        public override string Name
+        {
+            get { return name; }
+        }
 
         /// <inheritdoc />
         public override IDirectoryInfo RootDirectory
@@ -63,16 +72,50 @@
         }
 
         /// <inheritdoc />
+        public override long TotalFreeSpace
+        {
+            get
+            {
+                var mockDriveData = GetMockDriveData();
+                return mockDriveData.TotalFreeSpace;
+            }
+        }
+
+        /// <inheritdoc />
+        public override long TotalSize
+        {
+            get
+            {
+                var mockDriveData = GetMockDriveData();
+                return mockDriveData.TotalSize;
+            }
+        }
+
+        /// <inheritdoc />
+        public override string VolumeLabel
+        {
+            get
+            {
+                var mockDriveData = GetMockDriveData();
+                return mockDriveData.VolumeLabel;
+            }
+            set
+            {
+                var mockDriveData = GetMockDriveData();
+                mockDriveData.VolumeLabel = value;
+            }
+        }
+
+        /// <inheritdoc />
         public override string ToString()
         {
             return Name;
         }
 
-        /// <inheritdoc />
-        public new long TotalFreeSpace { get; protected set; }
-        /// <inheritdoc />
-        public new long TotalSize { get; protected set; }
-        /// <inheritdoc />
-        public override string VolumeLabel { get; set; }
+        private MockDriveData GetMockDriveData()
+        {
+            return mockFileDataAccessor.GetDrive(name)
+                ?? throw CommonExceptions.FileNotFound(name);
+        }
     }
 }

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDriveInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDriveInfoFactory.cs
@@ -23,15 +23,8 @@ namespace System.IO.Abstractions.TestingHelpers
         /// <inheritdoc />
         public IDriveInfo[] GetDrives()
         {
-            var driveLetters = new HashSet<string>(new DriveEqualityComparer(mockFileSystem));
-            foreach (var path in mockFileSystem.AllPaths)
-            {
-                var pathRoot = mockFileSystem.Path.GetPathRoot(path);
-                driveLetters.Add(pathRoot);
-            }
-
             var result = new List<DriveInfoBase>();
-            foreach (string driveLetter in driveLetters)
+            foreach (string driveLetter in mockFileSystem.AllDrives)
             {
                 try
                 {

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/PathVerifier.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/PathVerifier.cs
@@ -118,5 +118,38 @@ namespace System.IO.Abstractions.TestingHelpers
                 throw CommonExceptions.IllegalCharactersInPath();
             }
         }
+
+        /// <summary>
+        /// Determines the normalized drive name used for drive identification.
+        /// </summary>
+        public string NormalizeDriveName(string name)
+        {
+            if (name == null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            const string DRIVE_SEPARATOR = @":\";
+
+            if (name.Length == 1
+                || (name.Length == 2 && name[1] == ':')
+                || (name.Length == 3 && _mockFileDataAccessor.StringOperations.EndsWith(name, DRIVE_SEPARATOR)))
+            {
+                name = name[0] + DRIVE_SEPARATOR;
+            }
+            else
+            {
+                CheckInvalidPathChars(name);
+                name = _mockFileDataAccessor.Path.GetPathRoot(name);
+
+                if (string.IsNullOrEmpty(name) || _mockFileDataAccessor.StringOperations.StartsWith(name, @"\\"))
+                {
+                    throw new ArgumentException(
+                        @"Object must be a root directory (""C:\"") or a drive letter (""C"").");
+                }
+            }
+
+            return name;
+        }
     }
 }

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/PathVerifier.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/PathVerifier.cs
@@ -122,7 +122,19 @@ namespace System.IO.Abstractions.TestingHelpers
         /// <summary>
         /// Determines the normalized drive name used for drive identification.
         /// </summary>
+        /// <exception cref="ArgumentException">Thrown if the <paramref name="name"/> is not a valid drive name.</exception>
         public string NormalizeDriveName(string name)
+        {
+            return TryNormalizeDriveName(name, out var result)
+                ? result
+                : throw new ArgumentException(
+                      @"Object must be a root directory (""C:\"") or a drive letter (""C"").");
+        }
+
+        /// <summary>
+        /// Tries to determine the normalized drive name used for drive identification.
+        /// </summary>
+        public bool TryNormalizeDriveName(string name, out string result)
         {
             if (name == null)
             {
@@ -144,12 +156,13 @@ namespace System.IO.Abstractions.TestingHelpers
 
                 if (string.IsNullOrEmpty(name) || _mockFileDataAccessor.StringOperations.StartsWith(name, @"\\"))
                 {
-                    throw new ArgumentException(
-                        @"Object must be a root directory (""C:\"") or a drive letter (""C"").");
+                    result = null;
+                    return false;
                 }
             }
 
-            return name;
+            result = name;
+            return true;
         }
     }
 }

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DriveInfoBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DriveInfoBase.cs
@@ -20,118 +20,32 @@
         /// </summary>
         public IFileSystem FileSystem { get; }
 
-        /// <inheritdoc cref="DriveInfo.AvailableFreeSpace"/>
-        /// <summary>
-        /// Gets or sets the amount of available free space on a drive, in bytes.
-        /// </summary>
-        /// <value>The amount of free space available on the drive, in bytes.</value>
-        /// <remarks>
-        /// This property indicates the amount of free space available on the drive.
-        /// Note that this number may be different from the TotalFreeSpace number because this property takes into account disk quotas.
-        /// </remarks>
-        /// <exception cref="UnauthorizedAccessException">Thrown if the access to the drive information is denied.</exception>
-        /// <exception cref="IOException">Thrown if an I/O error occurred (for example, a disk error or a drive was not ready).</exception>
-        public virtual long AvailableFreeSpace { get; protected set; }
+        /// <inheritdoc cref="IDriveInfo.AvailableFreeSpace"/>
+        public abstract long AvailableFreeSpace { get; }
 
-        /// <inheritdoc cref="DriveInfo.DriveFormat"/>
-        /// <summary>
-        /// Gets or sets the name of the file system, such as NTFS or FAT32.
-        /// </summary>
-        /// <remarks>
-        /// Use DriveFormat to determine what formatting a drive uses.
-        /// </remarks>
-        /// <value>The name of the file system on the specified drive.</value>
-        /// <exception cref="UnauthorizedAccessException">Thrown if the access to the drive information is denied.</exception>
-        /// <exception cref="DriveNotFoundException">Thrown if the drive does not exist or is not mapped.</exception>
-        /// <exception cref="IOException">Thrown if an I/O error occurred (for example, a disk error or a drive was not ready).</exception>
-        public virtual string DriveFormat { get; protected set; }
+        /// <inheritdoc cref="IDriveInfo.DriveFormat"/>
+        public abstract string DriveFormat { get; }
 
-        /// <inheritdoc cref="DriveInfo.DriveType"/>
-        /// <summary>
-        /// Gets or sets the drive type, such as CD-ROM, removable, network, or fixed.
-        /// </summary>
-        /// <value>One of the enumeration values that specifies a drive type.</value>
-        /// <remarks>
-        /// The DriveType property indicates whether a drive is one of the following: CDRom, Fixed, Network, NoRootDirectory, Ram, Removable, or Unknown.
-        /// These values are described in the DriveType enumeration.
-        /// </remarks>
-        public virtual DriveType DriveType { get; protected set; }
+        /// <inheritdoc cref="IDriveInfo.DriveType"/>
+        public abstract DriveType DriveType { get; }
 
-        /// <inheritdoc cref="DriveInfo.IsReady"/>
-        /// <summary>
-        /// Gets or sets a value indicating whether a drive is ready.
-        /// </summary>
-        /// <value>
-        /// <see langword="true"/> if the drive is ready; <see langword="false"/> if the drive is not ready.
-        /// </value>
-        /// <remarks>
-        /// IsReady indicates whether a drive is ready.
-        /// For example, it indicates whether a CD is in a CD drive or whether a removable storage device is ready for read/write operations.
-        /// If you do not test whether a drive is ready, and it is not ready, querying the drive using <see cref="DriveInfoBase"/> will raise an IOException.
-        /// Do not rely on IsReady to avoid catching exceptions from other members such as TotalSize, TotalFreeSpace, and <see cref="DriveFormat"/>.
-        /// Between the time that your code checks IsReady and then accesses one of the other properties (even if the access occurs immediately after the check),
-        ///  a drive may have been disconnected or a disk may have been removed.
-        /// </remarks>
-        public virtual bool IsReady { get; protected set; }
+        /// <inheritdoc cref="IDriveInfo.IsReady"/>
+        public abstract bool IsReady { get; }
 
-        /// <inheritdoc cref="DriveInfo.Name"/>
-        /// <summary>
-        /// Gets or sets the name of a drive, such as C:\.
-        /// </summary>
-        /// <value>The name of the drive.</value>
-        /// <remarks>
-        /// This property is the name assigned to the drive, such as C:\ or E:\.
-        /// </remarks>
-        public virtual string Name { get; protected set; }
+        /// <inheritdoc cref="IDriveInfo.Name"/>
+        public abstract string Name { get; }
 
-        /// <inheritdoc cref="DriveInfo.RootDirectory"/>
-        /// <summary>
-        /// Gets or sets the root directory of a drive.
-        /// </summary>
-        /// <value>An object that contains the root directory of the drive.</value>
-        public virtual IDirectoryInfo RootDirectory { get; protected set; }
+        /// <inheritdoc cref="IDriveInfo.RootDirectory"/>
+        public abstract IDirectoryInfo RootDirectory { get; }
 
-        /// <inheritdoc cref="DriveInfo.TotalFreeSpace"/>
-        /// <summary>
-        /// Gets or sets the total amount of free space available on a drive, in bytes.
-        /// </summary>
-        /// <value>The total free space available on a drive, in bytes.</value>
-        /// <remarks>This property indicates the total amount of free space available on the drive, not just what is available to the current user.</remarks>
-        /// <exception cref="UnauthorizedAccessException">Thrown if the access to the drive information is denied.</exception>
-        /// <exception cref="DriveNotFoundException">Thrown if the drive does not exist or is not mapped.</exception>
-        /// <exception cref="IOException">Thrown if an I/O error occurred (for example, a disk error or a drive was not ready).</exception>
-        public virtual long TotalFreeSpace { get; protected set; }
+        /// <inheritdoc cref="IDriveInfo.TotalFreeSpace"/>
+        public abstract long TotalFreeSpace { get; }
 
-        /// <inheritdoc cref="DriveInfo.TotalSize"/>
-        /// <summary>
-        /// Gets or sets the total size of storage space on a drive, in bytes.
-        /// </summary>
-        /// <value>The total size of the drive, in bytes.</value>
-        /// <remarks>
-        /// This property indicates the total size of the drive in bytes, not just what is available to the current user.
-        /// </remarks>
-        /// <exception cref="UnauthorizedAccessException">Thrown if the access to the drive information is denied.</exception>
-        /// <exception cref="DriveNotFoundException">Thrown if the drive does not exist or is not mapped.</exception>
-        /// <exception cref="IOException">Thrown if an I/O error occurred (for example, a disk error or a drive was not ready).</exception>
-        public virtual long TotalSize { get; protected set; }
+        /// <inheritdoc cref="IDriveInfo.TotalSize"/>
+        public abstract long TotalSize { get; }
 
-        /// <inheritdoc cref="DriveInfo.VolumeLabel"/>
-        /// <summary>
-        /// Gets or sets the volume label of a drive.
-        /// </summary>
-        /// <value>The volume label.</value>
-        /// <remarks>
-        /// The label length is determined by the operating system. For example, NTFS allows a volume label to be up to 32 characters long. Note that <see langword="null"/> is a valid VolumeLabel.
-        /// </remarks>
-        /// <exception cref="IOException">Thrown if an I/O error occurred (for example, a disk error or a drive was not ready).</exception>
-        /// <exception cref="DriveNotFoundException">Thrown if the drive does not exist or is not mapped.</exception>
-        /// <exception cref="System.Security.SecurityException">Thrown if the caller does not have the required permission.</exception>
-        /// <exception cref="UnauthorizedAccessException">
-        /// Thrown if the volume label is being set on a network or CD-ROM drive
-        /// -or-
-        /// Access to the drive information is denied.
-        /// </exception>
-        public virtual string VolumeLabel { get; set; }
+        /// <inheritdoc cref="IDriveInfo.VolumeLabel"/>
+        public abstract string VolumeLabel { get; set; }
 
         /// <summary>
         /// Converts a <see cref="DriveInfo"/> into a <see cref="DriveInfoBase"/>.

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDriveInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDriveInfoTests.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using System.Linq;
 
 namespace System.IO.Abstractions.TestingHelpers.Tests
 {
@@ -93,10 +94,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var driveData = new MockDriveData { AvailableFreeSpace = availableFreeSpace };
             var fileSystem = new MockFileSystem();
             fileSystem.AddDrive("C:", driveData);
-            var mockDriveInfo = new MockDriveInfo(fileSystem, "C:");
+            var driveInfo = fileSystem.DriveInfo
+                .GetDrives()
+                .Single(x => x.Name == @"C:\");
 
             // Act
-            var result = mockDriveInfo.AvailableFreeSpace;
+            var result = driveInfo.AvailableFreeSpace;
 
             // Assert
             Assert.That(result, Is.EqualTo(availableFreeSpace));
@@ -110,10 +113,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var driveData = new MockDriveData { DriveFormat = driveFormat };
             var fileSystem = new MockFileSystem();
             fileSystem.AddDrive("C:", driveData);
-            var mockDriveInfo = new MockDriveInfo(fileSystem, "C:");
+            var driveInfo = fileSystem.DriveInfo
+                .GetDrives()
+                .Single(x => x.Name == @"C:\");
 
             // Act
-            var result = mockDriveInfo.DriveFormat;
+            var result = driveInfo.DriveFormat;
 
             // Assert
             Assert.That(result, Is.EqualTo(driveFormat));
@@ -127,10 +132,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var driveData = new MockDriveData { DriveType = driveType };
             var fileSystem = new MockFileSystem();
             fileSystem.AddDrive("C:", driveData);
-            var mockDriveInfo = new MockDriveInfo(fileSystem, "C:");
+            var driveInfo = fileSystem.DriveInfo
+                .GetDrives()
+                .Single(x => x.Name == @"C:\");
 
             // Act
-            var result = mockDriveInfo.DriveType;
+            var result = driveInfo.DriveType;
 
             // Assert
             Assert.That(result, Is.EqualTo(driveType));
@@ -144,10 +151,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var driveData = new MockDriveData { IsReady = isReady };
             var fileSystem = new MockFileSystem();
             fileSystem.AddDrive("C:", driveData);
-            var mockDriveInfo = new MockDriveInfo(fileSystem, "C:");
+            var driveInfo = fileSystem.DriveInfo
+                .GetDrives()
+                .Single(x => x.Name == @"C:\");
 
             // Act
-            var result = mockDriveInfo.IsReady;
+            var result = driveInfo.IsReady;
 
             // Assert
             Assert.That(result, Is.EqualTo(isReady));
@@ -161,10 +170,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var driveData = new MockDriveData { TotalFreeSpace = totalFreeSpace };
             var fileSystem = new MockFileSystem();
             fileSystem.AddDrive("C:", driveData);
-            var mockDriveInfo = new MockDriveInfo(fileSystem, "C:");
+            var driveInfo = fileSystem.DriveInfo
+                .GetDrives()
+                .Single(x => x.Name == @"C:\");
 
             // Act
-            var result = mockDriveInfo.TotalFreeSpace;
+            var result = driveInfo.TotalFreeSpace;
 
             // Assert
             Assert.That(result, Is.EqualTo(totalFreeSpace));
@@ -178,10 +189,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var driveData = new MockDriveData { TotalSize = totalSize };
             var fileSystem = new MockFileSystem();
             fileSystem.AddDrive("C:", driveData);
-            var mockDriveInfo = new MockDriveInfo(fileSystem, "C:");
+            var driveInfo = fileSystem.DriveInfo
+                .GetDrives()
+                .Single(x => x.Name == @"C:\");
 
             // Act
-            var result = mockDriveInfo.TotalSize;
+            var result = driveInfo.TotalSize;
 
             // Assert
             Assert.That(result, Is.EqualTo(totalSize));
@@ -195,10 +208,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var driveData = new MockDriveData { VolumeLabel = volumeLabel };
             var fileSystem = new MockFileSystem();
             fileSystem.AddDrive("C:", driveData);
-            var mockDriveInfo = new MockDriveInfo(fileSystem, "C:");
+            var driveInfo = fileSystem.DriveInfo
+                .GetDrives()
+                .Single(x => x.Name == @"C:\");
 
             // Act
-            var result = mockDriveInfo.VolumeLabel;
+            var result = driveInfo.VolumeLabel;
 
             // Assert
             Assert.That(result, Is.EqualTo(volumeLabel));

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDriveInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDriveInfoTests.cs
@@ -84,5 +84,124 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Assert
             Assert.That(mockDriveInfo.ToString(), Is.EqualTo(expectedPath));
         }
+
+        [Test]
+        public void MockDriveInfo_AvailableFreeSpace_ShouldReturnAvailableFreeSpaceOfDriveInMemoryFileSystem()
+        {
+            // Arrange
+            var availableFreeSpace = 1024L;
+            var driveData = new MockDriveData { AvailableFreeSpace = availableFreeSpace };
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDrive("C:", driveData);
+            var mockDriveInfo = new MockDriveInfo(fileSystem, "C:");
+
+            // Act
+            var result = mockDriveInfo.AvailableFreeSpace;
+
+            // Assert
+            Assert.That(result, Is.EqualTo(availableFreeSpace));
+        }
+
+        [Test]
+        public void MockDriveInfo_DriveFormat_ShouldReturnDriveFormatOfDriveInMemoryFileSystem()
+        {
+            // Arrange
+            var driveFormat = "NTFS";
+            var driveData = new MockDriveData { DriveFormat = driveFormat };
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDrive("C:", driveData);
+            var mockDriveInfo = new MockDriveInfo(fileSystem, "C:");
+
+            // Act
+            var result = mockDriveInfo.DriveFormat;
+
+            // Assert
+            Assert.That(result, Is.EqualTo(driveFormat));
+        }
+
+        [Test]
+        public void MockDriveInfo_DriveType_ShouldReturnDriveTypeOfDriveInMemoryFileSystem()
+        {
+            // Arrange
+            var driveType = DriveType.Fixed;
+            var driveData = new MockDriveData { DriveType = driveType };
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDrive("C:", driveData);
+            var mockDriveInfo = new MockDriveInfo(fileSystem, "C:");
+
+            // Act
+            var result = mockDriveInfo.DriveType;
+
+            // Assert
+            Assert.That(result, Is.EqualTo(driveType));
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void MockDriveInfo_IsReady_ShouldReturnIsReadyOfDriveInMemoryFileSystem(bool isReady)
+        {
+            // Arrange
+            var driveData = new MockDriveData { IsReady = isReady };
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDrive("C:", driveData);
+            var mockDriveInfo = new MockDriveInfo(fileSystem, "C:");
+
+            // Act
+            var result = mockDriveInfo.IsReady;
+
+            // Assert
+            Assert.That(result, Is.EqualTo(isReady));
+        }
+
+        [Test]
+        public void MockDriveInfo_TotalFreeSpace_ShouldReturnTotalFreeSpaceOfDriveInMemoryFileSystem()
+        {
+            // Arrange
+            var totalFreeSpace = 4096L;
+            var driveData = new MockDriveData { TotalFreeSpace = totalFreeSpace };
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDrive("C:", driveData);
+            var mockDriveInfo = new MockDriveInfo(fileSystem, "C:");
+
+            // Act
+            var result = mockDriveInfo.TotalFreeSpace;
+
+            // Assert
+            Assert.That(result, Is.EqualTo(totalFreeSpace));
+        }
+
+        [Test]
+        public void MockDriveInfo_TotalSize_ShouldReturnTotalSizeOfDriveInMemoryFileSystem()
+        {
+            // Arrange
+            var totalSize = 8192L;
+            var driveData = new MockDriveData { TotalSize = totalSize };
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDrive("C:", driveData);
+            var mockDriveInfo = new MockDriveInfo(fileSystem, "C:");
+
+            // Act
+            var result = mockDriveInfo.TotalSize;
+
+            // Assert
+            Assert.That(result, Is.EqualTo(totalSize));
+        }
+
+        [Test]
+        public void MockDriveInfo_VolumeLabel_ShouldReturnVolumeLabelOfDriveInMemoryFileSystem()
+        {
+            // Arrange
+            var volumeLabel = "Windows";
+            var driveData = new MockDriveData { VolumeLabel = volumeLabel };
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDrive("C:", driveData);
+            var mockDriveInfo = new MockDriveInfo(fileSystem, "C:");
+
+            // Act
+            var result = mockDriveInfo.VolumeLabel;
+
+            // Assert
+            Assert.That(result, Is.EqualTo(volumeLabel));
+        }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -208,6 +208,18 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockFileSystem_AddDrive_ShouldExist()
+        {
+            string name = @"D:\";
+            var fileSystem = new MockFileSystem();
+            fileSystem.AddDrive(name, new MockDriveData());
+
+            var actualResults = fileSystem.DriveInfo.GetDrives().Select(d => d.Name);
+
+            Assert.That(actualResults, Does.Contain(name));
+        }
+
+        [Test]
         public void MockFileSystem_DriveInfo_ShouldNotThrowAnyException()
         {
             var fileSystem = new MockFileSystem();


### PR DESCRIPTION
Fixes #826 

This adds the possibility to add drives to the `MockFileSystem` together with a `MockDriveData` that can be used to configure the various properties of the drive (free space, type, etc.).