### PR TITLE
fix: remove unused .NET versions in CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: | 
-            3.1.x
-            5.0.x
             6.0.x
             7.0.x
             8.0.x


### PR DESCRIPTION
Remove no longer used .NET SDK versions `3.1` and `5.0`.