### PR TITLE
fix!: support exclamation mark in conventional commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,9 @@ jobs:
       github.event_name == 'push' &&
       (
         startsWith(github.event.head_commit.message, 'feat:') ||
+        startsWith(github.event.head_commit.message, 'feat!:') ||
         startsWith(github.event.head_commit.message, 'fix:') ||
+        startsWith(github.event.head_commit.message, 'fix!:') ||
         contains(github.event.head_commit.message, 'breaking change')
       )
     needs: [pack]


### PR DESCRIPTION
According to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) breaking changes could be indicated via an exclamation mark (e.g. `feat!:` or `fix!:`).
Adapt the build pipeline, so that also breaking changes are deployed.