### PR TITLE
refactor: fix copyright year for nuget packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <Product>System.IO.Abstractions</Product>
-    <Copyright>Copyright © Tatham Oddie &amp; friends 2010-2022</Copyright>
+    <Copyright>Copyright © Tatham Oddie &amp; friends 2010-2024</Copyright>
     <Authors>Tatham Oddie &amp; friends</Authors>
     <SignAssembly Condition="'$(Configuration)' == 'Release'">True</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)StrongName.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
Update the copyright year to `2024` for nuget packages.