### PR TITLE
fix: Throw correct exception if opening read-only file for writing

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileData.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileData.cs
@@ -203,17 +203,23 @@ namespace System.IO.Abstractions.TestingHelpers
         public FileShare AllowedFileShare { get; set; } = FileShare.ReadWrite | FileShare.Delete;
         /// <summary>
         /// Checks whether the file is accessible for this type of FileAccess. 
-        /// MockfileData can be configured to have FileShare.None, which indicates it is locked by a 'different process'.
+        /// MockFileData can be configured to have FileShare.None, which indicates it is locked by a 'different process'.
         /// 
         /// If the file is 'locked by a different process', an IOException will be thrown.
+        /// If the file is read-only and is accessed for writing, an UnauthorizedAccessException will be thrown.
         /// </summary>
-        /// <param name="path">The path is used in the IOException message to match the message in real life situations</param>
+        /// <param name="path">The path is used in the exception message to match the message in real life situations</param>
         /// <param name="access">The access type to check</param>
         internal void CheckFileAccess(string path, FileAccess access)
         {
             if (!AllowedFileShare.HasFlag((FileShare)access))
             {
                 throw CommonExceptions.ProcessCannotAccessFileInUse(path);
+            }
+
+            if (Attributes.HasFlag(FileAttributes.ReadOnly) && access.HasFlag(FileAccess.Write))
+            {
+                throw CommonExceptions.AccessDenied(path);
             }
         }
 

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamTests.cs
@@ -105,6 +105,52 @@
         }
 
         [Test]
+        [TestCase(FileAccess.Write)]
+        [TestCase(FileAccess.ReadWrite)]
+        public void MockFileStream_Constructor_WriteAccessOnReadOnlyFile_Throws_Exception(
+            FileAccess fileAccess)
+        {
+            // Arrange
+            var filePath = @"C:\test.txt";
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { filePath, new MockFileData("hi") { Attributes = FileAttributes.ReadOnly } }
+            });
+
+            // Act
+            Assert.Throws<UnauthorizedAccessException>(() => new MockFileStream(fileSystem, filePath, FileMode.Open, fileAccess));
+        }
+
+        [Test]
+        public void MockFileStream_Constructor_ReadAccessOnReadOnlyFile_Does_Not_Throw_Exception()
+        {
+            // Arrange
+            var filePath = @"C:\test.txt";
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { filePath, new MockFileData("hi") { Attributes = FileAttributes.ReadOnly } }
+            });
+
+            // Act
+            Assert.DoesNotThrow(() => new MockFileStream(fileSystem, filePath, FileMode.Open, FileAccess.Read));
+        }
+
+
+        [Test]
+        public void MockFileStream_Constructor_WriteAccessOnNonReadOnlyFile_Does_Not_Throw_Exception()
+        {
+            // Arrange
+            var filePath = @"C:\test.txt";
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { filePath, new MockFileData("hi") { Attributes = FileAttributes.Normal } }
+            });
+
+            // Act
+            Assert.DoesNotThrow(() => new MockFileStream(fileSystem, filePath, FileMode.Open, FileAccess.Write));
+        }
+
+        [Test]
         [TestCase(FileShare.None, FileAccess.Read)]
         [TestCase(FileShare.None, FileAccess.ReadWrite)]
         [TestCase(FileShare.None, FileAccess.Write)]


### PR DESCRIPTION
Mock classes did not match .net's behavior of throwing `UnauthorizedAccessException` when opening read-only files with `FileAccess.Write`, making it impossible to test those scenarios.

This commit fixes the mock classes so that the exception will be thrown correctly.