### PR TITLE
fix: `Path.GetTempPath` should end with directory separator

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
@@ -14,7 +14,7 @@ namespace System.IO.Abstractions.TestingHelpers
     public class MockFileSystem : FileSystemBase, IMockFileDataAccessor
     {
         private const string DEFAULT_CURRENT_DIRECTORY = @"C:\";
-        private const string TEMP_DIRECTORY = @"C:\temp";
+        private const string TEMP_DIRECTORY = @"C:\temp\";
 
         private readonly IDictionary<string, FileSystemEntry> files;
         private readonly IDictionary<string, MockDriveData> drives;

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockPathTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockPathTests.cs
@@ -383,6 +383,20 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void GetTempPath_ShouldEndWithDirectorySeparator()
+        {
+            //Arrange
+            var mockPath = new MockFileSystem().Path;
+            var directorySeparator = mockPath.DirectorySeparatorChar.ToString();
+
+            //Act
+            var result = mockPath.GetTempPath();
+
+            //Assert
+            Assert.That(result, Does.EndWith(directorySeparator));
+        }
+
+        [Test]
         [TestCase(null)]
         [TestCase("")]
         [TestCase(@"C:\temp")]


### PR DESCRIPTION
Fixes #1171 