### PR TITLE
fix: Align MockDirectory and MockFile behavior with .NET's System.IO classes

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockDirectory.cs
@@ -158,6 +158,12 @@ namespace System.IO.Abstractions.TestingHelpers
                                       " is not an empty directory.");
             }
 
+            bool isFile = !mockFileDataAccessor.GetFile(path).IsDirectory;
+            if (isFile)
+            {
+                throw new IOException("The directory name is invalid.");
+            }
+
             foreach (var affectedPath in affectedPaths)
             {
                 mockFileDataAccessor.RemoveFile(affectedPath);

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -231,6 +231,11 @@ namespace System.IO.Abstractions.TestingHelpers
                 throw CommonExceptions.ProcessCannotAccessFileInUse(path);
             }
 
+            if (file != null && file.IsDirectory)
+            {
+                throw new UnauthorizedAccessException($"Access to the path '{path}' is denied.");
+            }
+
             mockFileDataAccessor.RemoveFile(path);
         }
 

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -1019,6 +1019,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockDirectory_Delete_ShouldThrowIOException_WhenPathIsAFile()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\foo.txt"), new MockFileData("Demo text content") },
+            });
+
+            // Act
+            TestDelegate action = () => fileSystem.Directory.Delete(XFS.Path(@"c:\foo.txt"));
+
+            // Assert
+            Assert.Throws<IOException>(action);
+        }
+
+        [Test]
         public void MockDirectory_GetFileSystemEntries_Returns_Files_And_Directories()
         {
             string testPath = XFS.Path(@"c:\foo\bar.txt");

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
@@ -496,6 +496,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
+        public void MockFile_Delete_ShouldThrowUnauthorizedAccessException_WhenPathIsADirectory()
+        {
+            // Arrange
+            var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+            {
+                { XFS.Path(@"c:\bar"), new MockDirectoryData() },
+            });
+
+            // Act
+            TestDelegate action = () => fileSystem.File.Delete(XFS.Path(@"c:\bar"));
+
+            // Assert
+            Assert.Throws<UnauthorizedAccessException>(action);
+        }
+
+        [Test]
         public void MockFile_AppendText_AppendTextToAnExistingFile()
         {
             string filepath = XFS.Path(@"c:\something\does\exist.txt");


### PR DESCRIPTION
The `MockDirectory` and `MockFile` classes previously did not replicate the .NET behavior of throwing exceptions in the following scenarios:  
- Attempting to delete a directory using `MockFile`.  
- Attempting to delete a file using `MockDirectory`.  

This pull request addresses these inconsistencies by updating the mocks to correctly throw exceptions in these cases, ensuring their behavior aligns with the corresponding `System.IO` classes they are designed to mimic.