### PR TITLE
refactor: add .NET9 target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
             6.0.x
             7.0.x
             8.0.x
+            9.0.x
       - name: Run tests
         run: dotnet test --collect:"XPlat Code Coverage"  --logger "GitHubActions"
       - name: Upload coverage

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,15 +5,15 @@
     <Authors>Tatham Oddie &amp; friends</Authors>
     <SignAssembly Condition="'$(Configuration)' == 'Release'">True</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)StrongName.snk</AssemblyOriginatorKeyFile>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>latest</LangVersion>
     <PackageTags>testing</PackageTags>
     <PackageProjectUrl>https://github.com/TestableIO/System.IO.Abstractions</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <DefineConstants Condition="'$(TargetFramework)' != 'net462'">$(DefineConstants);FEATURE_FILE_SYSTEM_ACL_EXTENSIONS</DefineConstants>
-    <DefineConstants Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'netstandard2.1'">$(DefineConstants);FEATURE_ASYNC_FILE;FEATURE_ENUMERATION_OPTIONS;FEATURE_ADVANCED_PATH_OPERATIONS;FEATURE_PATH_JOIN_WITH_SPAN;FEATURE_SPAN</DefineConstants>
-    <DefineConstants Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net6.0'">$(DefineConstants);FEATURE_FILE_MOVE_WITH_OVERWRITE;FEATURE_SUPPORTED_OS_ATTRIBUTE;FEATURE_FILE_SYSTEM_WATCHER_FILTERS;FEATURE_ENDS_IN_DIRECTORY_SEPARATOR;FEATURE_PATH_JOIN_WITH_PARAMS;FEATURE_PATH_JOIN_WITH_FOUR_PATHS;FEATURE_FILE_SYSTEM_INFO_LINK_TARGET;FEATURE_CREATE_SYMBOLIC_LINK;FEATURE_FILESTREAM_OPTIONS</DefineConstants>
-    <DefineConstants Condition="'$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net7.0'">$(DefineConstants);FEATURE_PATH_EXISTS;FEATURE_FILE_SYSTEM_WATCHER_WAIT_WITH_TIMESPAN;FEATURE_FILE_ATTRIBUTES_VIA_HANDLE;FEATURE_CREATE_TEMP_SUBDIRECTORY;FEATURE_READ_LINES_ASYNC;FEATURE_UNIX_FILE_MODE</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'netstandard2.1'">$(DefineConstants);FEATURE_ASYNC_FILE;FEATURE_ENUMERATION_OPTIONS;FEATURE_ADVANCED_PATH_OPERATIONS;FEATURE_PATH_JOIN_WITH_SPAN;FEATURE_SPAN</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net6.0'">$(DefineConstants);FEATURE_FILE_MOVE_WITH_OVERWRITE;FEATURE_SUPPORTED_OS_ATTRIBUTE;FEATURE_FILE_SYSTEM_WATCHER_FILTERS;FEATURE_ENDS_IN_DIRECTORY_SEPARATOR;FEATURE_PATH_JOIN_WITH_PARAMS;FEATURE_PATH_JOIN_WITH_FOUR_PATHS;FEATURE_FILE_SYSTEM_INFO_LINK_TARGET;FEATURE_CREATE_SYMBOLIC_LINK;FEATURE_FILESTREAM_OPTIONS</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net7.0'">$(DefineConstants);FEATURE_PATH_EXISTS;FEATURE_FILE_SYSTEM_WATCHER_WAIT_WITH_TIMESPAN;FEATURE_FILE_ATTRIBUTES_VIA_HANDLE;FEATURE_CREATE_TEMP_SUBDIRECTORY;FEATURE_READ_LINES_ASYNC;FEATURE_UNIX_FILE_MODE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/System.IO.Abstractions.sln
+++ b/System.IO.Abstractions.sln
@@ -30,6 +30,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_", "_", "{BBF7AD8D-5522-48
 		version.json = version.json
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{2BE9161B-A3F3-4511-81DB-DB1DCB6375C9}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{D905E09D-6DC3-4F7C-8E83-82FADAE2C9E5}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\ci.yml = .github\workflows\ci.yml
+		.github\workflows\pr.yml = .github\workflows\pr.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -78,6 +86,8 @@ Global
 		{015B3812-E01D-479C-895D-BDDF16E798CA} = {BCEC61BD-4941-41EC-975A-ACEFC7AC1780}
 		{7105D748-1253-409F-A624-4879412EF3C2} = {BCEC61BD-4941-41EC-975A-ACEFC7AC1780}
 		{919888D2-E37D-40E7-8AD0-600F9429316D} = {BCEC61BD-4941-41EC-975A-ACEFC7AC1780}
+		{2BE9161B-A3F3-4511-81DB-DB1DCB6375C9} = {BBF7AD8D-5522-48C0-A906-00CBB72308A0}
+		{D905E09D-6DC3-4F7C-8E83-82FADAE2C9E5} = {2BE9161B-A3F3-4511-81DB-DB1DCB6375C9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8885C59C-F6A0-4C2F-A3BC-B720E9BD161F}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.405",
+    "version": "9.0.102",
     "rollForward": "latestMinor"
   }
 }

--- a/src/System.IO.Abstractions.TestingHelpers/System.IO.Abstractions.TestingHelpers.csproj
+++ b/src/System.IO.Abstractions.TestingHelpers/System.IO.Abstractions.TestingHelpers.csproj
@@ -3,7 +3,7 @@
       <AssemblyName>System.IO.Abstractions.TestingHelpers</AssemblyName>
       <RootNamespace>System.IO.Abstractions.TestingHelpers</RootNamespace>
       <Description>A set of pre-built mocks to help when testing file system interactions.</Description>
-      <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+      <TargetFrameworks>net9.0;net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
       <PackageIcon>icon_256x256.png</PackageIcon>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileStream.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileStream.cs
@@ -291,7 +291,7 @@ namespace System.IO.Abstractions.TestingHelpers
                 Seek(0, SeekOrigin.Begin);
                 /* .. read everything out */
                 var data = new byte[Length];
-                Read(data, 0, (int)Length);
+                _ = Read(data, 0, (int)Length);
                 /* restore to original position */
                 Seek(position, SeekOrigin.Begin);
                 /* .. put it in the mock system */

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/TestableIO.System.IO.Abstractions.TestingHelpers.csproj
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/TestableIO.System.IO.Abstractions.TestingHelpers.csproj
@@ -3,7 +3,7 @@
         <AssemblyName>TestableIO.System.IO.Abstractions.TestingHelpers</AssemblyName>
         <RootNamespace>System.IO.Abstractions.TestingHelpers</RootNamespace>
         <Description>A set of pre-built mocks to help when testing file system interactions.</Description>
-        <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+        <TargetFrameworks>net9.0;net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
         <PackageIcon>icon_256x256.png</PackageIcon>
     </PropertyGroup>
     <ItemGroup>

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/TestableIO.System.IO.Abstractions.Wrappers.csproj
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/TestableIO.System.IO.Abstractions.Wrappers.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>TestableIO.System.IO.Abstractions.Wrappers</AssemblyName>
     <RootNamespace>System.IO.Abstractions</RootNamespace>
     <Description>A set of abstractions to help make file system interactions testable.</Description>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
     <PackageIcon>icon_256x256.png</PackageIcon>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netstandard2.0'">

--- a/src/TestableIO.System.IO.Abstractions/TestableIO.System.IO.Abstractions.csproj
+++ b/src/TestableIO.System.IO.Abstractions/TestableIO.System.IO.Abstractions.csproj
@@ -3,7 +3,7 @@
     <AssemblyName>TestableIO.System.IO.Abstractions</AssemblyName>
     <RootNamespace>System.IO.Abstractions</RootNamespace>
     <Description>A set of abstractions to help make file system interactions testable.</Description>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0;netstandard2.1;netstandard2.0;net462</TargetFrameworks>
     <PackageIcon>icon_256x256.png</PackageIcon>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemSerializationTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemSerializationTests.cs
@@ -1,3 +1,4 @@
+#if !NET9_0_OR_GREATER
 namespace System.IO.Abstractions.TestingHelpers.Tests
 {
     using NUnit.Framework;
@@ -38,3 +39,4 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
     }
 }
+#endif

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -162,7 +162,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.That(path.Exists, Is.True);
         }
-
+        
+#if !NET9_0_OR_GREATER
         [Test]
         public void MockFileSystem_ByDefault_IsSerializable()
         {
@@ -182,6 +183,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             Assert.That(memoryStream.Length > 0, "Length didn't increase after serialization task.");
         }
+#endif
 
         [Test]
         public void MockFileSystem_AddDirectory_ShouldCreateDirectory()

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
@@ -547,7 +547,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             Assert.That(file.TextContents, Is.EqualTo("New too!"));
             Assert.That(filesystem.FileExists(filepath));
         }
-
+        
+#if !NET9_0_OR_GREATER
         [Test]
         public void Serializable_works()
         {
@@ -565,7 +566,9 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             //Assert
             Assert.Pass();
         }
-
+#endif
+        
+#if !NET9_0_OR_GREATER
         [Test]
         public void Serializable_can_deserialize()
         {
@@ -588,6 +591,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             //Assert
             Assert.That(deserialized.TextContents, Is.EqualTo(textContentStr));
         }
+#endif
 
         [Test]
         public void MockFile_Encrypt_ShouldSetEncryptedAttribute()

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests.csproj
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="!$([MSBuild]::IsOsUnixLike())">$(TargetFrameworks);net462</TargetFrameworks>
     <Description>The unit tests for our pre-built mocks</Description>
     <AssemblyName>System.IO.Abstractions.TestingHelpers.Tests</AssemblyName>

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/ApiParityTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/ApiParityTests.cs
@@ -113,6 +113,8 @@ namespace System.IO.Abstractions.Tests
         private const string snapshotSuffix = ".NET 7.0";
 #elif NET8_0
         private const string snapshotSuffix = ".NET 8.0";
+#elif NET9_0
+        private const string snapshotSuffix = ".NET 9.0";
 #else
 #error Unknown target framework.
 #endif

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/FileSystemTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/FileSystemTests.cs
@@ -6,6 +6,7 @@ namespace System.IO.Abstractions.Tests
     [TestFixture]
     public class FileSystemTests
     {
+#if !NET9_0_OR_GREATER
         [Test]
         public void Is_Serializable()
         {
@@ -20,6 +21,7 @@ namespace System.IO.Abstractions.Tests
 
             Assert.That(memoryStream.Length > 0, "Length didn't increase after serialization task.");
         }
+#endif
 
         [Test]
         public void Mock_File_Succeeds()

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/TestableIO.System.IO.Abstractions.Wrappers.Tests.csproj
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/TestableIO.System.IO.Abstractions.Wrappers.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0;net7.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="!$([MSBuild]::IsOsUnixLike())">$(TargetFrameworks);net462</TargetFrameworks>
     <Description>The unit tests for our the core abstractions</Description>
     <AssemblyName>System.IO.Abstractions.Tests</AssemblyName>

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/__snapshots__/ApiParityTests.DirectoryInfo_.NET 9.0.snap
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/__snapshots__/ApiParityTests.DirectoryInfo_.NET 9.0.snap
@@ -1,0 +1,9 @@
+﻿{
+  "ExtraMembers": [],
+  "MissingMembers": [
+    "System.Object GetLifetimeService()",
+    "System.Object InitializeLifetimeService()",
+    "Void .ctor(System.String)",
+    "Void GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)"
+  ]
+}

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/__snapshots__/ApiParityTests.Directory_.NET 9.0.snap
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/__snapshots__/ApiParityTests.Directory_.NET 9.0.snap
@@ -1,0 +1,4 @@
+﻿{
+  "ExtraMembers": [],
+  "MissingMembers": []
+}

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/__snapshots__/ApiParityTests.DriveInfo_.NET 9.0.snap
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/__snapshots__/ApiParityTests.DriveInfo_.NET 9.0.snap
@@ -1,0 +1,7 @@
+﻿{
+  "ExtraMembers": [],
+  "MissingMembers": [
+    "System.IO.Abstractions.IDriveInfo[] GetDrives()",
+    "Void .ctor(System.String)"
+  ]
+}

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/__snapshots__/ApiParityTests.FileInfo_.NET 9.0.snap
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/__snapshots__/ApiParityTests.FileInfo_.NET 9.0.snap
@@ -1,0 +1,9 @@
+﻿{
+  "ExtraMembers": [],
+  "MissingMembers": [
+    "System.Object GetLifetimeService()",
+    "System.Object InitializeLifetimeService()",
+    "Void .ctor(System.String)",
+    "Void GetObjectData(System.Runtime.Serialization.SerializationInfo, System.Runtime.Serialization.StreamingContext)"
+  ]
+}

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/__snapshots__/ApiParityTests.FileSystemWatcher_.NET 9.0.snap
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/__snapshots__/ApiParityTests.FileSystemWatcher_.NET 9.0.snap
@@ -1,0 +1,15 @@
+﻿{
+  "ExtraMembers": [
+    "Void Dispose(Boolean)"
+  ],
+  "MissingMembers": [
+    "System.EventHandler Disposed",
+    "System.Object GetLifetimeService()",
+    "System.Object InitializeLifetimeService()",
+    "Void .ctor()",
+    "Void .ctor(System.String)",
+    "Void .ctor(System.String, System.String)",
+    "Void add_Disposed(System.EventHandler)",
+    "Void remove_Disposed(System.EventHandler)"
+  ]
+}

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/__snapshots__/ApiParityTests.FileVersionInfo_.NET 9.0.snap
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/__snapshots__/ApiParityTests.FileVersionInfo_.NET 9.0.snap
@@ -1,0 +1,4 @@
+﻿{
+  "ExtraMembers": [],
+  "MissingMembers": []
+}

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/__snapshots__/ApiParityTests.File_.NET 9.0.snap
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/__snapshots__/ApiParityTests.File_.NET 9.0.snap
@@ -1,0 +1,20 @@
+﻿{
+  "ExtraMembers": [],
+  "MissingMembers": [
+    "Microsoft.Win32.SafeHandles.SafeFileHandle OpenHandle(System.String, System.IO.FileMode, System.IO.FileAccess, System.IO.FileShare, System.IO.FileOptions, Int64)",
+    "System.Threading.Tasks.Task AppendAllBytesAsync(System.String, Byte[], System.Threading.CancellationToken)",
+    "System.Threading.Tasks.Task AppendAllBytesAsync(System.String, System.ReadOnlyMemory`1[System.Byte], System.Threading.CancellationToken)",
+    "System.Threading.Tasks.Task AppendAllTextAsync(System.String, System.ReadOnlyMemory`1[System.Char], System.Text.Encoding, System.Threading.CancellationToken)",
+    "System.Threading.Tasks.Task AppendAllTextAsync(System.String, System.ReadOnlyMemory`1[System.Char], System.Threading.CancellationToken)",
+    "System.Threading.Tasks.Task WriteAllBytesAsync(System.String, System.ReadOnlyMemory`1[System.Byte], System.Threading.CancellationToken)",
+    "System.Threading.Tasks.Task WriteAllTextAsync(System.String, System.ReadOnlyMemory`1[System.Char], System.Text.Encoding, System.Threading.CancellationToken)",
+    "System.Threading.Tasks.Task WriteAllTextAsync(System.String, System.ReadOnlyMemory`1[System.Char], System.Threading.CancellationToken)",
+    "Void AppendAllBytes(System.String, Byte[])",
+    "Void AppendAllBytes(System.String, System.ReadOnlySpan`1[System.Byte])",
+    "Void AppendAllText(System.String, System.ReadOnlySpan`1[System.Char])",
+    "Void AppendAllText(System.String, System.ReadOnlySpan`1[System.Char], System.Text.Encoding)",
+    "Void WriteAllBytes(System.String, System.ReadOnlySpan`1[System.Byte])",
+    "Void WriteAllText(System.String, System.ReadOnlySpan`1[System.Char])",
+    "Void WriteAllText(System.String, System.ReadOnlySpan`1[System.Char], System.Text.Encoding)"
+  ]
+}

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/__snapshots__/ApiParityTests.Path_.NET 9.0.snap
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/__snapshots__/ApiParityTests.Path_.NET 9.0.snap
@@ -1,0 +1,13 @@
+﻿{
+  "ExtraMembers": [
+    "Char get_AltDirectorySeparatorChar()",
+    "Char get_DirectorySeparatorChar()",
+    "Char get_PathSeparator()",
+    "Char get_VolumeSeparatorChar()",
+    "Char[] get_InvalidPathChars()"
+  ],
+  "MissingMembers": [
+    "System.String Combine(System.ReadOnlySpan`1[System.String])",
+    "System.String Join(System.ReadOnlySpan`1[System.String])"
+  ]
+}


### PR DESCRIPTION
Add .NET9 target as preparation for supporting new .NET9 APIs