### PR TITLE
refactor: support new `Path` methods from .NET9

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,6 +14,7 @@
     <DefineConstants Condition="'$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'netstandard2.1'">$(DefineConstants);FEATURE_ASYNC_FILE;FEATURE_ENUMERATION_OPTIONS;FEATURE_ADVANCED_PATH_OPERATIONS;FEATURE_PATH_JOIN_WITH_SPAN;FEATURE_SPAN</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net6.0'">$(DefineConstants);FEATURE_FILE_MOVE_WITH_OVERWRITE;FEATURE_SUPPORTED_OS_ATTRIBUTE;FEATURE_FILE_SYSTEM_WATCHER_FILTERS;FEATURE_ENDS_IN_DIRECTORY_SEPARATOR;FEATURE_PATH_JOIN_WITH_PARAMS;FEATURE_PATH_JOIN_WITH_FOUR_PATHS;FEATURE_FILE_SYSTEM_INFO_LINK_TARGET;FEATURE_CREATE_SYMBOLIC_LINK;FEATURE_FILESTREAM_OPTIONS</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net7.0'">$(DefineConstants);FEATURE_PATH_EXISTS;FEATURE_FILE_SYSTEM_WATCHER_WAIT_WITH_TIMESPAN;FEATURE_FILE_ATTRIBUTES_VIA_HANDLE;FEATURE_CREATE_TEMP_SUBDIRECTORY;FEATURE_READ_LINES_ASYNC;FEATURE_UNIX_FILE_MODE</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' == 'net9.0'">$(DefineConstants);FEATURE_PATH_SPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/PathBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/PathBase.cs
@@ -43,6 +43,11 @@ namespace System.IO.Abstractions
 
         /// <inheritdoc cref="Path.Combine(string[])"/>
         public abstract string Combine(params string[] paths);
+        
+#if FEATURE_PATH_SPAN
+        /// <inheritdoc cref="Path.Combine(ReadOnlySpan{string})"/>
+        public abstract string Combine(params ReadOnlySpan<string> paths);
+#endif
 
         /// <inheritdoc cref="Path.Combine(string,string)"/>
         public abstract string Combine(string path1, string path2);
@@ -116,6 +121,11 @@ namespace System.IO.Abstractions
 
         /// <inheritdoc />
         public abstract string Join(ReadOnlySpan<char> path1, ReadOnlySpan<char> path2, ReadOnlySpan<char> path3);
+
+#if FEATURE_PATH_SPAN
+        /// <inheritdoc cref="Path.Join(ReadOnlySpan{string})"/>
+        public abstract string Join(params ReadOnlySpan<string> paths);
+#endif
 
         /// <inheritdoc />
         public abstract bool TryJoin(ReadOnlySpan<char> path1, ReadOnlySpan<char> path2, ReadOnlySpan<char> path3, Span<char> destination, out int charsWritten);

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/PathWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/PathWrapper.cs
@@ -56,6 +56,14 @@ namespace System.IO.Abstractions
             return Path.Combine(paths);
         }
 
+#if FEATURE_PATH_SPAN
+        /// <inheritdoc />
+        public override string Combine(params ReadOnlySpan<string> paths)
+        {
+            return Path.Combine(paths);
+        }
+#endif
+
         /// <inheritdoc />
         public override string Combine(string path1, string path2)
         {
@@ -184,6 +192,14 @@ namespace System.IO.Abstractions
         /// <inheritdoc />
         public override string Join(ReadOnlySpan<char> path1, ReadOnlySpan<char> path2, ReadOnlySpan<char> path3) =>
             Path.Join(path1, path2, path3);
+
+#if FEATURE_PATH_SPAN
+        /// <inheritdoc />
+        public override string Join(params ReadOnlySpan<string> paths)
+        {
+            return Path.Join(paths);
+        }
+#endif
 
         /// <inheritdoc />
         public override bool TryJoin(ReadOnlySpan<char> path1, ReadOnlySpan<char> path2, Span<char> destination, out int charsWritten) =>

--- a/src/TestableIO.System.IO.Abstractions/IPath.cs
+++ b/src/TestableIO.System.IO.Abstractions/IPath.cs
@@ -33,6 +33,11 @@ namespace System.IO.Abstractions
         /// <inheritdoc cref="Path.Combine(string[])" />
         string Combine(params string[] paths);
 
+#if FEATURE_PATH_SPAN
+        /// <inheritdoc cref="Path.Combine(ReadOnlySpan{string})" />
+        string Combine(params ReadOnlySpan<string> paths);
+#endif
+
 #if FEATURE_ENDS_IN_DIRECTORY_SEPARATOR
         /// <inheritdoc cref="Path.EndsInDirectorySeparator(ReadOnlySpan{char})" />
         bool EndsInDirectorySeparator(ReadOnlySpan<char> path);
@@ -147,6 +152,11 @@ namespace System.IO.Abstractions
         string Join(ReadOnlySpan<char> path1,
             ReadOnlySpan<char> path2,
             ReadOnlySpan<char> path3);
+
+#if FEATURE_PATH_SPAN
+        /// <inheritdoc cref="Path.Join(ReadOnlySpan{string?})" />
+        string Join(params ReadOnlySpan<string?> paths);
+#endif
 
         /// <inheritdoc cref="Path.TryJoin(ReadOnlySpan{char}, ReadOnlySpan{char}, Span{char}, out int)" />
         bool TryJoin(ReadOnlySpan<char> path1,

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/__snapshots__/ApiParityTests.Path_.NET 9.0.snap
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/__snapshots__/ApiParityTests.Path_.NET 9.0.snap
@@ -6,8 +6,5 @@
     "Char get_VolumeSeparatorChar()",
     "Char[] get_InvalidPathChars()"
   ],
-  "MissingMembers": [
-    "System.String Combine(System.ReadOnlySpan`1[System.String])",
-    "System.String Join(System.ReadOnlySpan`1[System.String])"
-  ]
+  "MissingMembers": []
 }


### PR DESCRIPTION
Add the two new methods to `Path` introduced in .NET 9:
- `string Combine(params ReadOnlySpan<string> paths)`
- `string Join(params ReadOnlySpan<string?> paths)`