### PR TITLE
feat: add new `File` methods from .NET 9

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
     <DefineConstants Condition="'$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'netstandard2.1'">$(DefineConstants);FEATURE_ASYNC_FILE;FEATURE_ENUMERATION_OPTIONS;FEATURE_ADVANCED_PATH_OPERATIONS;FEATURE_PATH_JOIN_WITH_SPAN;FEATURE_SPAN</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net6.0'">$(DefineConstants);FEATURE_FILE_MOVE_WITH_OVERWRITE;FEATURE_SUPPORTED_OS_ATTRIBUTE;FEATURE_FILE_SYSTEM_WATCHER_FILTERS;FEATURE_ENDS_IN_DIRECTORY_SEPARATOR;FEATURE_PATH_JOIN_WITH_PARAMS;FEATURE_PATH_JOIN_WITH_FOUR_PATHS;FEATURE_FILE_SYSTEM_INFO_LINK_TARGET;FEATURE_CREATE_SYMBOLIC_LINK;FEATURE_FILESTREAM_OPTIONS</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' == 'net9.0' OR '$(TargetFramework)' == 'net8.0' OR '$(TargetFramework)' == 'net7.0'">$(DefineConstants);FEATURE_PATH_EXISTS;FEATURE_FILE_SYSTEM_WATCHER_WAIT_WITH_TIMESPAN;FEATURE_FILE_ATTRIBUTES_VIA_HANDLE;FEATURE_CREATE_TEMP_SUBDIRECTORY;FEATURE_READ_LINES_ASYNC;FEATURE_UNIX_FILE_MODE</DefineConstants>
-    <DefineConstants Condition="'$(TargetFramework)' == 'net9.0'">$(DefineConstants);FEATURE_PATH_SPAN</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' == 'net9.0'">$(DefineConstants);FEATURE_PATH_SPAN;FEATURE_FILE_SPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_SERIALIZABLE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFile.Async.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFile.Async.cs
@@ -10,12 +10,27 @@ namespace System.IO.Abstractions.TestingHelpers
 {
     partial class MockFile
     {
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="IFile.AppendAllBytesAsync(string,byte[],CancellationToken)"/>
+        public override Task AppendAllBytesAsync(string path, byte[] bytes, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            AppendAllBytes(path, bytes);
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc cref="IFile.AppendAllBytesAsync(string,ReadOnlyMemory{byte},CancellationToken)"/>
+        public override Task AppendAllBytesAsync(string path, ReadOnlyMemory<byte> bytes, CancellationToken cancellationToken = default)
+        {
+            return AppendAllBytesAsync(path, bytes.ToArray(), cancellationToken);
+        }
+#endif
         /// <inheritdoc />
-        public override Task AppendAllLinesAsync(string path, IEnumerable<string> contents, CancellationToken cancellationToken = default(CancellationToken)) =>
+        public override Task AppendAllLinesAsync(string path, IEnumerable<string> contents, CancellationToken cancellationToken = default) =>
             AppendAllLinesAsync(path, contents, MockFileData.DefaultEncoding, cancellationToken);
 
         /// <inheritdoc />
-        public override Task AppendAllLinesAsync(string path, IEnumerable<string> contents, Encoding encoding, CancellationToken cancellationToken = default(CancellationToken))
+        public override Task AppendAllLinesAsync(string path, IEnumerable<string> contents, Encoding encoding, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             AppendAllLines(path, contents, encoding);
@@ -23,44 +38,59 @@ namespace System.IO.Abstractions.TestingHelpers
         }
 
         /// <inheritdoc />
-        public override Task AppendAllTextAsync(string path, string contents, CancellationToken cancellationToken = default(CancellationToken)) =>
+        public override Task AppendAllTextAsync(string path, string contents, CancellationToken cancellationToken = default) =>
             AppendAllTextAsync(path, contents, MockFileData.DefaultEncoding, cancellationToken);
 
 
         /// <inheritdoc />
-        public override Task AppendAllTextAsync(string path, string contents, Encoding encoding, CancellationToken cancellationToken = default(CancellationToken))
+        public override Task AppendAllTextAsync(string path, string contents, Encoding encoding, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             AppendAllText(path, contents, encoding);
             return Task.CompletedTask;
         }
+        
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="IFile.AppendAllTextAsync(string,ReadOnlyMemory{char},CancellationToken)"/>
+        public override Task AppendAllTextAsync(string path, ReadOnlyMemory<char> contents, CancellationToken cancellationToken = default)
+        {
+            return AppendAllTextAsync(path, contents.ToString(), cancellationToken);
+        }
+
+        /// <inheritdoc cref="IFile.AppendAllTextAsync(string,ReadOnlyMemory{char},Encoding,CancellationToken)"/>
+        public override Task AppendAllTextAsync(string path, ReadOnlyMemory<char> contents, Encoding encoding,
+            CancellationToken cancellationToken = default)
+        {
+            return AppendAllTextAsync(path, contents.ToString(), encoding, cancellationToken);
+        }
+#endif
 
         /// <inheritdoc />
-        public override Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken = default(CancellationToken))
+        public override Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(ReadAllBytes(path));
         }
 
         /// <inheritdoc />
-        public override Task<string[]> ReadAllLinesAsync(string path, CancellationToken cancellationToken = default(CancellationToken)) =>
+        public override Task<string[]> ReadAllLinesAsync(string path, CancellationToken cancellationToken = default) =>
             ReadAllLinesAsync(path, MockFileData.DefaultEncoding, cancellationToken);
 
         /// <inheritdoc />
 
-        public override Task<string[]> ReadAllLinesAsync(string path, Encoding encoding, CancellationToken cancellationToken = default(CancellationToken))
+        public override Task<string[]> ReadAllLinesAsync(string path, Encoding encoding, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(ReadAllLines(path, encoding));
         }
 
         /// <inheritdoc />
-        public override Task<string> ReadAllTextAsync(string path, CancellationToken cancellationToken) =>
+        public override Task<string> ReadAllTextAsync(string path, CancellationToken cancellationToken = default) =>
             ReadAllTextAsync(path, MockFileData.DefaultEncoding, cancellationToken);
 
 
         /// <inheritdoc />
-        public override Task<string> ReadAllTextAsync(string path, Encoding encoding, CancellationToken cancellationToken)
+        public override Task<string> ReadAllTextAsync(string path, Encoding encoding, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(ReadAllText(path, encoding));
@@ -82,19 +112,27 @@ namespace System.IO.Abstractions.TestingHelpers
 #endif
 
         /// <inheritdoc />
-        public override Task WriteAllBytesAsync(string path, byte[] bytes, CancellationToken cancellationToken)
+        public override Task WriteAllBytesAsync(string path, byte[] bytes, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             WriteAllBytes(path, bytes);
             return Task.CompletedTask;
         }
+        
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="IFile.WriteAllBytesAsync(string,ReadOnlyMemory{byte},CancellationToken)"/>
+        public override Task WriteAllBytesAsync(string path, ReadOnlyMemory<byte> bytes, CancellationToken cancellationToken = default)
+        {
+            return WriteAllBytesAsync(path, bytes.ToArray(), cancellationToken);
+        }
+#endif
 
         /// <inheritdoc />
-        public override Task WriteAllLinesAsync(string path, IEnumerable<string> contents, CancellationToken cancellationToken) =>
+        public override Task WriteAllLinesAsync(string path, IEnumerable<string> contents, CancellationToken cancellationToken = default) =>
             WriteAllLinesAsync(path, contents, MockFileData.DefaultEncoding, cancellationToken);
 
         /// <inheritdoc />
-        public override Task WriteAllLinesAsync(string path, IEnumerable<string> contents, Encoding encoding, CancellationToken cancellationToken)
+        public override Task WriteAllLinesAsync(string path, IEnumerable<string> contents, Encoding encoding, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             WriteAllLines(path, contents, encoding);
@@ -102,16 +140,31 @@ namespace System.IO.Abstractions.TestingHelpers
         }
 
         /// <inheritdoc />
-        public override Task WriteAllTextAsync(string path, string contents, CancellationToken cancellationToken) =>
+        public override Task WriteAllTextAsync(string path, string contents, CancellationToken cancellationToken = default) =>
             WriteAllTextAsync(path, contents, MockFileData.DefaultEncoding, cancellationToken);
 
         /// <inheritdoc />
-        public override Task WriteAllTextAsync(string path, string contents, Encoding encoding, CancellationToken cancellationToken)
+        public override Task WriteAllTextAsync(string path, string contents, Encoding encoding, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             WriteAllText(path, contents, encoding);
             return Task.CompletedTask;
         }
+        
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="IFile.WriteAllTextAsync(string,ReadOnlyMemory{char},CancellationToken)"/>
+        public override Task WriteAllTextAsync(string path, ReadOnlyMemory<char> contents, CancellationToken cancellationToken = default)
+        {
+            return WriteAllTextAsync(path, contents.ToString(), cancellationToken);
+        }
+
+        /// <inheritdoc cref="IFile.WriteAllTextAsync(string,ReadOnlyMemory{char},Encoding,CancellationToken)"/>
+        public override Task WriteAllTextAsync(string path, ReadOnlyMemory<char> contents, Encoding encoding,
+            CancellationToken cancellationToken = default)
+        {
+            return WriteAllTextAsync(path, contents.ToString(), encoding, cancellationToken);
+        }
+#endif
     }
 }
 

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileBase.Async.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileBase.Async.cs
@@ -9,31 +9,52 @@ namespace System.IO.Abstractions
 {
     partial class FileBase
     {
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="IFile.AppendAllBytesAsync(string,byte[],CancellationToken)"/>
+        public abstract Task AppendAllBytesAsync(string path, byte[] bytes,
+            CancellationToken cancellationToken = default);
+
+        /// <inheritdoc cref="IFile.AppendAllBytesAsync(string,ReadOnlyMemory{byte},CancellationToken)"/>
+        public abstract Task AppendAllBytesAsync(string path, ReadOnlyMemory<byte> bytes,
+            CancellationToken cancellationToken = default);
+#endif
+
         /// <inheritdoc cref="IFile.AppendAllLinesAsync(string,IEnumerable{string},CancellationToken)"/>
-        public abstract Task AppendAllLinesAsync(string path, IEnumerable<string> contents, CancellationToken cancellationToken);
+        public abstract Task AppendAllLinesAsync(string path, IEnumerable<string> contents, CancellationToken cancellationToken = default);
 
         /// <inheritdoc cref="IFile.AppendAllLinesAsync(string,IEnumerable{string},Encoding,CancellationToken)"/>
-        public abstract Task AppendAllLinesAsync(string path, IEnumerable<string> contents, Encoding encoding, CancellationToken cancellationToken);
+        public abstract Task AppendAllLinesAsync(string path, IEnumerable<string> contents, Encoding encoding, CancellationToken cancellationToken = default);
 
 
         /// <inheritdoc cref="IFile.AppendAllTextAsync(string,string,CancellationToken)"/>
-        public abstract Task AppendAllTextAsync(String path, String contents, CancellationToken cancellationToken);
+        public abstract Task AppendAllTextAsync(String path, String contents, CancellationToken cancellationToken = default);
 
         /// <inheritdoc cref="IFile.AppendAllTextAsync(string,string,Encoding,CancellationToken)"/>
-        public abstract Task AppendAllTextAsync(String path, String contents, Encoding encoding, CancellationToken cancellationToken);
+        public abstract Task AppendAllTextAsync(String path, String contents, Encoding encoding, CancellationToken cancellationToken = default);
+
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="IFile.AppendAllTextAsync(string,ReadOnlyMemory{char},CancellationToken)"/>
+        public abstract Task AppendAllTextAsync(string path, ReadOnlyMemory<char> contents,
+            CancellationToken cancellationToken = default);
+
+        /// <inheritdoc cref="IFile.AppendAllTextAsync(string,ReadOnlyMemory{char},Encoding,CancellationToken)"/>
+        public abstract Task AppendAllTextAsync(string path, ReadOnlyMemory<char> contents, Encoding encoding,
+            CancellationToken cancellationToken = default);
+#endif
+
         /// <inheritdoc cref="IFile.ReadAllBytesAsync"/>
-        public abstract Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken);
+        public abstract Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken = default);
         /// <inheritdoc cref="IFile.ReadAllLinesAsync(string,CancellationToken)"/>
-        public abstract Task<string[]> ReadAllLinesAsync(string path, CancellationToken cancellationToken);
+        public abstract Task<string[]> ReadAllLinesAsync(string path, CancellationToken cancellationToken = default);
 
         /// <inheritdoc cref="IFile.ReadAllLinesAsync(string,Encoding,CancellationToken)"/>
-        public abstract Task<string[]> ReadAllLinesAsync(string path, Encoding encoding, CancellationToken cancellationToken);
+        public abstract Task<string[]> ReadAllLinesAsync(string path, Encoding encoding, CancellationToken cancellationToken = default);
 
         ///<inheritdoc cref="IFile.ReadAllTextAsync(string,CancellationToken)"/>
-        public abstract Task<string> ReadAllTextAsync(string path, CancellationToken cancellationToken);
+        public abstract Task<string> ReadAllTextAsync(string path, CancellationToken cancellationToken = default);
 
         ///<inheritdoc cref="IFile.ReadAllTextAsync(string,Encoding,CancellationToken)"/>
-        public abstract Task<string> ReadAllTextAsync(string path, Encoding encoding, CancellationToken cancellationToken);
+        public abstract Task<string> ReadAllTextAsync(string path, Encoding encoding, CancellationToken cancellationToken = default);
 
 #if FEATURE_READ_LINES_ASYNC
         ///<inheritdoc cref="IFile.ReadLinesAsync(string,Encoding,CancellationToken)"/>
@@ -45,20 +66,36 @@ namespace System.IO.Abstractions
             CancellationToken cancellationToken = default);
 #endif
 
-        /// <inheritdoc cref="IFile.WriteAllBytesAsync"/>
-        public abstract Task WriteAllBytesAsync(string path, byte[] bytes, CancellationToken cancellationToken);
+        /// <inheritdoc cref="IFile.WriteAllBytesAsync(string,byte[],CancellationToken)"/>
+        public abstract Task WriteAllBytesAsync(string path, byte[] bytes, CancellationToken cancellationToken = default);
+
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="IFile.WriteAllBytesAsync(string,ReadOnlyMemory{byte},CancellationToken)"/>
+        public abstract Task WriteAllBytesAsync(string path, ReadOnlyMemory<byte> bytes,
+            CancellationToken cancellationToken = default);
+#endif
 
         /// <inheritdoc cref="IFile.WriteAllLinesAsync(string,IEnumerable{string},CancellationToken)"/>
-        public abstract Task WriteAllLinesAsync(string path, IEnumerable<string> contents, CancellationToken cancellationToken);
+        public abstract Task WriteAllLinesAsync(string path, IEnumerable<string> contents, CancellationToken cancellationToken = default);
 
         /// <inheritdoc cref="IFile.WriteAllLinesAsync(string,IEnumerable{string},Encoding,CancellationToken)"/>
-        public abstract Task WriteAllLinesAsync(string path, IEnumerable<string> contents, Encoding encoding, CancellationToken cancellationToken);
+        public abstract Task WriteAllLinesAsync(string path, IEnumerable<string> contents, Encoding encoding, CancellationToken cancellationToken = default);
         
         /// <inheritdoc cref="IFile.WriteAllTextAsync(string,string,CancellationToken)"/>
-        public abstract Task WriteAllTextAsync(string path, string contents, CancellationToken cancellationToken);
+        public abstract Task WriteAllTextAsync(string path, string contents, CancellationToken cancellationToken = default);
 
         /// <inheritdoc cref="IFile.WriteAllTextAsync(string,string,Encoding,CancellationToken)"/>
-        public abstract Task WriteAllTextAsync(string path, string contents, Encoding encoding, CancellationToken cancellationToken);
+        public abstract Task WriteAllTextAsync(string path, string contents, Encoding encoding, CancellationToken cancellationToken = default);
+
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="IFile.WriteAllTextAsync(string,ReadOnlyMemory{char},CancellationToken)"/>
+        public abstract Task WriteAllTextAsync(string path, ReadOnlyMemory<char> contents,
+            CancellationToken cancellationToken = default);
+
+        /// <inheritdoc cref="IFile.WriteAllTextAsync(string,ReadOnlyMemory{char},Encoding,CancellationToken)"/>
+        public abstract Task WriteAllTextAsync(string path, ReadOnlyMemory<char> contents, Encoding encoding,
+            CancellationToken cancellationToken = default);
+#endif
     }
 }
 

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileBase.cs
@@ -24,6 +24,14 @@ namespace System.IO.Abstractions
         /// </summary>
         public IFileSystem FileSystem { get; }
 
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="IFile.AppendAllBytes(string,byte[])"/>
+        public abstract void AppendAllBytes(string path, byte[] bytes);
+
+        /// <inheritdoc cref="IFile.AppendAllBytes(string,ReadOnlySpan{byte})"/>
+        public abstract void AppendAllBytes(string path, ReadOnlySpan<byte> bytes);
+#endif
+
         /// <inheritdoc cref="IFile.AppendAllLines(string,IEnumerable{string})"/>
         public abstract void AppendAllLines(string path, IEnumerable<string> contents);
 
@@ -35,6 +43,14 @@ namespace System.IO.Abstractions
 
         /// <inheritdoc cref="IFile.AppendAllText(string,string,Encoding)"/>
         public abstract void AppendAllText(string path, string contents, Encoding encoding);
+
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="IFile.AppendAllText(string,ReadOnlySpan{char})"/>
+        public abstract void AppendAllText(string path, ReadOnlySpan<char> contents);
+
+        /// <inheritdoc cref="IFile.AppendAllText(string,ReadOnlySpan{char},Encoding)"/>
+        public abstract void AppendAllText(string path, ReadOnlySpan<char> contents, Encoding encoding);
+#endif
 
         /// <inheritdoc cref="IFile.AppendText"/>
         public abstract StreamWriter AppendText(string path);
@@ -271,6 +287,11 @@ namespace System.IO.Abstractions
         /// <inheritdoc cref="IFile.WriteAllBytes(string, byte[])"/>
         public abstract void WriteAllBytes(string path, byte[] bytes);
 
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="IFile.WriteAllBytes(string,ReadOnlySpan{byte})"/>
+        public abstract void WriteAllBytes(string path, ReadOnlySpan<byte> bytes);
+#endif
+
         /// <inheritdoc cref="IFile.WriteAllLines(string,IEnumerable{string})"/>
         public abstract void WriteAllLines(string path, IEnumerable<string> contents);
 
@@ -288,5 +309,13 @@ namespace System.IO.Abstractions
 
         /// <inheritdoc cref="IFile.WriteAllText(string,string,Encoding)"/>
         public abstract void WriteAllText(string path, string contents, Encoding encoding);
+
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="IFile.WriteAllText(string,ReadOnlySpan{char})"/>
+        public abstract void WriteAllText(string path, ReadOnlySpan<char> contents);
+
+        /// <inheritdoc cref="IFile.WriteAllText(string,ReadOnlySpan{char},Encoding)"/>
+        public abstract void WriteAllText(string path, ReadOnlySpan<char> contents, Encoding encoding);
+#endif
     }
 }

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileWrapper.Async.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileWrapper.Async.cs
@@ -9,56 +9,84 @@ namespace System.IO.Abstractions
 {
     partial class FileWrapper
     {
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="IFile.AppendAllBytesAsync(string,byte[],CancellationToken)"/>
+        public override Task AppendAllBytesAsync(string path, byte[] bytes, CancellationToken cancellationToken = default)
+        {
+            return File.AppendAllBytesAsync(path, bytes, cancellationToken);
+        }
+
+        /// <inheritdoc cref="IFile.AppendAllBytesAsync(string,ReadOnlyMemory{byte},CancellationToken)"/>
+        public override Task AppendAllBytesAsync(string path, ReadOnlyMemory<byte> bytes, CancellationToken cancellationToken = default)
+        {
+            return File.AppendAllBytesAsync(path, bytes, cancellationToken);
+        }
+#endif
         /// <inheritdoc />
-        public override Task AppendAllLinesAsync(string path, IEnumerable<string> contents, CancellationToken cancellationToken)
+        public override Task AppendAllLinesAsync(string path, IEnumerable<string> contents, CancellationToken cancellationToken = default)
         {
             return File.AppendAllLinesAsync(path, contents, cancellationToken);
         }
 
         /// <inheritdoc />
-        public override Task AppendAllLinesAsync(string path, IEnumerable<string> contents, Encoding encoding, CancellationToken cancellationToken)
+        public override Task AppendAllLinesAsync(string path, IEnumerable<string> contents, Encoding encoding, CancellationToken cancellationToken = default)
         {
             return File.AppendAllLinesAsync(path, contents, encoding, cancellationToken);
         }
 
         /// <inheritdoc />
-        public override Task AppendAllTextAsync(string path, string contents, CancellationToken cancellationToken)
+        public override Task AppendAllTextAsync(string path, string contents, CancellationToken cancellationToken = default)
         {
             return File.AppendAllTextAsync(path, contents, cancellationToken);
         }
 
         /// <inheritdoc />
-        public override Task AppendAllTextAsync(string path, string contents, Encoding encoding, CancellationToken cancellationToken)
+        public override Task AppendAllTextAsync(string path, string contents, Encoding encoding, CancellationToken cancellationToken = default)
         {
             return File.AppendAllTextAsync(path, contents, encoding, cancellationToken);
         }
+        
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="IFile.AppendAllTextAsync(string,ReadOnlyMemory{char},CancellationToken)"/>
+        public override Task AppendAllTextAsync(string path, ReadOnlyMemory<char> contents, CancellationToken cancellationToken = default)
+        {
+            return File.AppendAllTextAsync(path, contents, cancellationToken);
+        }
+
+        /// <inheritdoc cref="IFile.AppendAllTextAsync(string,ReadOnlyMemory{char},Encoding,CancellationToken)"/>
+        public override Task AppendAllTextAsync(string path, ReadOnlyMemory<char> contents, Encoding encoding,
+            CancellationToken cancellationToken = default)
+        {
+            return File.AppendAllTextAsync(path, contents, encoding, cancellationToken);
+        }
+#endif
 
         /// <inheritdoc />
-        public override Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken)
+        public override Task<byte[]> ReadAllBytesAsync(string path, CancellationToken cancellationToken = default)
         {
             return File.ReadAllBytesAsync(path, cancellationToken);
         }
 
         /// <inheritdoc />
-        public override Task<string[]> ReadAllLinesAsync(string path, CancellationToken cancellationToken)
+        public override Task<string[]> ReadAllLinesAsync(string path, CancellationToken cancellationToken = default)
         {
             return File.ReadAllLinesAsync(path, cancellationToken);
         }
 
         /// <inheritdoc />
-        public override Task<string[]> ReadAllLinesAsync(string path, Encoding encoding, CancellationToken cancellationToken)
+        public override Task<string[]> ReadAllLinesAsync(string path, Encoding encoding, CancellationToken cancellationToken = default)
         {
             return File.ReadAllLinesAsync(path, encoding, cancellationToken);
         }
 
         /// <inheritdoc />
-        public override Task<string> ReadAllTextAsync(string path, CancellationToken cancellationToken)
+        public override Task<string> ReadAllTextAsync(string path, CancellationToken cancellationToken = default)
         {
             return File.ReadAllTextAsync(path, cancellationToken);
         }
 
         /// <inheritdoc />
-        public override Task<string> ReadAllTextAsync(string path, Encoding encoding, CancellationToken cancellationToken)
+        public override Task<string> ReadAllTextAsync(string path, Encoding encoding, CancellationToken cancellationToken = default)
         {
             return File.ReadAllTextAsync(path, encoding, cancellationToken);
         }
@@ -76,34 +104,57 @@ namespace System.IO.Abstractions
 #endif
 
         /// <inheritdoc />
-        public override Task WriteAllBytesAsync(string path, byte[] bytes, CancellationToken cancellationToken)
+        public override Task WriteAllBytesAsync(string path, byte[] bytes, CancellationToken cancellationToken = default)
         {
             return File.WriteAllBytesAsync(path, bytes, cancellationToken);
         }
+        
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="IFile.WriteAllBytesAsync(string,ReadOnlyMemory{byte},CancellationToken)"/>
+        public override Task WriteAllBytesAsync(string path, ReadOnlyMemory<byte> bytes, CancellationToken cancellationToken = default)
+        {
+            return File.WriteAllBytesAsync(path, bytes, cancellationToken);
+        }
+#endif
 
         /// <inheritdoc />
-        public override Task WriteAllLinesAsync(string path, IEnumerable<string> contents, CancellationToken cancellationToken)
+        public override Task WriteAllLinesAsync(string path, IEnumerable<string> contents, CancellationToken cancellationToken = default)
         {
             return File.WriteAllLinesAsync(path, contents, cancellationToken);
         }
 
         /// <inheritdoc />
-        public override Task WriteAllLinesAsync(string path, IEnumerable<string> contents, Encoding encoding, CancellationToken cancellationToken)
+        public override Task WriteAllLinesAsync(string path, IEnumerable<string> contents, Encoding encoding, CancellationToken cancellationToken = default)
         {
             return File.WriteAllLinesAsync(path, contents, encoding, cancellationToken);
         }
 
         /// <inheritdoc />
-        public override Task WriteAllTextAsync(string path, string contents, CancellationToken cancellationToken)
+        public override Task WriteAllTextAsync(string path, string contents, CancellationToken cancellationToken = default)
         {
             return File.WriteAllTextAsync(path, contents, cancellationToken);
         }
 
         /// <inheritdoc />
-        public override Task WriteAllTextAsync(string path, string contents, Encoding encoding, CancellationToken cancellationToken)
+        public override Task WriteAllTextAsync(string path, string contents, Encoding encoding, CancellationToken cancellationToken = default)
         {
             return File.WriteAllTextAsync(path, contents, encoding, cancellationToken);
         }
+        
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="IFile.WriteAllTextAsync(string,ReadOnlyMemory{char},CancellationToken)"/>
+        public override Task WriteAllTextAsync(string path, ReadOnlyMemory<char> contents, CancellationToken cancellationToken = default)
+        {
+            return File.WriteAllTextAsync(path, contents, cancellationToken);
+        }
+
+        /// <inheritdoc cref="IFile.WriteAllTextAsync(string,ReadOnlyMemory{char},Encoding,CancellationToken)"/>
+        public override Task WriteAllTextAsync(string path, ReadOnlyMemory<char> contents, Encoding encoding,
+            CancellationToken cancellationToken = default)
+        {
+            return File.WriteAllTextAsync(path, contents, encoding, cancellationToken);
+        }
+#endif
     }
 }
 #endif

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileWrapper.cs
@@ -16,6 +16,20 @@ namespace System.IO.Abstractions
         {
         }
 
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="IFile.AppendAllBytes(string,byte[])"/>
+        public override void AppendAllBytes(string path, byte[] bytes)
+        {
+            File.AppendAllBytes(path, bytes);
+        }
+
+        /// <inheritdoc cref="IFile.AppendAllBytes(string,ReadOnlySpan{byte})"/>
+        public override void AppendAllBytes(string path, ReadOnlySpan<byte> bytes)
+        {
+            File.AppendAllBytes(path, bytes);
+        }
+#endif
+
         /// <inheritdoc />
         public override void AppendAllLines(string path, IEnumerable<string> contents)
         {
@@ -41,6 +55,20 @@ namespace System.IO.Abstractions
             File.AppendAllText(path, contents, encoding);
         }
 
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="IFile.AppendAllText(string,ReadOnlySpan{char})"/>
+        public override void AppendAllText(string path, ReadOnlySpan<char> contents)
+        {
+            File.AppendAllText(path, contents);
+        }
+
+        /// <inheritdoc cref="IFile.AppendAllText(string,ReadOnlySpan{char},Encoding)"/>
+        public override void AppendAllText(string path, ReadOnlySpan<char> contents, Encoding encoding)
+        {
+            File.AppendAllText(path, contents, encoding);
+        }
+#endif
+        
         /// <inheritdoc />
         public override StreamWriter AppendText(string path)
         {
@@ -504,6 +532,14 @@ namespace System.IO.Abstractions
         {
             File.WriteAllBytes(path, bytes);
         }
+        
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="IFile.WriteAllBytes(string,ReadOnlySpan{byte})"/>
+        public override void WriteAllBytes(string path, ReadOnlySpan<byte> bytes)
+        {
+            File.WriteAllBytes(path, bytes);
+        }
+#endif
 
         /// <summary>
         /// Creates a new file, writes a collection of strings to the file, and then closes the file.
@@ -743,5 +779,19 @@ namespace System.IO.Abstractions
         {
             File.WriteAllText(path, contents, encoding);
         }
+
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="IFile.WriteAllText(string,ReadOnlySpan{char})"/>
+        public override void WriteAllText(string path, ReadOnlySpan<char> contents)
+        {
+            File.WriteAllText(path, contents);
+        }
+
+        /// <inheritdoc cref="IFile.WriteAllText(string,ReadOnlySpan{char},Encoding)"/>
+        public override void WriteAllText(string path, ReadOnlySpan<char> contents, Encoding encoding)
+        {
+            File.WriteAllText(path, contents, encoding);
+        }
+#endif
     }
 }

--- a/src/TestableIO.System.IO.Abstractions/IFile.Async.cs
+++ b/src/TestableIO.System.IO.Abstractions/IFile.Async.cs
@@ -9,6 +9,18 @@ namespace System.IO.Abstractions
 {
     partial interface IFile
     {
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="File.AppendAllBytesAsync(string, byte[], CancellationToken)" />
+        Task AppendAllBytesAsync(string path,
+            byte[] bytes,
+            CancellationToken cancellationToken = default);
+        
+        /// <inheritdoc cref="File.AppendAllBytesAsync(string, ReadOnlyMemory{byte}, CancellationToken)" />
+        Task AppendAllBytesAsync(string path,
+            ReadOnlyMemory<byte> bytes,
+            CancellationToken cancellationToken = default);
+#endif
+        
         /// <inheritdoc cref="File.AppendAllLinesAsync(string, IEnumerable{string}, CancellationToken)" />
         Task AppendAllLinesAsync(string path,
             IEnumerable<string> contents,
@@ -31,6 +43,19 @@ namespace System.IO.Abstractions
             Encoding encoding,
             CancellationToken cancellationToken = default);
 
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="File.AppendAllTextAsync(string, ReadOnlyMemory{char}, CancellationToken)" />
+        Task AppendAllTextAsync(string path,
+            ReadOnlyMemory<char> contents,
+            CancellationToken cancellationToken = default);
+        
+        /// <inheritdoc cref="File.AppendAllTextAsync(string, ReadOnlyMemory{char}, Encoding, CancellationToken)" />
+        Task AppendAllTextAsync(string path,
+            ReadOnlyMemory<char> contents,
+            Encoding encoding,
+            CancellationToken cancellationToken = default);
+#endif
+        
         /// <inheritdoc cref="File.ReadAllBytesAsync(string, CancellationToken)" />
         Task<byte[]> ReadAllBytesAsync(string path,
             CancellationToken cancellationToken = default);
@@ -71,6 +96,13 @@ namespace System.IO.Abstractions
             byte[] bytes,
             CancellationToken cancellationToken = default);
 
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="File.WriteAllBytesAsync(string, ReadOnlyMemory{byte}, CancellationToken)" />
+        Task WriteAllBytesAsync(string path,
+            ReadOnlyMemory<byte> bytes,
+            CancellationToken cancellationToken = default);
+#endif
+
         /// <inheritdoc cref="File.WriteAllLinesAsync(string, IEnumerable{string}, CancellationToken)" />
         Task WriteAllLinesAsync(string path,
             IEnumerable<string> contents,
@@ -92,6 +124,19 @@ namespace System.IO.Abstractions
             string? contents,
             Encoding encoding,
             CancellationToken cancellationToken = default);
+
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="File.WriteAllTextAsync(string, ReadOnlyMemory{char}, CancellationToken)" />
+        Task WriteAllTextAsync(string path,
+            ReadOnlyMemory<char> contents,
+            CancellationToken cancellationToken = default);
+        
+        /// <inheritdoc cref="File.WriteAllTextAsync(string, ReadOnlyMemory{char}, Encoding, CancellationToken)" />
+        Task WriteAllTextAsync(string path,
+            ReadOnlyMemory<char> contents,
+            Encoding encoding,
+            CancellationToken cancellationToken = default);
+#endif
     }
 }
 

--- a/src/TestableIO.System.IO.Abstractions/IFile.cs
+++ b/src/TestableIO.System.IO.Abstractions/IFile.cs
@@ -15,6 +15,16 @@ namespace System.IO.Abstractions
     public interface IFile : IFileSystemEntity
 #endif
     {
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="File.AppendAllBytes(string, byte[])" />
+        void AppendAllBytes(string path,
+            byte[] bytes);
+        
+        /// <inheritdoc cref="File.AppendAllBytes(string, ReadOnlySpan{byte})" />
+        void AppendAllBytes(string path,
+            ReadOnlySpan<byte> bytes);
+#endif
+        
         /// <inheritdoc cref="File.AppendAllLines(string, IEnumerable{string})" />
         void AppendAllLines(string path, IEnumerable<string> contents);
 
@@ -26,6 +36,17 @@ namespace System.IO.Abstractions
 
         /// <inheritdoc cref="File.AppendAllText(string, string?, Encoding)" />
         void AppendAllText(string path, string? contents, Encoding encoding);
+
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="File.AppendAllText(string, ReadOnlySpan{char})" />
+        void AppendAllText(string path,
+            ReadOnlySpan<char> contents);
+        
+        /// <inheritdoc cref="File.AppendAllText(string, ReadOnlySpan{char}, Encoding)" />
+        void AppendAllText(string path,
+            ReadOnlySpan<char> contents,
+            Encoding encoding);
+#endif
 
         /// <inheritdoc cref="File.AppendText(string)" />
         StreamWriter AppendText(string path);
@@ -274,6 +295,12 @@ namespace System.IO.Abstractions
         /// <inheritdoc cref="File.WriteAllBytes(string, byte[])" />
         void WriteAllBytes(string path, byte[] bytes);
 
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="File.WriteAllBytes(string, ReadOnlySpan{byte})" />
+        void WriteAllBytes(string path,
+            ReadOnlySpan<byte> bytes);
+#endif
+
         /// <inheritdoc cref="File.WriteAllLines(string, string[])" />
         void WriteAllLines(string path, string[] contents);
 
@@ -291,5 +318,16 @@ namespace System.IO.Abstractions
 
         /// <inheritdoc cref="File.WriteAllText(string, string, Encoding)" />
         void WriteAllText(string path, string? contents, Encoding encoding);
+
+#if FEATURE_FILE_SPAN
+        /// <inheritdoc cref="File.WriteAllText(string, ReadOnlySpan{char})" />
+        void WriteAllText(string path,
+            ReadOnlySpan<char> contents);
+        
+        /// <inheritdoc cref="File.WriteAllText(string, ReadOnlySpan{char}, Encoding)" />
+        void WriteAllText(string path,
+            ReadOnlySpan<char> contents,
+            Encoding encoding);
+#endif
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllTextTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllTextTests.cs
@@ -315,7 +315,7 @@
             fileSystem.AddDirectory(directoryPath);
 
             // Act
-            await fileSystem.File.WriteAllTextAsync(filePath, null);
+            await fileSystem.File.WriteAllTextAsync(filePath, "");
 
             // Assert
             // no exception should be thrown, also the documentation says so
@@ -334,7 +334,7 @@
             fileSystem.AddFile(filePath, mockFileData);
 
             // Act
-            AsyncTestDelegate action = () => fileSystem.File.WriteAllTextAsync(filePath, null);
+            AsyncTestDelegate action = () => fileSystem.File.WriteAllTextAsync(filePath, "");
 
             // Assert
             Assert.ThrowsAsync<UnauthorizedAccessException>(action);
@@ -349,7 +349,7 @@
             fileSystem.AddDirectory(directoryPath);
 
             // Act
-            AsyncTestDelegate action = () => fileSystem.File.WriteAllTextAsync(directoryPath, null);
+            AsyncTestDelegate action = () => fileSystem.File.WriteAllTextAsync(directoryPath, "");
 
             // Assert
             Assert.ThrowsAsync<UnauthorizedAccessException>(action);

--- a/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/__snapshots__/ApiParityTests.File_.NET 9.0.snap
+++ b/tests/TestableIO.System.IO.Abstractions.Wrappers.Tests/__snapshots__/ApiParityTests.File_.NET 9.0.snap
@@ -1,20 +1,6 @@
 ﻿{
   "ExtraMembers": [],
   "MissingMembers": [
-    "Microsoft.Win32.SafeHandles.SafeFileHandle OpenHandle(System.String, System.IO.FileMode, System.IO.FileAccess, System.IO.FileShare, System.IO.FileOptions, Int64)",
-    "System.Threading.Tasks.Task AppendAllBytesAsync(System.String, Byte[], System.Threading.CancellationToken)",
-    "System.Threading.Tasks.Task AppendAllBytesAsync(System.String, System.ReadOnlyMemory`1[System.Byte], System.Threading.CancellationToken)",
-    "System.Threading.Tasks.Task AppendAllTextAsync(System.String, System.ReadOnlyMemory`1[System.Char], System.Text.Encoding, System.Threading.CancellationToken)",
-    "System.Threading.Tasks.Task AppendAllTextAsync(System.String, System.ReadOnlyMemory`1[System.Char], System.Threading.CancellationToken)",
-    "System.Threading.Tasks.Task WriteAllBytesAsync(System.String, System.ReadOnlyMemory`1[System.Byte], System.Threading.CancellationToken)",
-    "System.Threading.Tasks.Task WriteAllTextAsync(System.String, System.ReadOnlyMemory`1[System.Char], System.Text.Encoding, System.Threading.CancellationToken)",
-    "System.Threading.Tasks.Task WriteAllTextAsync(System.String, System.ReadOnlyMemory`1[System.Char], System.Threading.CancellationToken)",
-    "Void AppendAllBytes(System.String, Byte[])",
-    "Void AppendAllBytes(System.String, System.ReadOnlySpan`1[System.Byte])",
-    "Void AppendAllText(System.String, System.ReadOnlySpan`1[System.Char])",
-    "Void AppendAllText(System.String, System.ReadOnlySpan`1[System.Char], System.Text.Encoding)",
-    "Void WriteAllBytes(System.String, System.ReadOnlySpan`1[System.Byte])",
-    "Void WriteAllText(System.String, System.ReadOnlySpan`1[System.Char])",
-    "Void WriteAllText(System.String, System.ReadOnlySpan`1[System.Char], System.Text.Encoding)"
+    "Microsoft.Win32.SafeHandles.SafeFileHandle OpenHandle(System.String, System.IO.FileMode, System.IO.FileAccess, System.IO.FileShare, System.IO.FileOptions, Int64)"
   ]
 }


### PR DESCRIPTION
- Task AppendAllBytesAsync(string, byte[], CancellationToken)
- Task AppendAllBytesAsync(string, ReadOnlyMemory<byte>, CancellationToken)
- Task AppendAllTextAsync(string, ReadOnlyMemory<char>, Encoding, CancellationToken)
- Task AppendAllTextAsync(string, ReadOnlyMemory<char>, CancellationToken)
- Task WriteAllBytesAsync(string, ReadOnlyMemory<byte>, CancellationToken)
- Task WriteAllTextAsync(string, ReadOnlyMemory<char>, Encoding, CancellationToken)
- Task WriteAllTextAsync(string, ReadOnlyMemory<char>, CancellationToken)
- void AppendAllBytes(string, byte[])
- void AppendAllBytes(string, ReadOnlySpan<byte>)
- void AppendAllText(string, ReadOnlySpan<char>)
- void AppendAllText(string, ReadOnlySpan<char>, Encoding)
- void WriteAllBytes(string, ReadOnlySpan<byte>)
- void WriteAllText(string, ReadOnlySpan<char>)
- void WriteAllText(string, ReadOnlySpan<char>, Encoding)