### PR TITLE
docs: fix XML documentation warnings

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryBase.cs
@@ -1,6 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Runtime.Versioning;
-using System.Security.AccessControl;
 
 namespace System.IO.Abstractions
 {
@@ -10,7 +8,9 @@ namespace System.IO.Abstractions
 #endif
     public abstract class DirectoryBase : IDirectory
     {
-        /// <inheritdoc />
+        /// <summary>
+        /// Base class for calling static methods of <see cref="Directory"/>
+        /// </summary>
         protected DirectoryBase(IFileSystem fileSystem)
         {
             FileSystem = fileSystem;

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryInfoBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryInfoBase.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Security.AccessControl;
 
 namespace System.IO.Abstractions
 {
@@ -9,7 +8,9 @@ namespace System.IO.Abstractions
 #endif
     public abstract class DirectoryInfoBase : FileSystemInfoBase, IDirectoryInfo
     {
-        /// <inheritdoc />
+        /// <summary>
+        /// Base class for calling methods of <see cref="DirectoryInfo"/>
+        /// </summary>
         protected DirectoryInfoBase(IFileSystem fileSystem) : base(fileSystem)
         {
         }
@@ -120,7 +121,9 @@ namespace System.IO.Abstractions
         /// <inheritdoc cref="IDirectoryInfo.Root"/>
         public abstract IDirectoryInfo Root { get; }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Implicitly converts a <see cref="DirectoryInfo"/> to a <see cref="DirectoryInfoBase"/>.
+        /// </summary>
         public static implicit operator DirectoryInfoBase(DirectoryInfo directoryInfo)
         {
             if (directoryInfo == null)

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryInfoFactory.cs
@@ -7,7 +7,9 @@ namespace System.IO.Abstractions
     {
         private readonly IFileSystem fileSystem;
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Base factory class for creating a <see cref="IDirectoryInfo"/>
+        /// </summary>
         public DirectoryInfoFactory(IFileSystem fileSystem)
         {
             this.fileSystem = fileSystem;

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryInfoWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryInfoWrapper.cs
@@ -1,12 +1,11 @@
 ﻿using System.Collections.Generic;
-using System.IO.Pipes;
 using System.Linq;
 using System.Runtime.Versioning;
 using System.Security.AccessControl;
 
 namespace System.IO.Abstractions
 {
-    /// <inheritdoc />
+    /// <inheritdoc cref="DirectoryInfoBase" />
 #if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
@@ -14,7 +13,9 @@ namespace System.IO.Abstractions
     {
         private readonly DirectoryInfo instance;
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Wrapper class for calling methods of <see cref="DirectoryInfo"/>
+        /// </summary>
         public DirectoryInfoWrapper(IFileSystem fileSystem, DirectoryInfo instance) : base(fileSystem)
         {
             this.instance = instance ?? throw new ArgumentNullException(nameof(instance));

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DirectoryWrapper.cs
@@ -3,7 +3,7 @@ using System.Runtime.Versioning;
 
 namespace System.IO.Abstractions
 {
-    /// <inheritdoc />
+    /// <inheritdoc cref="DirectoryBase" />
 #if FEATURE_SERIALIZABLE
     [Serializable]
 #endif

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DriveInfoBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DriveInfoBase.cs
@@ -6,7 +6,9 @@
 #endif
     public abstract class DriveInfoBase : IDriveInfo
     {
-        /// <inheritdoc />
+        /// <summary>
+        /// Base class for calling methods of <see cref="DriveInfo"/>
+        /// </summary>
         protected DriveInfoBase(IFileSystem fileSystem)
         {
             FileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
@@ -48,9 +50,8 @@
         public abstract string VolumeLabel { get; set; }
 
         /// <summary>
-        /// Converts a <see cref="DriveInfo"/> into a <see cref="DriveInfoBase"/>.
+        /// Implicitly converts a <see cref="DriveInfo"/> to a <see cref="DriveInfoBase"/>.
         /// </summary>
-        /// <param name="driveInfo">The drive info to be converted.</param>
         public static implicit operator DriveInfoBase(DriveInfo driveInfo)
         {
             if (driveInfo == null)

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/DriveInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/DriveInfoFactory.cs
@@ -7,6 +7,9 @@
     {
         private readonly IFileSystem fileSystem;
 
+        /// <summary>
+        /// Base factory class for creating a <see cref="IDriveInfo"/>
+        /// </summary>
         public DriveInfoFactory(IFileSystem fileSystem)
         {
             this.fileSystem = fileSystem;

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileBase.cs
@@ -10,7 +10,9 @@ namespace System.IO.Abstractions
 #endif
     public abstract partial class FileBase : IFile
     {
-        ///
+        /// <summary>
+        /// Base class for calling static methods of <see cref="File"/>
+        /// </summary>
         protected FileBase(IFileSystem fileSystem)
         {
             FileSystem = fileSystem;

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileInfoBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileInfoBase.cs
@@ -1,6 +1,4 @@
-﻿using System.Security.AccessControl;
-
-namespace System.IO.Abstractions
+﻿namespace System.IO.Abstractions
 {
     /// <inheritdoc cref="FileInfo"/>
 #if FEATURE_SERIALIZABLE
@@ -8,7 +6,9 @@ namespace System.IO.Abstractions
 #endif
     public abstract class FileInfoBase : FileSystemInfoBase, IFileInfo
     {
-        /// <inheritdoc />
+        /// <summary>
+        /// Base class for calling methods of <see cref="FileInfo"/>
+        /// </summary>
         protected FileInfoBase(IFileSystem fileSystem) : base(fileSystem)
         {
         }
@@ -86,7 +86,9 @@ namespace System.IO.Abstractions
         /// <inheritdoc cref="IFileInfo.Length"/>
         public abstract long Length { get; }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Implicitly converts a <see cref="FileInfo"/> to a <see cref="FileInfoBase"/>.
+        /// </summary>
         public static implicit operator FileInfoBase(FileInfo fileInfo)
         {
             if (fileInfo == null)

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileInfoFactory.cs
@@ -7,7 +7,9 @@
     {
         private readonly IFileSystem fileSystem;
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Base factory class for creating a <see cref="IFileInfo"/>
+        /// </summary>
         public FileInfoFactory(IFileSystem fileSystem)
         {
             this.fileSystem = fileSystem;

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileInfoWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileInfoWrapper.cs
@@ -3,7 +3,7 @@ using System.Security.AccessControl;
 
 namespace System.IO.Abstractions
 {
-    /// <inheritdoc />
+    /// <inheritdoc cref="FileInfoBase" />
 #if FEATURE_SERIALIZABLE
     [Serializable]
 #endif
@@ -11,7 +11,9 @@ namespace System.IO.Abstractions
     {
         private readonly FileInfo instance;
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Wrapper class for calling methods of <see cref="FileInfo"/>
+        /// </summary>
         public FileInfoWrapper(IFileSystem fileSystem, FileInfo instance) : base(fileSystem)
         {
             this.instance = instance ?? throw new ArgumentNullException(nameof(instance));

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileStreamAclExtensions.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileStreamAclExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.Versioning;
+﻿using System.Runtime.Versioning;
 using System.Security.AccessControl;
 
 namespace System.IO.Abstractions

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileStreamFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileStreamFactory.cs
@@ -7,6 +7,9 @@ namespace System.IO.Abstractions
 #endif
     internal sealed class FileStreamFactory : IFileStreamFactory
     {
+        /// <summary>
+        /// Base factory class for creating a <see cref="FileSystemStream"/>
+        /// </summary>
         public FileStreamFactory(IFileSystem fileSystem)
         {
             FileSystem = fileSystem;

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemInfoBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemInfoBase.cs
@@ -8,7 +8,9 @@ namespace System.IO.Abstractions
 #endif
     public abstract class FileSystemInfoBase : IFileSystemInfo
     {
-        ///
+        /// <summary>
+        /// Base class for calling methods of <see cref="FileSystemInfo"/>
+        /// </summary>
         protected FileSystemInfoBase(IFileSystem fileSystem)
         {
             FileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemWatcherBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemWatcherBase.cs
@@ -25,7 +25,7 @@ namespace System.IO.Abstractions
 
 #if FEATURE_FILE_SYSTEM_WATCHER_FILTERS
         /// <inheritdoc cref="FileSystemWatcher.Filters"/>
-        public abstract System.Collections.ObjectModel.Collection<string> Filters { get; }
+        public abstract Collections.ObjectModel.Collection<string> Filters { get; }
 #endif
 
         /// <inheritdoc cref="FileSystemWatcher.InternalBufferSize"/>
@@ -82,7 +82,9 @@ namespace System.IO.Abstractions
         public abstract IWaitForChangedResult WaitForChanged(WatcherChangeTypes changeType, TimeSpan timeout);
 #endif
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Implicitly converts a <see cref="FileSystemWatcher"/> to a <see cref="FileSystemWatcherBase"/>.
+        /// </summary>
         public static implicit operator FileSystemWatcherBase(FileSystemWatcher watcher)
         {
             if (watcher == null)
@@ -93,37 +95,49 @@ namespace System.IO.Abstractions
             return new FileSystemWatcherWrapper(new FileSystem(), watcher);
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Callback executed during <see cref="IDisposable.Dispose()"/>
+        /// </summary>
         public virtual void Dispose(bool disposing)
         {
             // do nothing
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Invokes the <see cref="Created"/> event.
+        /// </summary>
         protected void OnCreated(object sender, FileSystemEventArgs args)
         {
             Created?.Invoke(sender, args);
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Invokes the <see cref="Changed"/> event.
+        /// </summary>
         protected void OnChanged(object sender, FileSystemEventArgs args)
         {
             Changed?.Invoke(sender, args);
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Invokes the <see cref="Deleted"/> event.
+        /// </summary>
         protected void OnDeleted(object sender, FileSystemEventArgs args)
         {
             Deleted?.Invoke(sender, args);
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Invokes the <see cref="Renamed"/> event.
+        /// </summary>
         protected void OnRenamed(object sender, RenamedEventArgs args)
         {
             Renamed?.Invoke(sender, args);
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Invokes the <see cref="Error"/> event.
+        /// </summary>
         protected void OnError(object sender, ErrorEventArgs args)
         {
             Error?.Invoke(sender, args);

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemWatcherFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemWatcherFactory.cs
@@ -6,7 +6,9 @@
 #endif
     public class FileSystemWatcherFactory : IFileSystemWatcherFactory
     {
-        ///
+        /// <summary>
+        /// Base factory class for creating a <see cref="IFileSystemWatcher"/>
+        /// </summary>
         public FileSystemWatcherFactory(IFileSystem fileSystem)
         {
             FileSystem = fileSystem;

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemWatcherWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileSystemWatcherWrapper.cs
@@ -76,7 +76,7 @@ namespace System.IO.Abstractions
 
 #if FEATURE_FILE_SYSTEM_WATCHER_FILTERS
         /// <inheritdoc />
-        public override System.Collections.ObjectModel.Collection<string> Filters
+        public override Collections.ObjectModel.Collection<string> Filters
         {
             get { return watcher.Filters; }
         }
@@ -168,33 +168,33 @@ namespace System.IO.Abstractions
         private readonly struct WaitForChangedResultWrapper
             : IWaitForChangedResult, IEquatable<WaitForChangedResultWrapper>
         {
-            private readonly WaitForChangedResult _instance;
+            private readonly WaitForChangedResult instance;
 
             public WaitForChangedResultWrapper(WaitForChangedResult instance)
             {
-                _instance = instance;
+                this.instance = instance;
             }
 
             /// <inheritdoc cref="IWaitForChangedResult.ChangeType" />
             public WatcherChangeTypes ChangeType
-                => _instance.ChangeType;
+                => instance.ChangeType;
 
             /// <inheritdoc cref="IWaitForChangedResult.Name" />
             public string Name
-                => _instance.Name;
+                => instance.Name;
 
             /// <inheritdoc cref="IWaitForChangedResult.OldName" />
             public string OldName
-                => _instance.OldName;
+                => instance.OldName;
 
             /// <inheritdoc cref="IWaitForChangedResult.TimedOut" />
             public bool TimedOut
-                => _instance.TimedOut;
+                => instance.TimedOut;
 
             /// <inheritdoc cref="IEquatable{WaitForChangedResultWrapper}.Equals(WaitForChangedResultWrapper)" />
             public bool Equals(WaitForChangedResultWrapper other)
             {
-                return _instance.Equals(other._instance);
+                return instance.Equals(other.instance);
             }
 
             /// <inheritdoc cref="object.Equals(object)" />
@@ -207,7 +207,7 @@ namespace System.IO.Abstractions
             /// <inheritdoc cref="object.GetHashCode()" />
             public override int GetHashCode()
             {
-                return _instance.GetHashCode();
+                return instance.GetHashCode();
             }
         }
     }

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileVersionInfoBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileVersionInfoBase.cs
@@ -89,7 +89,9 @@ namespace System.IO.Abstractions
         /// <inheritdoc cref="IFileVersionInfo.SpecialBuild" />
         public abstract string SpecialBuild { get; }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Implicitly converts a <see cref="FileVersionInfo"/> to a <see cref="FileVersionInfoBase"/>.
+        /// </summary>
         public static implicit operator FileVersionInfoBase(FileVersionInfo fileVersionInfo)
         {
             if (fileVersionInfo == null)
@@ -100,7 +102,7 @@ namespace System.IO.Abstractions
             return new FileVersionInfoWrapper(fileVersionInfo);
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc cref="FileVersionInfo.ToString()" />
         public new abstract string ToString();
     }
 }

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/FileVersionInfoFactory.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/FileVersionInfoFactory.cs
@@ -7,7 +7,9 @@
     {
         private readonly IFileSystem fileSystem;
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Base factory class for creating a <see cref="IFileVersionInfo"/>
+        /// </summary>
         public FileVersionInfoFactory(IFileSystem fileSystem)
         {
             this.fileSystem = fileSystem;

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/PathBase.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/PathBase.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-
-namespace System.IO.Abstractions
+﻿namespace System.IO.Abstractions
 {
     /// <inheritdoc cref="Path"/>
 #if FEATURE_SERIALIZABLE
@@ -8,7 +6,9 @@ namespace System.IO.Abstractions
 #endif
     public abstract class PathBase : IPath
     {
-        /// <inheritdoc />
+        /// <summary>
+        /// Base class for calling static methods of <see cref="Path"/>
+        /// </summary>
         protected PathBase(IFileSystem fileSystem)
         {
             this.FileSystem = fileSystem;

--- a/src/TestableIO.System.IO.Abstractions.Wrappers/PathWrapper.cs
+++ b/src/TestableIO.System.IO.Abstractions.Wrappers/PathWrapper.cs
@@ -1,6 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-
-namespace System.IO.Abstractions
+﻿namespace System.IO.Abstractions
 {
     /// <inheritdoc />
 #if FEATURE_SERIALIZABLE


### PR DESCRIPTION
Fix warnings due to incorrect XML documentation in "TestableIO.System.IO.Abstractions.Wrappers"