### PR TITLE
feat: update version to 21.3 due to .NET9 support

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "21.2",
+  "version": "21.3",
   "assemblyVersion": {
     "precision": "major"
   },


### PR DESCRIPTION
The support for .NET9 should have increased the minor version and not just the patch version and was forgotten in #1193 