### PR TITLE
refactor: remove SauceControl.Inheritdoc

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,7 +22,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SauceControl.InheritDoc" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.7.115" />
-    <PackageVersion Include="SauceControl.InheritDoc" Version="2.0.2" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,6 +6,5 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile >true</GenerateDocumentationFile>
-    <InheritDocEnabled>true</InheritDocEnabled>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Simplify dependencies as the inheritdoc functionality works without external libraries in modern IDEs