### PR TITLE
fix: avoid duplicate commit ID in file version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,6 +24,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath=""/>


### PR DESCRIPTION
Currently the Commit SHA is added twice in the file version:
![image](https://github.com/user-attachments/assets/d1681cfd-717f-4ea5-aa1f-87cce686ca81)

Set `IncludeSourceRevisionInInformationalVersion` to false, to avoid the automatic suffix and only use the explicit one in the pipeline.