### PR TITLE
refactor: use aweXpect in testinghelper tests

### DIFF
--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryArgumentPathTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryArgumentPathTests.cs
@@ -29,17 +29,17 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [TestCaseSource(nameof(GetFileSystemActionsForArgumentNullException))]
-        public void Operations_ShouldThrowArgumentNullExceptionIfPathIsNull(Action<IDirectory> action)
+        public async Task Operations_ShouldThrowArgumentNullExceptionIfPathIsNull(Action<IDirectory> action)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate wrapped = () => action(fileSystem.Directory);
+            Action wrapped = () => action(fileSystem.Directory);
 
             // Assert
-            var exception = Assert.Throws<ArgumentNullException>(wrapped);
-            Assert.That(exception.ParamName, Is.EqualTo("path"));
+            var exception = await That(wrapped).Throws<ArgumentNullException>();
+            await That(exception.ParamName).IsEqualTo("path");
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryGetAccessControlTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryGetAccessControlTests.cs
@@ -13,35 +13,35 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     {
         [TestCase(" ")]
         [TestCase("   ")]
-        public void MockDirectory_GetAccessControl_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        public async Task MockDirectory_GetAccessControl_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => fileSystem.Directory.GetAccessControl(path);
+            Action action = () => fileSystem.Directory.GetAccessControl(path);
 
             // Assert
-            var exception = Assert.Throws<ArgumentException>(action);
-            Assert.That(exception.ParamName, Is.EqualTo("path"));
+            var exception = await That(action).Throws<ArgumentException>();
+            await That(exception.ParamName).IsEqualTo("path");
         }
 
         [Test]
-        public void MockDirectory_GetAccessControl_ShouldThrowDirectoryNotFoundExceptionIfDirectoryDoesNotExistInMockData()
+        public async Task MockDirectory_GetAccessControl_ShouldThrowDirectoryNotFoundExceptionIfDirectoryDoesNotExistInMockData()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
             var expectedDirectoryName = XFS.Path(@"c:\a");
 
             // Act
-            TestDelegate action = () => fileSystem.Directory.GetAccessControl(expectedDirectoryName);
+            Action action = () => fileSystem.Directory.GetAccessControl(expectedDirectoryName);
 
             // Assert
-            Assert.Throws<DirectoryNotFoundException>(action);
+            await That(action).Throws<DirectoryNotFoundException>();
         }
 
         [Test]
-        public void MockDirectory_GetAccessControl_ShouldReturnAccessControlOfDirectoryData()
+        public async Task MockDirectory_GetAccessControl_ShouldReturnAccessControlOfDirectoryData()
         {
             // Arrange
             var expectedDirectorySecurity = new DirectorySecurity();
@@ -62,7 +62,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var directorySecurity = fileSystem.Directory.GetAccessControl(filePath);
 
             // Assert
-            Assert.That(directorySecurity, Is.EqualTo(expectedDirectorySecurity));
+            await That(directorySecurity).IsEqualTo(expectedDirectorySecurity);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoAccessControlTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoAccessControlTests.cs
@@ -12,7 +12,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockDirectoryInfoAccessControlTests
     {
         [Test]
-        public void MockDirectoryInfo_GetAccessControl_ShouldReturnAccessControlOfDirectoryData()
+        public async Task MockDirectoryInfo_GetAccessControl_ShouldReturnAccessControlOfDirectoryData()
         {
             // Arrange
             var expectedDirectorySecurity = new DirectorySecurity();
@@ -35,11 +35,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var directorySecurity = directorInfo.GetAccessControl();
 
             // Assert
-            Assert.That(directorySecurity, Is.EqualTo(expectedDirectorySecurity));
+            await That(directorySecurity).IsEqualTo(expectedDirectorySecurity);
         }
 
         [Test]
-        public void MockDirectoryInfo_SetAccessControl_ShouldSetAccessControlOfDirectoryData()
+        public async Task MockDirectoryInfo_SetAccessControl_ShouldSetAccessControlOfDirectoryData()
         {
             // Arrange
             var filePath = XFS.Path(@"c:\a\");
@@ -59,7 +59,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             var accessControl = directorInfo.GetAccessControl();
-            Assert.That(accessControl, Is.EqualTo(expectedAccessControl));
+            await That(accessControl).IsEqualTo(expectedAccessControl);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoFactoryTests.cs
@@ -6,24 +6,24 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockDirectoryInfoFactoryTests
     {
         [Test]
-        public void MockDirectoryInfoFactory_Wrap_WithNull_ShouldReturnNull()
+        public async Task MockDirectoryInfoFactory_Wrap_WithNull_ShouldReturnNull()
         {
             var fileSystem = new MockFileSystem();
 
             var result = fileSystem.DirectoryInfo.Wrap(null);
             
-            Assert.That(result, Is.Null);
+            await That(result).IsNull();
         }
 
         [Test]
-        public void MockDirectoryInfoFactory_Wrap_ShouldKeepNameAndFullName()
+        public async Task MockDirectoryInfoFactory_Wrap_ShouldKeepNameAndFullName()
         {
             var fs = new MockFileSystem();
             var directoryInfo = new DirectoryInfo(@"C:\subfolder\file");
             var wrappedDirectoryInfo = fs.DirectoryInfo.Wrap(directoryInfo);
 
-            Assert.That(wrappedDirectoryInfo.FullName, Is.EqualTo(directoryInfo.FullName));
-            Assert.That(wrappedDirectoryInfo.Name, Is.EqualTo(directoryInfo.Name));
+            await That(wrappedDirectoryInfo.FullName).IsEqualTo(directoryInfo.FullName);
+            await That(wrappedDirectoryInfo.Name).IsEqualTo(directoryInfo.Name);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoSymlinkTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoSymlinkTests.cs
@@ -15,7 +15,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 #if FEATURE_CREATE_SYMBOLIC_LINK
 
         [Test]
-        public void MockDirectoryInfo_ResolveLinkTarget_ShouldReturnPathOfTargetLink()
+        public async Task MockDirectoryInfo_ResolveLinkTarget_ShouldReturnPathOfTargetLink()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.Directory.CreateDirectory("bar");
@@ -23,11 +23,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.DirectoryInfo.New("foo").ResolveLinkTarget(false);
 
-            Assert.That(result.Name, Is.EqualTo("bar"));
+            await That(result.Name).IsEqualTo("bar");
         }
 
         [Test]
-        public void MockDirectoryInfo_ResolveLinkTarget_WithFinalTarget_ShouldReturnPathOfTargetLink()
+        public async Task MockDirectoryInfo_ResolveLinkTarget_WithFinalTarget_ShouldReturnPathOfTargetLink()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.Directory.CreateDirectory("bar");
@@ -36,11 +36,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.DirectoryInfo.New("foo1").ResolveLinkTarget(true);
 
-            Assert.That(result.Name, Is.EqualTo("bar"));
+            await That(result.Name).IsEqualTo("bar");
         }
 
         [Test]
-        public void MockDirectoryInfo_ResolveLinkTarget_WithoutFinalTarget_ShouldReturnFirstLink()
+        public async Task MockDirectoryInfo_ResolveLinkTarget_WithoutFinalTarget_ShouldReturnFirstLink()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.Directory.CreateDirectory("bar");
@@ -49,20 +49,20 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.DirectoryInfo.New("foo1").ResolveLinkTarget(false);
 
-            Assert.That(result.Name, Is.EqualTo("foo"));
+            await That(result.Name).IsEqualTo("foo");
         }
 
         [Test]
-        public void MockDirectoryInfo_ResolveLinkTarget_WithoutTargetLink_ShouldThrowIOException()
+        public async Task MockDirectoryInfo_ResolveLinkTarget_WithoutTargetLink_ShouldThrowIOException()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.Directory.CreateDirectory("bar");
             fileSystem.Directory.CreateSymbolicLink("foo", "bar");
 
-            Assert.Throws<IOException>(() =>
+            await That(() =>
             {
                 fileSystem.DirectoryInfo.New("bar").ResolveLinkTarget(false);
-            });
+            }).Throws<IOException>();
         }
 #endif
     }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryInfoTests.cs
@@ -20,7 +20,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [TestCaseSource(nameof(MockDirectoryInfo_GetExtension_Cases))]
-        public void MockDirectoryInfo_GetExtension_ShouldReturnEmptyString(string directoryPath)
+        public async Task MockDirectoryInfo_GetExtension_ShouldReturnEmptyString(string directoryPath)
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
@@ -30,7 +30,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = directoryInfo.Extension;
 
             // Assert
-            Assert.That(result, Is.Empty);
+            await That(result).IsEmpty();
         }
 
         public static IEnumerable<object[]> MockDirectoryInfo_Exists_Cases
@@ -43,7 +43,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [TestCaseSource(nameof(MockDirectoryInfo_Exists_Cases))]
-        public void MockDirectoryInfo_Exists(string path, bool expected)
+        public async Task MockDirectoryInfo_Exists(string path, bool expected)
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -53,21 +53,21 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = directoryInfo.Exists;
 
-            Assert.That(result, Is.EqualTo(expected));
+            await That(result).IsEqualTo(expected);
         }
 
         [Test]
-        public void MockDirectoryInfo_Attributes_ShouldReturnMinusOneForNonExistingFile()
+        public async Task MockDirectoryInfo_Attributes_ShouldReturnMinusOneForNonExistingFile()
         {
             var fileSystem = new MockFileSystem();
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\non\existing\file.txt"));
             FileAttributes expected = (FileAttributes)(-1);
 
-            Assert.That(directoryInfo.Attributes, Is.EqualTo(expected));
+            await That(directoryInfo.Attributes).IsEqualTo(expected);
         }
 
         [Test]
-        public void MockDirectoryInfo_Attributes_Clear_ShouldRemainDirectory()
+        public async Task MockDirectoryInfo_Attributes_Clear_ShouldRemainDirectory()
         {
             var fileSystem = new MockFileSystem();
             var path = XFS.Path(@"c:\existing\directory");
@@ -75,22 +75,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var directoryInfo = fileSystem.DirectoryInfo.New(path);
             directoryInfo.Attributes = 0;
 
-            Assert.That(fileSystem.File.Exists(path), Is.False);
-            Assert.That(directoryInfo.Attributes, Is.EqualTo(FileAttributes.Directory));
+            await That(fileSystem.File.Exists(path)).IsFalse();
+            await That(directoryInfo.Attributes).IsEqualTo(FileAttributes.Directory);
         }
 
         [Test]
-        public void MockDirectoryInfo_Attributes_SetterShouldThrowDirectoryNotFoundExceptionOnNonExistingFileOrDirectory()
+        public async Task MockDirectoryInfo_Attributes_SetterShouldThrowDirectoryNotFoundExceptionOnNonExistingFileOrDirectory()
         {
             var fileSystem = new MockFileSystem();
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\non\existing"));
 
-            Assert.That(() => directoryInfo.Attributes = FileAttributes.Hidden, Throws.TypeOf<DirectoryNotFoundException>());
+            await That(() => directoryInfo.Attributes = FileAttributes.Hidden).Throws<DirectoryNotFoundException>();
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.UNCPaths)]
-        public void MockDirectoryInfo_GetFiles_ShouldWorkWithUNCPath()
+        public async Task MockDirectoryInfo_GetFiles_ShouldWorkWithUNCPath()
         {
             var fileName = XFS.Path(@"\\unc\folder\file.txt");
             var directoryName = XFS.Path(@"\\unc\folder");
@@ -106,12 +106,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var files = directoryInfo.GetFiles();
 
             // Assert
-            Assert.That(files[0].FullName, Is.EqualTo(fileName));
+            await That(files[0].FullName).IsEqualTo(fileName);
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.UNCPaths)]
-        public void MockDirectoryInfo_GetFiles_ShouldWorkWithUNCPath_WhenCurrentDirectoryIsUnc()
+        public async Task MockDirectoryInfo_GetFiles_ShouldWorkWithUNCPath_WhenCurrentDirectoryIsUnc()
         {
             var fileName = XFS.Path(@"\\unc\folder\file.txt");
             var directoryName = XFS.Path(@"\\unc\folder");
@@ -129,11 +129,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var files = directoryInfo.GetFiles();
 
             // Assert
-            Assert.That(files[0].FullName, Is.EqualTo(fileName));
+            await That(files[0].FullName).IsEqualTo(fileName);
         }
 
         [Test]
-        public void MockDirectoryInfo_FullName_ShouldReturnFullNameWithoutIncludingTrailingPathDelimiter()
+        public async Task MockDirectoryInfo_FullName_ShouldReturnFullNameWithoutIncludingTrailingPathDelimiter()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -146,11 +146,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = directoryInfo.FullName;
 
-            Assert.That(result, Is.EqualTo(XFS.Path(@"c:\temp\folder")));
+            await That(result).IsEqualTo(XFS.Path(@"c:\temp\folder"));
         }
 
         [Test]
-        public void MockDirectoryInfo_GetFileSystemInfos_ShouldReturnBothDirectoriesAndFiles()
+        public async Task MockDirectoryInfo_GetFileSystemInfos_ShouldReturnBothDirectoriesAndFiles()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -161,11 +161,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\temp\folder"));
             var result = directoryInfo.GetFileSystemInfos();
 
-            Assert.That(result.Length, Is.EqualTo(2));
+            await That(result.Length).IsEqualTo(2);
         }
 
         [Test]
-        public void MockDirectoryInfo_EnumerateFileSystemInfos_ShouldReturnBothDirectoriesAndFiles()
+        public async Task MockDirectoryInfo_EnumerateFileSystemInfos_ShouldReturnBothDirectoriesAndFiles()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -176,11 +176,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\temp\folder"));
             var result = directoryInfo.EnumerateFileSystemInfos().ToArray();
 
-            Assert.That(result.Length, Is.EqualTo(2));
+            await That(result.Length).IsEqualTo(2);
         }
 
         [Test]
-        public void MockDirectoryInfo_GetFileSystemInfos_ShouldReturnDirectoriesAndNamesWithSearchPattern()
+        public async Task MockDirectoryInfo_GetFileSystemInfos_ShouldReturnDirectoriesAndNamesWithSearchPattern()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -192,11 +192,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\temp\folder"));
             var result = directoryInfo.GetFileSystemInfos("f*");
 
-            Assert.That(result.Length, Is.EqualTo(2));
+            await That(result.Length).IsEqualTo(2);
         }
 
         [Test]
-        public void MockDirectoryInfo_EnumerateFileSystemInfos_ShouldReturnDirectoriesAndNamesWithSearchPattern()
+        public async Task MockDirectoryInfo_EnumerateFileSystemInfos_ShouldReturnDirectoriesAndNamesWithSearchPattern()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -208,11 +208,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\temp\folder"));
             var result = directoryInfo.EnumerateFileSystemInfos("f*", SearchOption.AllDirectories).ToArray();
 
-            Assert.That(result.Length, Is.EqualTo(2));
+            await That(result.Length).IsEqualTo(2);
         }
 
         [Test]
-        public void MockDirectoryInfo_EnumerateFileSystemInfos_ShouldReturnDirectoriesAndNamesWithSearchPatternRecursive()
+        public async Task MockDirectoryInfo_EnumerateFileSystemInfos_ShouldReturnDirectoriesAndNamesWithSearchPatternRecursive()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -224,12 +224,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\"));
             var result = directoryInfo.EnumerateFileSystemInfos("*", SearchOption.AllDirectories).ToArray();
 
-            Assert.That(result.Length, Is.EqualTo(5));
+            await That(result.Length).IsEqualTo(5);
         }
 
 #if FEATURE_ENUMERATION_OPTIONS
         [Test]
-        public void MockDirectoryInfo_EnumerateFileSystemInfos_ShouldReturnDirectoriesAndNamesWithSearchPatternRecursiveEnumerateOptions()
+        public async Task MockDirectoryInfo_EnumerateFileSystemInfos_ShouldReturnDirectoriesAndNamesWithSearchPatternRecursiveEnumerateOptions()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -247,12 +247,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = directoryInfo.EnumerateFileSystemInfos("*", enumerationOptions).ToArray();
 
-            Assert.That(result.Length, Is.EqualTo(5));
+            await That(result.Length).IsEqualTo(5);
         }
 #endif
 
         [Test]
-        public void MockDirectoryInfo_GetParent_ShouldReturnDirectoriesAndNamesWithSearchPattern()
+        public async Task MockDirectoryInfo_GetParent_ShouldReturnDirectoriesAndNamesWithSearchPattern()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -263,11 +263,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = directoryInfo.Parent;
 
             // Assert
-            Assert.That(result.FullName, Is.EqualTo(XFS.Path(@"c:\a\b")));
+            await That(result.FullName).IsEqualTo(XFS.Path(@"c:\a\b"));
         }
 
         [Test]
-        public void MockDirectoryInfo_EnumerateFiles_ShouldReturnAllFiles()
+        public async Task MockDirectoryInfo_EnumerateFiles_ShouldReturnAllFiles()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -287,11 +287,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\temp\folder"));
 
             // Assert
-            Assert.That(directoryInfo.EnumerateFiles().ToList().Select(x => x.Name).ToArray(), Is.EqualTo(new[] { "b.txt", "c.txt" }));
+            await That(directoryInfo.EnumerateFiles().ToList().Select(x => x.Name).ToArray()).IsEqualTo(new[] { "b.txt", "c.txt" });
         }
 
         [Test]
-        public void MockDirectoryInfo_EnumerateDirectories_ShouldReturnAllDirectories()
+        public async Task MockDirectoryInfo_EnumerateDirectories_ShouldReturnAllDirectories()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -309,13 +309,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var directories = directoryInfo.EnumerateDirectories().Select(a => a.Name).ToArray();
 
             // Assert
-            Assert.That(directories, Is.EqualTo(new[] { "b", "c" }));
+            await That(directories).IsEqualTo(new[] { "b", "c" });
         }
 
         [TestCase(@"\\unc\folder", @"\\unc\folder")]
         [TestCase(@"\\unc/folder\\foo", @"\\unc\folder\foo")]
         [WindowsOnly(WindowsSpecifics.UNCPaths)]
-        public void MockDirectoryInfo_FullName_ShouldReturnNormalizedUNCPath(string directoryPath, string expectedFullName)
+        public async Task MockDirectoryInfo_FullName_ShouldReturnNormalizedUNCPath(string directoryPath, string expectedFullName)
         {
             // Arrange
             directoryPath = XFS.Path(directoryPath);
@@ -327,13 +327,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualFullName = directoryInfo.FullName;
 
             // Assert
-            Assert.That(actualFullName, Is.EqualTo(expectedFullName));
+            await That(actualFullName).IsEqualTo(expectedFullName);
         }
 
         [TestCase(@"c:\temp\\folder", @"c:\temp\folder")]
         [TestCase(@"c:\temp//folder", @"c:\temp\folder")]
         [TestCase(@"c:\temp//\\///folder", @"c:\temp\folder")]
-        public void MockDirectoryInfo_FullName_ShouldReturnNormalizedPath(string directoryPath, string expectedFullName)
+        public async Task MockDirectoryInfo_FullName_ShouldReturnNormalizedPath(string directoryPath, string expectedFullName)
         {
             // Arrange
             directoryPath = XFS.Path(directoryPath);
@@ -345,12 +345,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualFullName = directoryInfo.FullName;
 
             // Assert
-            Assert.That(actualFullName, Is.EqualTo(expectedFullName));
+            await That(actualFullName).IsEqualTo(expectedFullName);
         }
 
         [TestCase(@"c:\temp\folder  ", @"c:\temp\folder")]
         [WindowsOnly(WindowsSpecifics.Drives)]
-        public void MockDirectoryInfo_FullName_ShouldReturnPathWithTrimmedTrailingSpaces(string directoryPath, string expectedFullName)
+        public async Task MockDirectoryInfo_FullName_ShouldReturnPathWithTrimmedTrailingSpaces(string directoryPath, string expectedFullName)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -360,11 +360,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualFullName = directoryInfo.FullName;
 
             // Assert
-            Assert.That(actualFullName, Is.EqualTo(expectedFullName));
+            await That(actualFullName).IsEqualTo(expectedFullName);
         }
 
         [Test]
-        public void MockDirectoryInfo_MoveTo_ShouldUpdateFullName()
+        public async Task MockDirectoryInfo_MoveTo_ShouldUpdateFullName()
         {
             // Arrange
             var path = XFS.Path(@"c:\source");
@@ -377,12 +377,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             directoryInfo.MoveTo(destination);
 
             // Assert
-            Assert.That(directoryInfo.FullName, Is.EqualTo(destination));
+            await That(directoryInfo.FullName).IsEqualTo(destination);
         }
 
         [TestCase(@"c:\temp\\folder ", @"folder")]
         [WindowsOnly(WindowsSpecifics.Drives)]
-        public void MockDirectoryInfo_Name_ShouldReturnNameWithTrimmedTrailingSpaces(string directoryPath, string expectedName)
+        public async Task MockDirectoryInfo_Name_ShouldReturnNameWithTrimmedTrailingSpaces(string directoryPath, string expectedName)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -392,12 +392,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualName = directoryInfo.Name;
 
             // Assert
-            Assert.That(actualName, Is.EqualTo(expectedName));
+            await That(actualName).IsEqualTo(expectedName);
         }
 
         [TestCase(@"c:\", @"c:\")]
         [WindowsOnly(WindowsSpecifics.Drives)]
-        public void MockDirectoryInfo_Name_ShouldReturnPathRoot_IfDirectoryPathIsPathRoot(string directoryPath, string expectedName)
+        public async Task MockDirectoryInfo_Name_ShouldReturnPathRoot_IfDirectoryPathIsPathRoot(string directoryPath, string expectedName)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -407,53 +407,53 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualName = directoryInfo.Name;
 
             // Assert
-            Assert.That(actualName, Is.EqualTo(expectedName));
+            await That(actualName).IsEqualTo(expectedName);
         }
 
         [Test]
-        public void MockDirectoryInfo_Constructor_ShouldThrowArgumentNullException_IfArgumentDirectoryIsNull()
+        public async Task MockDirectoryInfo_Constructor_ShouldThrowArgumentNullException_IfArgumentDirectoryIsNull()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => new MockDirectoryInfo(fileSystem, null);
+            Action action = () => new MockDirectoryInfo(fileSystem, null);
 
             // Assert
-            var exception = Assert.Throws<ArgumentNullException>(action);
-            Assert.That(exception.Message, Does.StartWith("Value cannot be null."));
+            var exception = await That(action).Throws<ArgumentNullException>();
+            await That(exception.Message).StartsWith("Value cannot be null.");
         }
 
         [Test]
-        public void MockDirectoryInfo_Constructor_ShouldThrowArgumentNullException_IfArgumentFileSystemIsNull()
+        public async Task MockDirectoryInfo_Constructor_ShouldThrowArgumentNullException_IfArgumentFileSystemIsNull()
         {
             // Arrange
             // nothing to do
 
             // Act
-            TestDelegate action = () => new MockDirectoryInfo(null, XFS.Path(@"c:\foo\bar\folder"));
+            Action action = () => new MockDirectoryInfo(null, XFS.Path(@"c:\foo\bar\folder"));
 
             // Assert
-            Assert.Throws<ArgumentNullException>(action);
+            await That(action).Throws<ArgumentNullException>();
         }
 
         [Test]
-        public void MockDirectoryInfo_Constructor_ShouldThrowArgumentException_IfArgumentDirectoryIsEmpty()
+        public async Task MockDirectoryInfo_Constructor_ShouldThrowArgumentException_IfArgumentDirectoryIsEmpty()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => new MockDirectoryInfo(fileSystem, string.Empty);
+            Action action = () => new MockDirectoryInfo(fileSystem, string.Empty);
 
             // Assert
-            var exception = Assert.Throws<ArgumentException>(action);
-            Assert.That(exception.Message, Does.StartWith("The path is not of a legal form."));
+            var exception = await That(action).Throws<ArgumentException>();
+            await That(exception.Message).StartsWith("The path is not of a legal form.");
         }
 
         [TestCase(@"c:\temp\folder\folder")]
         [TestCase(@"..\..\..\Desktop")]
-        public void MockDirectoryInfo_ToString_ShouldReturnDirectoryName(string directoryName)
+        public async Task MockDirectoryInfo_ToString_ShouldReturnDirectoryName(string directoryName)
         {
             // Arrange
             var directoryPath = XFS.Path(directoryName);
@@ -462,11 +462,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var mockDirectoryInfo = new MockDirectoryInfo(new MockFileSystem(), directoryPath);
 
             // Assert
-            Assert.That(mockDirectoryInfo.ToString(), Is.EqualTo(directoryPath));
+            await That(mockDirectoryInfo.ToString()).IsEqualTo(directoryPath);
         }
 
         [Test]
-        public void MockDirectoryInfo_Exists_ShouldReturnCachedData()
+        public async Task MockDirectoryInfo_Exists_ShouldReturnCachedData()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -477,11 +477,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(path);
 
             // Assert
-            Assert.That(directoryInfo.Exists, Is.False);
+            await That(directoryInfo.Exists).IsFalse();
         }
 
         [Test]
-        public void MockDirectoryInfo_Exists_ShouldUpdateCachedDataOnRefresh()
+        public async Task MockDirectoryInfo_Exists_ShouldUpdateCachedDataOnRefresh()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -493,11 +493,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             directoryInfo.Refresh();
 
             // Assert
-            Assert.That(directoryInfo.Exists, Is.True);
+            await That(directoryInfo.Exists).IsTrue();
         }
 
         [Test]
-        public void Directory_exists_after_creation()
+        public async Task Directory_exists_after_creation()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -507,11 +507,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             directoryInfo.Create();
 
             // Assert
-            Assert.That(directoryInfo.Exists, Is.True);
+            await That(directoryInfo.Exists).IsTrue();
         }
 
         [Test, WindowsOnly(WindowsSpecifics.AccessControlLists)]
-        public void Directory_exists_after_creation_with_security()
+        public async Task Directory_exists_after_creation_with_security()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -523,11 +523,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 #pragma warning restore CA1416
 
             // Assert
-            Assert.That(directoryInfo.Exists, Is.True);
+            await That(directoryInfo.Exists).IsTrue();
         }
 
         [Test]
-        public void Directory_does_not_exist_after_delete()
+        public async Task Directory_does_not_exist_after_delete()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -537,11 +537,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             directoryInfo.Delete();
 
             // Assert
-            Assert.That(directoryInfo.Exists, Is.False);
+            await That(directoryInfo.Exists).IsFalse();
         }
 
         [Test]
-        public void Directory_does_not_exist_after_recursive_delete()
+        public async Task Directory_does_not_exist_after_recursive_delete()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -551,11 +551,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             directoryInfo.Delete(true);
 
             // Assert
-            Assert.That(directoryInfo.Exists, Is.False);
+            await That(directoryInfo.Exists).IsFalse();
         }
 
         [Test]
-        public void Directory_still_exists_after_move()
+        public async Task Directory_still_exists_after_move()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -565,11 +565,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             directoryInfo.MoveTo(XFS.Path(@"c:\abc2"));
 
             // Assert
-            Assert.That(directoryInfo.Exists, Is.True);
+            await That(directoryInfo.Exists).IsTrue();
         }
 
         [Test]
-        public void MockDirectoryInfo_LastAccessTime_ShouldReflectChangedValue()
+        public async Task MockDirectoryInfo_LastAccessTime_ShouldReflectChangedValue()
         {
             // Arrange  
             var path = XFS.Path(@"c:\abc");
@@ -584,141 +584,141 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             directoryInfo.LastAccessTime = lastAccessTime;
 
             // Assert
-            Assert.That(directoryInfo.LastAccessTime, Is.EqualTo(lastAccessTime));
+            await That(directoryInfo.LastAccessTime).IsEqualTo(lastAccessTime);
         }
 
         [Test]
-        public void MockDirectoryInfo_CreationTime_ShouldReturnDefaultTimeForNonExistingFile()
+        public async Task MockDirectoryInfo_CreationTime_ShouldReturnDefaultTimeForNonExistingFile()
         {
             var fileSystem = new MockFileSystem();
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\non\existing"));
 
             var result = directoryInfo.CreationTime;
 
-            Assert.That(result, Is.EqualTo(MockFileData.DefaultDateTimeOffset.LocalDateTime));
+            await That(result).IsEqualTo(MockFileData.DefaultDateTimeOffset.LocalDateTime);
         }
 
         [Test]
-        public void MockDirectoryInfo_LastAccessTime_ShouldReturnDefaultTimeForNonExistingFile()
+        public async Task MockDirectoryInfo_LastAccessTime_ShouldReturnDefaultTimeForNonExistingFile()
         {
             var fileSystem = new MockFileSystem();
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\non\existing"));
 
             var result = directoryInfo.LastAccessTime;
 
-            Assert.That(result, Is.EqualTo(MockFileData.DefaultDateTimeOffset.LocalDateTime));
+            await That(result).IsEqualTo(MockFileData.DefaultDateTimeOffset.LocalDateTime);
         }
 
         [Test]
-        public void MockDirectoryInfo_LastWriteTime_ShouldReturnDefaultTimeForNonExistingFile()
+        public async Task MockDirectoryInfo_LastWriteTime_ShouldReturnDefaultTimeForNonExistingFile()
         {
             var fileSystem = new MockFileSystem();
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\non\existing"));
 
             var result = directoryInfo.LastWriteTime;
 
-            Assert.That(result, Is.EqualTo(MockFileData.DefaultDateTimeOffset.LocalDateTime));
+            await That(result).IsEqualTo(MockFileData.DefaultDateTimeOffset.LocalDateTime);
         }
 
         [Test]
-        public void MockDirectoryInfo_CreationTimeUtc_ShouldReturnDefaultTimeForNonExistingFile()
+        public async Task MockDirectoryInfo_CreationTimeUtc_ShouldReturnDefaultTimeForNonExistingFile()
         {
             var fileSystem = new MockFileSystem();
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\non\existing"));
 
             var result = directoryInfo.CreationTimeUtc;
 
-            Assert.That(result, Is.EqualTo(MockFileData.DefaultDateTimeOffset.UtcDateTime));
+            await That(result).IsEqualTo(MockFileData.DefaultDateTimeOffset.UtcDateTime);
         }
 
         [Test]
-        public void MockDirectoryInfo_LastAccessTimeUtc_ShouldReturnDefaultTimeForNonExistingFile()
+        public async Task MockDirectoryInfo_LastAccessTimeUtc_ShouldReturnDefaultTimeForNonExistingFile()
         {
             var fileSystem = new MockFileSystem();
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\non\existing"));
 
             var result = directoryInfo.LastAccessTimeUtc;
 
-            Assert.That(result, Is.EqualTo(MockFileData.DefaultDateTimeOffset.UtcDateTime));
+            await That(result).IsEqualTo(MockFileData.DefaultDateTimeOffset.UtcDateTime);
         }
 
         [Test]
-        public void MockDirectoryInfo_LastWriteTimeUtc_ShouldReturnDefaultTimeForNonExistingFile()
+        public async Task MockDirectoryInfo_LastWriteTimeUtc_ShouldReturnDefaultTimeForNonExistingFile()
         {
             var fileSystem = new MockFileSystem();
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\non\existing"));
 
             var result = directoryInfo.LastWriteTimeUtc;
 
-            Assert.That(result, Is.EqualTo(MockFileData.DefaultDateTimeOffset.UtcDateTime));
+            await That(result).IsEqualTo(MockFileData.DefaultDateTimeOffset.UtcDateTime);
         }
 
         [Test]
-        public void MockDirectoryInfo_Create_WithConflictingFile_ShouldThrowIOException()
+        public async Task MockDirectoryInfo_Create_WithConflictingFile_ShouldThrowIOException()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.AddFile(XFS.Path(@"c:\foo\bar.txt"), new MockFileData("Demo text content"));
             var sut = fileSystem.DirectoryInfo.New(XFS.Path(@"c:\foo\bar.txt"));
 
             // Act
-            TestDelegate action = () => sut.Create();
+            Action action = () => sut.Create();
 
             // Assert
-            Assert.Throws<IOException>(action);
+            await That(action).Throws<IOException>();
         }
 
-        public void MockDirectoryInfo_CreationTime_SetterShouldThrowDirectoryNotFoundExceptionForNonExistingDirectory()
+        public async Task MockDirectoryInfo_CreationTime_SetterShouldThrowDirectoryNotFoundExceptionForNonExistingDirectory()
         {
             var newTime = new DateTime(2022, 04, 06);
             var fileSystem = new MockFileSystem();
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\non\existing"));
 
-            Assert.That(() => directoryInfo.CreationTime = newTime, Throws.TypeOf<DirectoryNotFoundException>());
+            await That(() => directoryInfo.CreationTime = newTime).Throws<DirectoryNotFoundException>();
         }
 
-        public void MockDirectoryInfo_LastAccessTime_SetterShouldThrowDirectoryNotFoundExceptionForNonExistingDirectory()
+        public async Task MockDirectoryInfo_LastAccessTime_SetterShouldThrowDirectoryNotFoundExceptionForNonExistingDirectory()
         {
             var newTime = new DateTime(2022, 04, 06);
             var fileSystem = new MockFileSystem();
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\non\existing"));
 
-            Assert.That(() => directoryInfo.LastAccessTime = newTime, Throws.TypeOf<DirectoryNotFoundException>());
+            await That(() => directoryInfo.LastAccessTime = newTime).Throws<DirectoryNotFoundException>();
         }
 
-        public void MockDirectoryInfo_LastWriteTime_SetterShouldThrowDirectoryNotFoundExceptionForNonExistingDirectory()
+        public async Task MockDirectoryInfo_LastWriteTime_SetterShouldThrowDirectoryNotFoundExceptionForNonExistingDirectory()
         {
             var newTime = new DateTime(2022, 04, 06);
             var fileSystem = new MockFileSystem();
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\non\existing"));
 
-            Assert.That(() => directoryInfo.LastWriteTime = newTime, Throws.TypeOf<DirectoryNotFoundException>());
+            await That(() => directoryInfo.LastWriteTime = newTime).Throws<DirectoryNotFoundException>();
         }
 
-        public void MockDirectoryInfo_CreationTimeUtc_SetterShouldThrowDirectoryNotFoundExceptionForNonExistingDirectory()
+        public async Task MockDirectoryInfo_CreationTimeUtc_SetterShouldThrowDirectoryNotFoundExceptionForNonExistingDirectory()
         {
             var newTime = new DateTime(2022, 04, 06);
             var fileSystem = new MockFileSystem();
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\non\existing"));
 
-            Assert.That(() => directoryInfo.CreationTimeUtc = newTime, Throws.TypeOf<DirectoryNotFoundException>());
+            await That(() => directoryInfo.CreationTimeUtc = newTime).Throws<DirectoryNotFoundException>();
         }
 
-        public void MockDirectoryInfo_LastAccessTimeUtc_SetterShouldThrowDirectoryNotFoundExceptionForNonExistingDirectory()
+        public async Task MockDirectoryInfo_LastAccessTimeUtc_SetterShouldThrowDirectoryNotFoundExceptionForNonExistingDirectory()
         {
             var newTime = new DateTime(2022, 04, 06);
             var fileSystem = new MockFileSystem();
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\non\existing"));
 
-            Assert.That(() => directoryInfo.LastAccessTimeUtc = newTime, Throws.TypeOf<DirectoryNotFoundException>());
+            await That(() => directoryInfo.LastAccessTimeUtc = newTime).Throws<DirectoryNotFoundException>();
         }
 
-        public void MockDirectoryInfo_LastWriteTimeUtc_SetterShouldThrowDirectoryNotFoundExceptionForNonExistingDirectory()
+        public async Task MockDirectoryInfo_LastWriteTimeUtc_SetterShouldThrowDirectoryNotFoundExceptionForNonExistingDirectory()
         {
             var newTime = new DateTime(2022, 04, 06);
             var fileSystem = new MockFileSystem();
             var directoryInfo = new MockDirectoryInfo(fileSystem, XFS.Path(@"c:\non\existing"));
 
-            Assert.That(() => directoryInfo.LastWriteTime = newTime, Throws.TypeOf<DirectoryNotFoundException>());
+            await That(() => directoryInfo.LastWriteTime = newTime).Throws<DirectoryNotFoundException>();
         }
 
     }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectorySetAccessControlTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectorySetAccessControlTests.cs
@@ -14,22 +14,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     {
         [TestCase(" ")]
         [TestCase("   ")]
-        public void MockDirectory_SetAccessControl_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        public async Task MockDirectory_SetAccessControl_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
             var directorySecurity = new DirectorySecurity();
 
             // Act
-            TestDelegate action = () => fileSystem.Directory.SetAccessControl(path, directorySecurity);
+            Action action = () => fileSystem.Directory.SetAccessControl(path, directorySecurity);
 
             // Assert
-            var exception = Assert.Throws<ArgumentException>(action);
-            Assert.That(exception.ParamName, Is.EqualTo("path"));
+            var exception = await That(action).Throws<ArgumentException>();
+            await That(exception.ParamName).IsEqualTo("path");
         }
 
         [Test]
-        public void MockDirectory_SetAccessControl_ShouldThrowDirectoryNotFoundExceptionIfDirectoryDoesNotExistInMockData()
+        public async Task MockDirectory_SetAccessControl_ShouldThrowDirectoryNotFoundExceptionIfDirectoryDoesNotExistInMockData()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -37,14 +37,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var directorySecurity = new DirectorySecurity();
 
             // Act
-            TestDelegate action = () => fileSystem.Directory.SetAccessControl(expectedFileName, directorySecurity);
+            Action action = () => fileSystem.Directory.SetAccessControl(expectedFileName, directorySecurity);
 
             // Assert
-            Assert.Throws<DirectoryNotFoundException>(action);
+            await That(action).Throws<DirectoryNotFoundException>();
         }
 
         [Test]
-        public void MockDirectory_SetAccessControl_ShouldSetAccessControlOfDirectoryData()
+        public async Task MockDirectory_SetAccessControl_ShouldSetAccessControlOfDirectoryData()
         {
             // Arrange
             var filePath = XFS.Path(@"c:\a\");
@@ -62,7 +62,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             var accessControl = fileSystem.Directory.GetAccessControl(filePath);
-            Assert.That(accessControl, Is.EqualTo(expectedAccessControl));
+            await That(accessControl).IsEqualTo(expectedAccessControl);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectorySymlinkTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectorySymlinkTests.cs
@@ -11,7 +11,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 #if FEATURE_CREATE_SYMBOLIC_LINK
 
         [Test]
-        public void MockDirectory_CreateSymbolicLink_ShouldReturnFileSystemInfo()
+        public async Task MockDirectory_CreateSymbolicLink_ShouldReturnFileSystemInfo()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -23,12 +23,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             IFileSystemInfo fileSystemInfo = fileSystem.Directory.CreateSymbolicLink(path, pathToTarget);
 
             // Assert
-            Assert.That(fileSystemInfo.FullName, Is.EqualTo(path));
-            Assert.That(fileSystemInfo.LinkTarget, Is.EqualTo(pathToTarget));
+            await That(fileSystemInfo.FullName).IsEqualTo(path);
+            await That(fileSystemInfo.LinkTarget).IsEqualTo(pathToTarget);
         }
 
         [Test]
-        public void MockDirectory_CreateSymbolicLink_ShouldSucceedFromDirectoryInfo()
+        public async Task MockDirectory_CreateSymbolicLink_ShouldSucceedFromDirectoryInfo()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -41,12 +41,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             IDirectoryInfo directoryInfo = fileSystem.DirectoryInfo.New(path);
 
             // Assert
-            Assert.That(directoryInfo.FullName, Is.EqualTo(path));
-            Assert.That(directoryInfo.LinkTarget, Is.EqualTo(pathToTarget));
+            await That(directoryInfo.FullName).IsEqualTo(path);
+            await That(directoryInfo.LinkTarget).IsEqualTo(pathToTarget);
         }
 
         [Test]
-        public void MockDirectory_CreateSymbolicLink_ShouldFailWithNullPath()
+        public async Task MockDirectory_CreateSymbolicLink_ShouldFailWithNullPath()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -54,14 +54,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(pathToTarget);
 
             // Act
-            var ex = Assert.Throws<ArgumentNullException>(() => fileSystem.Directory.CreateSymbolicLink(null, pathToTarget));
+            var ex = await That(() => fileSystem.Directory.CreateSymbolicLink(null, pathToTarget)).Throws<ArgumentNullException>();
 
             // Assert
-            Assert.That(ex.ParamName, Is.EqualTo("path"));
+            await That(ex.ParamName).IsEqualTo("path");
         }
 
         [Test]
-        public void MockDirectory_CreateSymbolicLink_ShouldFailWithNullTarget()
+        public async Task MockDirectory_CreateSymbolicLink_ShouldFailWithNullTarget()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -69,14 +69,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(path);
 
             // Act
-            var ex = Assert.Throws<ArgumentNullException>(() => fileSystem.Directory.CreateSymbolicLink(path, null));
+            var ex = await That(() => fileSystem.Directory.CreateSymbolicLink(path, null)).Throws<ArgumentNullException>();
 
             // Assert
-            Assert.That(ex.ParamName, Is.EqualTo("pathToTarget"));
+            await That(ex.ParamName).IsEqualTo("pathToTarget");
         }
 
         [Test]
-        public void MockDirectory_CreateSymbolicLink_ShouldFailWithEmptyPath()
+        public async Task MockDirectory_CreateSymbolicLink_ShouldFailWithEmptyPath()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -84,14 +84,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(pathToTarget);
 
             // Act
-            var ex = Assert.Throws<ArgumentException>(() => fileSystem.Directory.CreateSymbolicLink("", pathToTarget));
+            var ex = await That(() => fileSystem.Directory.CreateSymbolicLink("", pathToTarget)).Throws<ArgumentException>();
 
             // Assert
-            Assert.That(ex.ParamName, Is.EqualTo("path"));
+            await That(ex.ParamName).IsEqualTo("path");
         }
 
         [Test]
-        public void MockDirectory_CreateSymbolicLink_ShouldFailWithEmptyTarget()
+        public async Task MockDirectory_CreateSymbolicLink_ShouldFailWithEmptyTarget()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -99,14 +99,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(path);
 
             // Act
-            var ex = Assert.Throws<ArgumentException>(() => fileSystem.Directory.CreateSymbolicLink(path, ""));
+            var ex = await That(() => fileSystem.Directory.CreateSymbolicLink(path, "")).Throws<ArgumentException>();
 
             // Assert
-            Assert.That(ex.ParamName, Is.EqualTo("pathToTarget"));
+            await That(ex.ParamName).IsEqualTo("pathToTarget");
         }
 
         [Test]
-        public void MockDirectory_CreateSymbolicLink_ShouldFailWithIllegalPath()
+        public async Task MockDirectory_CreateSymbolicLink_ShouldFailWithIllegalPath()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -114,14 +114,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(pathToTarget);
 
             // Act
-            var ex = Assert.Throws<ArgumentException>(() => fileSystem.Directory.CreateSymbolicLink(" ", pathToTarget));
+            var ex = await That(() => fileSystem.Directory.CreateSymbolicLink(" ", pathToTarget)).Throws<ArgumentException>();
 
             // Assert
-            Assert.That(ex.ParamName, Is.EqualTo("path"));
+            await That(ex.ParamName).IsEqualTo("path");
         }
 
         [Test]
-        public void MockDirectory_CreateSymbolicLink_ShouldFailWithIllegalTarget()
+        public async Task MockDirectory_CreateSymbolicLink_ShouldFailWithIllegalTarget()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -129,15 +129,15 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(path);
 
             // Act
-            var ex = Assert.Throws<ArgumentException>(() => fileSystem.Directory.CreateSymbolicLink(path, " "));
+            var ex = await That(() => fileSystem.Directory.CreateSymbolicLink(path, " ")).Throws<ArgumentException>();
 
             // Assert
-            Assert.That(ex.ParamName, Is.EqualTo("pathToTarget"));
+            await That(ex.ParamName).IsEqualTo("pathToTarget");
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.StrictPathRules)]
-        public void MockDirectory_CreateSymbolicLink_ShouldFailWithIllegalCharactersInPath()
+        public async Task MockDirectory_CreateSymbolicLink_ShouldFailWithIllegalCharactersInPath()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -145,29 +145,29 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(pathToTarget);
 
             // Act
-            TestDelegate ex = () => fileSystem.Directory.CreateSymbolicLink(@"C:\bar_?_", pathToTarget);
+            Action ex = () => fileSystem.Directory.CreateSymbolicLink(@"C:\bar_?_", pathToTarget);
 
             // Assert
-            Assert.Throws<ArgumentException>(ex);
+            await That(ex).Throws<ArgumentException>();
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.StrictPathRules)]
-        public void MockDirectory_CreateSymbolicLink_ShouldFailWithIllegalCharactersInTarget()
+        public async Task MockDirectory_CreateSymbolicLink_ShouldFailWithIllegalCharactersInTarget()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
             string path = XFS.Path(@"C:\foo");
 
             // Act
-            TestDelegate ex = () => fileSystem.Directory.CreateSymbolicLink(path, @"C:\bar_?_");
+            Action ex = () => fileSystem.Directory.CreateSymbolicLink(path, @"C:\bar_?_");
 
             // Assert
-            Assert.Throws<ArgumentException>(ex);
+            await That(ex).Throws<ArgumentException>();
         }
 
         [Test]
-        public void MockDirectory_CreateSymbolicLink_ShouldFailIfPathExists()
+        public async Task MockDirectory_CreateSymbolicLink_ShouldFailIfPathExists()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -177,14 +177,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(path);
 
             // Act
-            var ex = Assert.Throws<IOException>(() => fileSystem.Directory.CreateSymbolicLink(path, pathToTarget));
+            var ex = await That(() => fileSystem.Directory.CreateSymbolicLink(path, pathToTarget)).Throws<IOException>();
 
             // Assert
-            Assert.That(ex.Message.Contains("path"));
+            await That(ex.Message).Contains("path");
         }
 
         [Test]
-        public void MockDirectory_CreateSymbolicLink_ShouldNotFailIfTargetDoesNotExist()
+        public async Task MockDirectory_CreateSymbolicLink_ShouldNotFailIfTargetDoesNotExist()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -195,11 +195,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSystemInfo = fileSystem.Directory.CreateSymbolicLink(path, pathToTarget);
 
             // Assert
-            Assert.That(fileSystemInfo.Exists, Is.True);
+            await That(fileSystemInfo.Exists).IsTrue();
         }
 
         [Test]
-        public void MockDirectory_CreateSymbolicLink_ShouldSetReparsePointAttribute()
+        public async Task MockDirectory_CreateSymbolicLink_ShouldSetReparsePointAttribute()
         {
             var path = "foo";
             var pathToTarget = "bar";
@@ -209,11 +209,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.CreateSymbolicLink(path, pathToTarget);
 
             var attributes = fileSystem.DirectoryInfo.New(path).Attributes;
-            Assert.That(attributes.HasFlag(FileAttributes.ReparsePoint), Is.True);
+            await That(attributes.HasFlag(FileAttributes.ReparsePoint)).IsTrue();
         }
 
         [Test]
-        public void MockDirectory_ResolveLinkTarget_ShouldReturnPathOfTargetLink()
+        public async Task MockDirectory_ResolveLinkTarget_ShouldReturnPathOfTargetLink()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.Directory.CreateDirectory("bar");
@@ -221,11 +221,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.Directory.ResolveLinkTarget("foo", false);
 
-            Assert.That(result.Name, Is.EqualTo("bar"));
+            await That(result.Name).IsEqualTo("bar");
         }
 
         [Test]
-        public void MockDirectory_ResolveLinkTarget_WithFinalTarget_ShouldReturnPathOfTargetLink()
+        public async Task MockDirectory_ResolveLinkTarget_WithFinalTarget_ShouldReturnPathOfTargetLink()
         {
             // The maximum number of symbolic links that are followed:
             // https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.resolvelinktarget?view=net-6.0#remarks
@@ -242,11 +242,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.Directory.ResolveLinkTarget(previousPath, true);
 
-            Assert.That(result.Name, Is.EqualTo("bar"));
+            await That(result.Name).IsEqualTo("bar");
         }
 
         [Test]
-        public void MockDirectory_ResolveLinkTarget_WithFinalTargetWithTooManyLinks_ShouldThrowIOException()
+        public async Task MockDirectory_ResolveLinkTarget_WithFinalTargetWithTooManyLinks_ShouldThrowIOException()
         {
             // The maximum number of symbolic links that are followed:
             // https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.resolvelinktarget?view=net-6.0#remarks
@@ -262,11 +262,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 previousPath = newPath;
             }
 
-            Assert.Throws<IOException>(() => fileSystem.Directory.ResolveLinkTarget(previousPath, true));
+            await That(() => fileSystem.Directory.ResolveLinkTarget(previousPath, true)).Throws<IOException>();
         }
 
         [Test]
-        public void MockDirectory_ResolveLinkTarget_WithoutFinalTarget_ShouldReturnFirstLink()
+        public async Task MockDirectory_ResolveLinkTarget_WithoutFinalTarget_ShouldReturnFirstLink()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.Directory.CreateDirectory("bar");
@@ -275,20 +275,20 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.Directory.ResolveLinkTarget("foo1", false);
 
-            Assert.That(result.Name, Is.EqualTo("foo"));
+            await That(result.Name).IsEqualTo("foo");
         }
 
         [Test]
-        public void MockDirectory_ResolveLinkTarget_WithoutTargetLink_ShouldThrowIOException()
+        public async Task MockDirectory_ResolveLinkTarget_WithoutTargetLink_ShouldThrowIOException()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.Directory.CreateDirectory("bar");
             fileSystem.Directory.CreateSymbolicLink("foo", "bar");
 
-            Assert.Throws<IOException>(() =>
+            await That(() =>
             {
                 fileSystem.Directory.ResolveLinkTarget("bar", false);
-            });
+            }).Throws<IOException>();
         }
 #endif
     }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -2113,7 +2113,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var path = XFS.Path(@"C:\NoTrailingBackslash");
             var fs = new MockFileSystem();
             fs.Directory.CreateDirectory(path);
-            fs.Directory.SetCreationTime(path, DateTime.Now);
+            await That(()=> fs.Directory.SetCreationTime(path, DateTime.Now)).DoesNotThrow();
             fs.Directory.Delete(path);
         }
 

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Versioning;
 using System.Security.AccessControl;
+using aweXpect.Equivalency;
 using NUnit.Framework;
 
 namespace System.IO.Abstractions.TestingHelpers.Tests
@@ -12,7 +13,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockDirectoryTests
     {
         [Test]
-        public void MockDirectory_GetFiles_ShouldReturnAllFilesBelowPathWhenPatternIsEmptyAndSearchOptionIsAllDirectories()
+        public async Task MockDirectory_GetFiles_ShouldReturnAllFilesBelowPathWhenPatternIsEmptyAndSearchOptionIsAllDirectories()
         {
             // Arrange
             var fileSystem = SetupFileSystem();
@@ -32,11 +33,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\a"), "", SearchOption.AllDirectories);
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 
         [Test]
-        public void MockDirectory_GetFiles_ShouldReturnFilesDirectlyBelowPathWhenPatternIsEmptyAndSearchOptionIsTopDirectoryOnly()
+        public async Task MockDirectory_GetFiles_ShouldReturnFilesDirectlyBelowPathWhenPatternIsEmptyAndSearchOptionIsTopDirectoryOnly()
         {
             // Arrange
             var fileSystem = SetupFileSystem();
@@ -52,11 +53,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\a"), "", SearchOption.TopDirectoryOnly);
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 
         [Test]
-        public void MockDirectory_GetFiles_ShouldReturnAllFilesBelowPathWhenPatternIsWildcardAndSearchOptionIsAllDirectories()
+        public async Task MockDirectory_GetFiles_ShouldReturnAllFilesBelowPathWhenPatternIsWildcardAndSearchOptionIsAllDirectories()
         {
             // Arrange
             var fileSystem = SetupFileSystem();
@@ -76,12 +77,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\a"), "*", SearchOption.AllDirectories);
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 
 #if FEATURE_ENUMERATION_OPTIONS
         [Test]
-        public void MockDirectory_GetFiles_ShouldReturnAllPatternMatchingFilesWhenEnumerationOptionHasRecurseSubdirectoriesSetToTrue()
+        public async Task MockDirectory_GetFiles_ShouldReturnAllPatternMatchingFilesWhenEnumerationOptionHasRecurseSubdirectoriesSetToTrue()
         {
             // Arrange
             var fileSystem = SetupFileSystem();
@@ -99,7 +100,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), "*.txt", new EnumerationOptions { RecurseSubdirectories = true });
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 #endif
 
@@ -124,7 +125,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockDirectory_GetFiles_ShouldReturnFilesDirectlyBelowPathWhenPatternIsWildcardAndSearchOptionIsTopDirectoryOnly()
+        public async Task MockDirectory_GetFiles_ShouldReturnFilesDirectlyBelowPathWhenPatternIsWildcardAndSearchOptionIsTopDirectoryOnly()
         {
             // Arrange
             var fileSystem = SetupFileSystem();
@@ -140,11 +141,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\a"), "*", SearchOption.TopDirectoryOnly);
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 
         [Test]
-        public void MockDirectory_GetFiles_ShouldFilterByExtensionBasedSearchPattern()
+        public async Task MockDirectory_GetFiles_ShouldFilterByExtensionBasedSearchPattern()
         {
             // Arrange
             var fileSystem = SetupFileSystem();
@@ -159,11 +160,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), "*.gif", SearchOption.AllDirectories);
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 
         [Test]
-        public void MockDirectory_GetFiles_ShouldFilterByExtensionBasedSearchPatternWithThreeCharacterLongFileExtension_RespectingAllDirectorySearchOption()
+        public async Task MockDirectory_GetFiles_ShouldFilterByExtensionBasedSearchPatternWithThreeCharacterLongFileExtension_RespectingAllDirectorySearchOption()
         {
             // Arrange
             var additionalFilePath = XFS.Path(@"c:\a\a\c.gifx");
@@ -183,11 +184,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), "*.gif", SearchOption.AllDirectories);
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 
         [Test]
-        public void MockDirectory_GetFiles_ShouldFilterByExtensionBasedSearchPatternWithThreeCharacterLongFileExtension_RespectingTopDirectorySearchOption()
+        public async Task MockDirectory_GetFiles_ShouldFilterByExtensionBasedSearchPatternWithThreeCharacterLongFileExtension_RespectingTopDirectorySearchOption()
         {
             // Arrange
             var additionalFilePath = XFS.Path(@"c:\a\c.gifx");
@@ -205,11 +206,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\a"), "*.gif", SearchOption.TopDirectoryOnly);
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 
         [Test]
-        public void MockDirectory_GetFiles_ShouldFilterByExtensionBasedSearchPatternOnlyIfTheFileExtensionIsThreeCharacterLong()
+        public async Task MockDirectory_GetFiles_ShouldFilterByExtensionBasedSearchPatternOnlyIfTheFileExtensionIsThreeCharacterLong()
         {
             // Arrange
             var additionalFilePath = XFS.Path(@"c:\a\c.gi");
@@ -227,11 +228,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\a"), "*.gi", SearchOption.AllDirectories);
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 
         [Test]
-        public void MockDirectory_GetFiles_ShouldFilterByExtensionBasedSearchPatternWithDotsInFilenames()
+        public async Task MockDirectory_GetFiles_ShouldFilterByExtensionBasedSearchPatternWithDotsInFilenames()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -257,11 +258,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), "*.gif", SearchOption.AllDirectories);
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 
         [Test]
-        public void MockDirectory_GetFiles_FilterShouldFindFilesWithSpecialChars()
+        public async Task MockDirectory_GetFiles_FilterShouldFindFilesWithSpecialChars()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -279,11 +280,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), "*.*", SearchOption.AllDirectories);
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 
         [Test]
-        public void MockDirectory_GetFiles_ShouldFilterByExtensionBasedSearchPatternAndSearchOptionTopDirectoryOnly()
+        public async Task MockDirectory_GetFiles_ShouldFilterByExtensionBasedSearchPatternAndSearchOptionTopDirectoryOnly()
         {
             // Arrange
             var fileSystem = SetupFileSystem();
@@ -293,11 +294,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), "*.gif", SearchOption.TopDirectoryOnly);
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 
         [Test]
-        public void MockDirectory_GetFiles_ShouldFilterForAllFilesWithNoExtensionsAndSearchOptionTopDirectoryOnly()
+        public async Task MockDirectory_GetFiles_ShouldFilterForAllFilesWithNoExtensionsAndSearchOptionTopDirectoryOnly()
         {
             // Arrange
             var fileSystem = SetupFileSystem();
@@ -321,11 +322,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.GetFiles(XFS.Path(@"C:\"), "*.", SearchOption.TopDirectoryOnly);
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 
         [Test]
-        public void MockDirectory_GetFiles_ShouldFilterForAllFilesWithNoExtensionsAndSearchOptionAllDirectories()
+        public async Task MockDirectory_GetFiles_ShouldFilterForAllFilesWithNoExtensionsAndSearchOptionAllDirectories()
         {
             // Arrange
             var fileSystem = SetupFileSystem();
@@ -351,11 +352,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), "*.", SearchOption.AllDirectories);
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 
         [Test]
-        public void MockDirectory_GetFiles_ShouldFilterForFilesWithNoExtensionsAndNonTrivialFilterAndSearchOptionTopDirectoryOnly()
+        public async Task MockDirectory_GetFiles_ShouldFilterForFilesWithNoExtensionsAndNonTrivialFilterAndSearchOptionTopDirectoryOnly()
         {
             // Arrange
             var fileSystem = SetupFileSystem();
@@ -379,11 +380,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.GetFiles(XFS.Path(@"C:\"), "my??s*.", SearchOption.TopDirectoryOnly);
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 
         [Test]
-        public void MockDirectory_GetFiles_ShouldFilterForFilesWithNoExtensionsAndNonTrivialFilter2AndSearchOptionTopDirectoryOnly()
+        public async Task MockDirectory_GetFiles_ShouldFilterForFilesWithNoExtensionsAndNonTrivialFilter2AndSearchOptionTopDirectoryOnly()
         {
             // Arrange
             var fileSystem = SetupFileSystem();
@@ -406,11 +407,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.GetFiles(XFS.Path(@"C:\"), "my*.n*.", SearchOption.TopDirectoryOnly);
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 
         [Test]
-        public void MockDirectory_GetFiles_ShouldFilterForFilesWithNoExtensionsAndFilterThatIncludesDotAndSearchOptionTopDirectoryOnly()
+        public async Task MockDirectory_GetFiles_ShouldFilterForFilesWithNoExtensionsAndFilterThatIncludesDotAndSearchOptionTopDirectoryOnly()
         {
             // Arrange
             var fileSystem = SetupFileSystem();
@@ -432,10 +433,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.GetFiles(XFS.Path(@"C:\"), "my*.n*.", SearchOption.TopDirectoryOnly);
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 
-        private void ExecuteTimeAttributeTest(DateTime time, Action<IFileSystem, string, DateTime> setter, Func<IFileSystem, string, DateTime> getter)
+        private async Task ExecuteTimeAttributeTest(DateTime time, Action<IFileSystem, string, DateTime> setter, Func<IFileSystem, string, DateTime> getter)
         {
             string path = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -448,119 +449,119 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = getter(fileSystem, path);
 
             // Assert
-            Assert.That(result, Is.EqualTo(time));
+            await That(result).IsEqualTo(time);
         }
 
         [Test]
-        public void MockDirectory_GetCreationTime_ShouldReturnCreationTimeFromFile()
+        public async Task MockDirectory_GetCreationTime_ShouldReturnCreationTimeFromFile()
         {
-            ExecuteTimeAttributeTest(
+            await ExecuteTimeAttributeTest(
                 new DateTime(2010, 6, 4, 13, 26, 42),
                 (fs, p, d) => fs.File.SetCreationTime(p, d),
                 (fs, p) => fs.Directory.GetCreationTime(p));
         }
 
         [Test]
-        public void MockDirectory_GetCreationTimeUtc_ShouldReturnCreationTimeUtcFromFile()
+        public async Task MockDirectory_GetCreationTimeUtc_ShouldReturnCreationTimeUtcFromFile()
         {
-            ExecuteTimeAttributeTest(
+            await ExecuteTimeAttributeTest(
                 new DateTime(2010, 6, 4, 13, 26, 42, DateTimeKind.Utc),
                 (fs, p, d) => fs.File.SetCreationTimeUtc(p, d),
                 (fs, p) => fs.Directory.GetCreationTimeUtc(p));
         }
 
         [Test]
-        public void MockDirectory_GetLastAccessTime_ShouldReturnLastAccessTimeFromFile()
+        public async Task MockDirectory_GetLastAccessTime_ShouldReturnLastAccessTimeFromFile()
         {
-            ExecuteTimeAttributeTest(
+            await ExecuteTimeAttributeTest(
                 new DateTime(2010, 6, 4, 13, 26, 42),
                 (fs, p, d) => fs.File.SetLastAccessTime(p, d),
                 (fs, p) => fs.Directory.GetLastAccessTime(p));
         }
 
         [Test]
-        public void MockDirectory_GetLastAccessTimeUtc_ShouldReturnLastAccessTimeUtcFromFile()
+        public async Task MockDirectory_GetLastAccessTimeUtc_ShouldReturnLastAccessTimeUtcFromFile()
         {
-            ExecuteTimeAttributeTest(
+            await ExecuteTimeAttributeTest(
                 new DateTime(2010, 6, 4, 13, 26, 42, DateTimeKind.Utc),
                 (fs, p, d) => fs.File.SetLastAccessTimeUtc(p, d),
                 (fs, p) => fs.Directory.GetLastAccessTimeUtc(p));
         }
 
         [Test]
-        public void MockDirectory_GetLastWriteTime_ShouldReturnLastWriteTimeFromFile()
+        public async Task MockDirectory_GetLastWriteTime_ShouldReturnLastWriteTimeFromFile()
         {
-            ExecuteTimeAttributeTest(
+            await ExecuteTimeAttributeTest(
                 new DateTime(2010, 6, 4, 13, 26, 42),
                 (fs, p, d) => fs.File.SetLastWriteTime(p, d),
                 (fs, p) => fs.Directory.GetLastWriteTime(p));
         }
 
         [Test]
-        public void MockDirectory_GetLastWriteTimeUtc_ShouldReturnLastWriteTimeUtcFromFile()
+        public async Task MockDirectory_GetLastWriteTimeUtc_ShouldReturnLastWriteTimeUtcFromFile()
         {
-            ExecuteTimeAttributeTest(
+            await ExecuteTimeAttributeTest(
                 new DateTime(2010, 6, 4, 13, 26, 42, DateTimeKind.Utc),
                 (fs, p, d) => fs.File.SetLastWriteTimeUtc(p, d),
                 (fs, p) => fs.Directory.GetLastWriteTimeUtc(p));
         }
 
         [Test]
-        public void MockDirectory_SetCreationTime_ShouldSetCreationTimeOnFile()
+        public async Task MockDirectory_SetCreationTime_ShouldSetCreationTimeOnFile()
         {
-            ExecuteTimeAttributeTest(
+            await ExecuteTimeAttributeTest(
                 new DateTime(2010, 6, 4, 13, 26, 42),
                 (fs, p, d) => fs.Directory.SetCreationTime(p, d),
                 (fs, p) => fs.File.GetCreationTime(p));
         }
 
         [Test]
-        public void MockDirectory_SetCreationTimeUtc_ShouldSetCreationTimeUtcOnFile()
+        public async Task MockDirectory_SetCreationTimeUtc_ShouldSetCreationTimeUtcOnFile()
         {
-            ExecuteTimeAttributeTest(
+            await ExecuteTimeAttributeTest(
                 new DateTime(2010, 6, 4, 13, 26, 42, DateTimeKind.Utc),
                 (fs, p, d) => fs.Directory.SetCreationTimeUtc(p, d),
                 (fs, p) => fs.File.GetCreationTimeUtc(p));
         }
 
         [Test]
-        public void MockDirectory_SetLastAccessTime_ShouldSetLastAccessTimeOnFile()
+        public async Task MockDirectory_SetLastAccessTime_ShouldSetLastAccessTimeOnFile()
         {
-            ExecuteTimeAttributeTest(
+            await ExecuteTimeAttributeTest(
                 new DateTime(2010, 6, 4, 13, 26, 42),
                 (fs, p, d) => fs.Directory.SetLastAccessTime(p, d),
                 (fs, p) => fs.File.GetLastAccessTime(p));
         }
 
         [Test]
-        public void MockDirectory_SetLastAccessTimeUtc_ShouldSetLastAccessTimeUtcOnFile()
+        public async Task MockDirectory_SetLastAccessTimeUtc_ShouldSetLastAccessTimeUtcOnFile()
         {
-            ExecuteTimeAttributeTest(
+            await ExecuteTimeAttributeTest(
                 new DateTime(2010, 6, 4, 13, 26, 42, DateTimeKind.Utc),
                 (fs, p, d) => fs.Directory.SetLastAccessTimeUtc(p, d),
                 (fs, p) => fs.File.GetLastAccessTimeUtc(p));
         }
 
         [Test]
-        public void MockDirectory_SetLastWriteTime_ShouldSetLastWriteTimeOnFile()
+        public async Task MockDirectory_SetLastWriteTime_ShouldSetLastWriteTimeOnFile()
         {
-            ExecuteTimeAttributeTest(
+            await ExecuteTimeAttributeTest(
                 new DateTime(2010, 6, 4, 13, 26, 42),
                 (fs, p, d) => fs.Directory.SetLastWriteTime(p, d),
                 (fs, p) => fs.File.GetLastWriteTime(p));
         }
 
         [Test]
-        public void MockDirectory_SetLastWriteTimeUtc_ShouldSetLastWriteTimeUtcOnFile()
+        public async Task MockDirectory_SetLastWriteTimeUtc_ShouldSetLastWriteTimeUtcOnFile()
         {
-            ExecuteTimeAttributeTest(
+            await ExecuteTimeAttributeTest(
                 new DateTime(2010, 6, 4, 13, 26, 42, DateTimeKind.Utc),
                 (fs, p, d) => fs.Directory.SetLastWriteTimeUtc(p, d),
                 (fs, p) => fs.File.GetLastWriteTimeUtc(p));
         }
 
         [Test]
-        public void MockDirectory_Exists_ShouldReturnTrueForDirectoryDefinedInMemoryFileSystemWithoutTrailingSlash()
+        public async Task MockDirectory_Exists_ShouldReturnTrueForDirectoryDefinedInMemoryFileSystemWithoutTrailingSlash()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -572,11 +573,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.Exists(XFS.Path(@"c:\foo"));
 
             // Assert
-            Assert.That(result, Is.True);
+            await That(result).IsTrue();
         }
 
         [Test]
-        public void MockDirectory_Exists_ShouldReturnTrueForDirectoryDefinedInMemoryFileSystemWithTrailingSlash()
+        public async Task MockDirectory_Exists_ShouldReturnTrueForDirectoryDefinedInMemoryFileSystemWithTrailingSlash()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -588,11 +589,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.Exists(XFS.Path(@"c:\foo\"));
 
             // Assert
-            Assert.That(result, Is.True);
+            await That(result).IsTrue();
         }
 
         [Test]
-        public void MockDirectory_Exists_ShouldReturnFalseForDirectoryNotDefinedInMemoryFileSystemWithoutTrailingSlash()
+        public async Task MockDirectory_Exists_ShouldReturnFalseForDirectoryNotDefinedInMemoryFileSystemWithoutTrailingSlash()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -604,11 +605,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.Exists(XFS.Path(@"c:\baz"));
 
             // Assert
-            Assert.That(result, Is.False);
+            await That(result).IsFalse();
         }
 
         [Test]
-        public void MockDirectory_Exists_ShouldReturnFalseForDirectoryNotDefinedInMemoryFileSystemWithTrailingSlash()
+        public async Task MockDirectory_Exists_ShouldReturnFalseForDirectoryNotDefinedInMemoryFileSystemWithTrailingSlash()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -620,11 +621,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.Exists(XFS.Path(@"c:\baz\"));
 
             // Assert
-            Assert.That(result, Is.False);
+            await That(result).IsFalse();
         }
 
         [Test]
-        public void MockDirectory_Exists_ShouldReturnFalseForDirectoryNotDefinedInMemoryFileSystemWithSimilarFileName()
+        public async Task MockDirectory_Exists_ShouldReturnFalseForDirectoryNotDefinedInMemoryFileSystemWithSimilarFileName()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -637,11 +638,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.Exists(XFS.Path(@"c:\baz"));
 
             // Assert
-            Assert.That(result, Is.False);
+            await That(result).IsFalse();
         }
 
         [Test]
-        public void MockDirectory_Exists_ShouldReturnTrueForDirectoryCreatedViaMocks()
+        public async Task MockDirectory_Exists_ShouldReturnTrueForDirectoryCreatedViaMocks()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -654,11 +655,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.Exists(XFS.Path(@"c:\bar"));
 
             // Assert
-            Assert.That(result, Is.True);
+            await That(result).IsTrue();
         }
 
         [Test]
-        public void MockDirectory_Exists_ShouldReturnTrueForFolderContainingFileAddedToMockFileSystem()
+        public async Task MockDirectory_Exists_ShouldReturnTrueForFolderContainingFileAddedToMockFileSystem()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -668,13 +669,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.Exists(XFS.Path(@"c:\foo\"));
 
             // Assert
-            Assert.That(result, Is.True);
+            await That(result).IsTrue();
         }
 
         [TestCase(@"\\s")]
         [TestCase(@"<")]
         [TestCase("\t")]
-        public void MockDirectory_Exists_ShouldReturnFalseForIllegalPath(string path)
+        public async Task MockDirectory_Exists_ShouldReturnFalseForIllegalPath(string path)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -683,24 +684,24 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.Exists(path);
 
             // Assert
-            Assert.That(result, Is.False);
+            await That(result).IsFalse();
         }
 
         [Test]
-        public void MockDirectory_CreateDirectory_WithConflictingFile_ShouldThrowIOException()
+        public async Task MockDirectory_CreateDirectory_WithConflictingFile_ShouldThrowIOException()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.AddFile(XFS.Path(@"c:\foo\bar.txt"), new MockFileData("Demo text content"));
             
             // Act
-            TestDelegate action = () => fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\foo\bar.txt"));
+            Action action = () => fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\foo\bar.txt"));
 
             // Assert
-            Assert.Throws<IOException>(action);
+            await That(action).Throws<IOException>();
         }
 
         [Test]
-        public void MockDirectory_Exists_ShouldReturnFalseForFiles()
+        public async Task MockDirectory_Exists_ShouldReturnFalseForFiles()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -710,11 +711,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.Exists(XFS.Path(@"c:\foo\bar.txt"));
 
             // Assert
-            Assert.That(result, Is.False);
+            await That(result).IsFalse();
         }
 
         [Test]
-        public void MockDirectory_CreateDirectory_ShouldCreateFolderInMemoryFileSystem()
+        public async Task MockDirectory_CreateDirectory_ShouldCreateFolderInMemoryFileSystem()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -726,12 +727,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\bar"));
 
             // Assert
-            Assert.That(fileSystem.FileExists(XFS.Path(@"c:\bar\")), Is.True);
-            Assert.That(fileSystem.AllDirectories.Any(d => d == XFS.Path(@"c:\bar")), Is.True);
+            await That(fileSystem.FileExists(XFS.Path(@"c:\bar\"))).IsTrue();
+            await That(fileSystem.AllDirectories.Any(d => d == XFS.Path(@"c:\bar"))).IsTrue();
         }
 
         [Test]
-        public void MockDirectory_CreateDirectory_ShouldThrowIfIllegalCharacterInPath()
+        public async Task MockDirectory_CreateDirectory_ShouldThrowIfIllegalCharacterInPath()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -740,15 +741,15 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             });
 
             // Act
-            TestDelegate createDelegate = () => fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\bar_?_"));
+            Action createDelegate = () => fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\bar_?_"));
 
             // Assert
-            Assert.Throws<ArgumentException>(createDelegate);
+            await That(createDelegate).Throws<ArgumentException>();
         }
 
         // Issue #210
         [Test]
-        public void MockDirectory_CreateDirectory_ShouldIgnoreExistingDirectoryRegardlessOfTrailingSlash()
+        public async Task MockDirectory_CreateDirectory_ShouldIgnoreExistingDirectoryRegardlessOfTrailingSlash()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -757,12 +758,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             });
 
             // Act/Assert
-            Assert.That(() => fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\foo")), Throws.Nothing);
-            Assert.That(() => fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\foo\")), Throws.Nothing);
+            await That(() => fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\foo"))).DoesNotThrow();
+            await That(() => fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\foo\"))).DoesNotThrow();
         }
 
         [Test]
-        public void MockDirectory_CreateDirectory_ShouldReturnDirectoryInfoBase()
+        public async Task MockDirectory_CreateDirectory_ShouldReturnDirectoryInfoBase()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -774,12 +775,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\bar"));
 
             // Assert
-            Assert.That(result, Is.Not.Null);
+            await That(result).IsNotNull();
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.Drives)]
-        public void MockDirectory_CreateDirectory_ShouldTrimTrailingSpaces()
+        public async Task MockDirectory_CreateDirectory_ShouldTrimTrailingSpaces()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -788,11 +789,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\temp\folder "));
 
             // Assert
-            Assert.That(fileSystem.Directory.Exists(XFS.Path(@"c:\temp\folder")), Is.True);
+            await That(fileSystem.Directory.Exists(XFS.Path(@"c:\temp\folder"))).IsTrue();
         }
 
         [Test]
-        public void MockDirectory_CreMockDirectory_CreateDirectory_ShouldReturnDirectoryInfoBaseWhenDirectoryExists()
+        public async Task MockDirectory_CreMockDirectory_CreateDirectory_ShouldReturnDirectoryInfoBaseWhenDirectoryExists()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -804,12 +805,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.CreateDirectory(XFS.Path(@"c:\foo\"));
 
             // Assert
-            Assert.That(result, Is.Not.Null);
+            await That(result).IsNotNull();
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.UNCPaths)]
-        public void MockDirectory_CreateDirectory_ShouldWorkWithUNCPath()
+        public async Task MockDirectory_CreateDirectory_ShouldWorkWithUNCPath()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -818,27 +819,27 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.CreateDirectory(@"\\server\share\path\to\create");
 
             // Assert
-            Assert.That(fileSystem.Directory.Exists(@"\\server\share\path\to\create\"), Is.True);
+            await That(fileSystem.Directory.Exists(@"\\server\share\path\to\create\")).IsTrue();
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.UNCPaths)]
-        public void MockDirectory_CreateDirectory_ShouldFailIfTryingToCreateUNCPathOnlyServer()
+        public async Task MockDirectory_CreateDirectory_ShouldFailIfTryingToCreateUNCPathOnlyServer()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            var ex = Assert.Throws<ArgumentException>(() => fileSystem.Directory.CreateDirectory(@"\\server"));
+            var ex = await That(() => fileSystem.Directory.CreateDirectory(@"\\server")).Throws<ArgumentException>();
 
             // Assert
-            Assert.That(ex.Message, Does.StartWith("The UNC path should be of the form \\\\server\\share."));
-            Assert.That(ex.ParamName, Is.EqualTo("path"));
+            await That(ex.Message).StartsWith("The UNC path should be of the form \\\\server\\share.");
+            await That(ex.ParamName).IsEqualTo("path");
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.UNCPaths)]
-        public void MockDirectory_CreateDirectory_ShouldSucceedIfTryingToCreateUNCPathShare()
+        public async Task MockDirectory_CreateDirectory_ShouldSucceedIfTryingToCreateUNCPathShare()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -847,12 +848,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.CreateDirectory(@"\\server\share");
 
             // Assert
-            Assert.That(fileSystem.Directory.Exists(@"\\server\share\"), Is.True);
+            await That(fileSystem.Directory.Exists(@"\\server\share\")).IsTrue();
         }
 
 #if FEATURE_CREATE_TEMP_SUBDIRECTORY
         [Test]
-        public void MockDirectory_CreateTempSubdirectory_ShouldCreateSubdirectoryInTempDirectory()
+        public async Task MockDirectory_CreateTempSubdirectory_ShouldCreateSubdirectoryInTempDirectory()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -861,12 +862,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.CreateTempSubdirectory();
 
             // Assert
-            Assert.That(fileSystem.Directory.Exists(result.FullName), Is.True);
-            Assert.That(result.FullName, Does.StartWith(fileSystem.Path.GetTempPath()));
+            await That(fileSystem.Directory.Exists(result.FullName)).IsTrue();
+            await That(result.FullName).StartsWith(fileSystem.Path.GetTempPath());
         }
 
         [Test]
-        public void MockDirectory_CreateTempSubdirectoryWithPrefix_ShouldCreateDirectoryWithGivenPrefixInTempDirectory()
+        public async Task MockDirectory_CreateTempSubdirectoryWithPrefix_ShouldCreateDirectoryWithGivenPrefixInTempDirectory()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -875,14 +876,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.CreateTempSubdirectory("foo-");
 
             // Assert
-            Assert.That(fileSystem.Directory.Exists(result.FullName), Is.True);
-            Assert.That(Path.GetFileName(result.FullName).StartsWith("foo-"), Is.True);
-            Assert.That(result.FullName.Contains(fileSystem.Path.GetTempPath()), Is.True);
+            await That(fileSystem.Directory.Exists(result.FullName)).IsTrue();
+            await That(Path.GetFileName(result.FullName).StartsWith("foo-")).IsTrue();
+            await That(result.FullName.Contains(fileSystem.Path.GetTempPath())).IsTrue();
         }
 #endif
 
         [Test]
-        public void MockDirectory_Delete_ShouldDeleteDirectory()
+        public async Task MockDirectory_Delete_ShouldDeleteDirectory()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -894,11 +895,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.Delete(XFS.Path(@"c:\bar"), true);
 
             // Assert
-            Assert.That(fileSystem.Directory.Exists(XFS.Path(@"c:\bar")), Is.False);
+            await That(fileSystem.Directory.Exists(XFS.Path(@"c:\bar"))).IsFalse();
         }
 
         [Test]
-        public void MockDirectory_Delete_ShouldNotDeleteAllDirectories()
+        public async Task MockDirectory_Delete_ShouldNotDeleteAllDirectories()
         {
             // Arrange
             var folder1Path = XFS.Path(@"D:\Test\Program");
@@ -915,14 +916,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.Delete(folder1Path, recursive: true);
 
             // Assert
-            Assert.That(fileSystem.Directory.Exists(folder1Path), Is.False);
-            Assert.That(fileSystem.Directory.Exists(folder1SubFolderPath), Is.False);
-            Assert.That(fileSystem.Directory.Exists(folder2Path), Is.True);
+            await That(fileSystem.Directory.Exists(folder1Path)).IsFalse();
+            await That(fileSystem.Directory.Exists(folder1SubFolderPath)).IsFalse();
+            await That(fileSystem.Directory.Exists(folder2Path)).IsTrue();
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.CaseInsensitivity)]
-        public void MockDirectory_Delete_ShouldDeleteDirectoryCaseInsensitively()
+        public async Task MockDirectory_Delete_ShouldDeleteDirectoryCaseInsensitively()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -934,12 +935,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.Delete(XFS.Path(@"c:\BAR"), true);
 
             // Assert
-            Assert.That(fileSystem.Directory.Exists(XFS.Path(@"c:\bar")), Is.False);
+            await That(fileSystem.Directory.Exists(XFS.Path(@"c:\bar"))).IsFalse();
         }
 
         [Test]
         [UnixOnly(UnixSpecifics.CaseSensitivity)]
-        public void MockDirectory_Delete_ShouldThrowDirectoryNotFoundException_WhenSpecifiedWithInDifferentCase()
+        public async Task MockDirectory_Delete_ShouldThrowDirectoryNotFoundException_WhenSpecifiedWithInDifferentCase()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -948,15 +949,15 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             });
 
             // Act
-            TestDelegate action = () => fileSystem.Directory.Delete("/BAR", true);
+            Action action = () => fileSystem.Directory.Delete("/BAR", true);
 
             // Assert
-            Assert.Throws<DirectoryNotFoundException>(action);
+            await That(action).Throws<DirectoryNotFoundException>();
         }
 
         [Test]
         [UnixOnly(UnixSpecifics.CaseSensitivity)]
-        public void MockDirectory_Delete_ShouldDeleteDirectoryCaseSensitively()
+        public async Task MockDirectory_Delete_ShouldDeleteDirectoryCaseSensitively()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -968,11 +969,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.Delete("/bar", true);
 
             // Assert
-            Assert.That(fileSystem.Directory.Exists("/bar"), Is.False);
+            await That(fileSystem.Directory.Exists("/bar")).IsFalse();
         }
 
         [Test]
-        public void MockDirectory_Delete_ShouldThrowDirectoryNotFoundException()
+        public async Task MockDirectory_Delete_ShouldThrowDirectoryNotFoundException()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -980,13 +981,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 { XFS.Path(@"c:\bar\foo.txt"), new MockFileData("Demo text content") }
             });
 
-            var ex = Assert.Throws<DirectoryNotFoundException>(() => fileSystem.Directory.Delete(XFS.Path(@"c:\baz")));
+            var ex = await That(() => fileSystem.Directory.Delete(XFS.Path(@"c:\baz"))).Throws<DirectoryNotFoundException>();
 
-            Assert.That(ex.Message, Is.EqualTo($"'{XFS.Path("c:\\baz")}' does not exist or could not be found."));
+            await That(ex.Message).IsEqualTo($"'{XFS.Path("c:\\baz")}' does not exist or could not be found.");
         }
 
         [Test]
-        public void MockDirectory_Delete_ShouldThrowIOException()
+        public async Task MockDirectory_Delete_ShouldThrowIOException()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -995,13 +996,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 { XFS.Path(@"c:\bar\baz.txt"), new MockFileData("Demo text content") }
             });
 
-            var ex = Assert.Throws<IOException>(() => fileSystem.Directory.Delete(XFS.Path(@"c:\bar")));
+            var ex = await That(() => fileSystem.Directory.Delete(XFS.Path(@"c:\bar"))).Throws<IOException>();
 
-            Assert.That(ex.Message, Is.EqualTo("The directory specified by " + XFS.Path("c:\\bar") + " is read-only, or recursive is false and " + XFS.Path("c:\\bar") + " is not an empty directory."));
+            await That(ex.Message).IsEqualTo("The directory specified by " + XFS.Path("c:\\bar") + " is read-only, or recursive is false and " + XFS.Path("c:\\bar") + " is not an empty directory.");
         }
 
         [Test]
-        public void MockDirectory_Delete_ShouldDeleteDirectoryRecursively()
+        public async Task MockDirectory_Delete_ShouldDeleteDirectoryRecursively()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -1014,12 +1015,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.DirectoryInfo.New(XFS.Path(@"c:\bar")).Delete(true);
 
             // Assert
-            Assert.That(fileSystem.Directory.Exists(XFS.Path(@"c:\bar")), Is.False);
-            Assert.That(fileSystem.Directory.Exists(XFS.Path(@"c:\bar\bar2")), Is.False);
+            await That(fileSystem.Directory.Exists(XFS.Path(@"c:\bar"))).IsFalse();
+            await That(fileSystem.Directory.Exists(XFS.Path(@"c:\bar\bar2"))).IsFalse();
         }
 
         [Test]
-        public void MockDirectory_Delete_ShouldThrowIOException_WhenPathIsAFile()
+        public async Task MockDirectory_Delete_ShouldThrowIOException_WhenPathIsAFile()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -1028,14 +1029,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             });
 
             // Act
-            TestDelegate action = () => fileSystem.Directory.Delete(XFS.Path(@"c:\foo.txt"));
+            Action action = () => fileSystem.Directory.Delete(XFS.Path(@"c:\foo.txt"));
 
             // Assert
-            Assert.Throws<IOException>(action);
+            await That(action).Throws<IOException>();
         }
 
         [Test]
-        public void MockDirectory_GetFileSystemEntries_Returns_Files_And_Directories()
+        public async Task MockDirectory_GetFileSystemEntries_Returns_Files_And_Directories()
         {
             string testPath = XFS.Path(@"c:\foo\bar.txt");
             string testDir = XFS.Path(@"c:\foo\bar");
@@ -1046,13 +1047,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             });
 
             var entries = fileSystem.Directory.GetFileSystemEntries(XFS.Path(@"c:\foo")).OrderBy(k => k);
-            Assert.That(entries.Count(), Is.EqualTo(2));
-            Assert.That(entries.First(), Is.EqualTo(testDir));
-            Assert.That(entries.Last(), Is.EqualTo(testPath));
+            await That(entries.Count()).IsEqualTo(2);
+            await That(entries.First()).IsEqualTo(testDir);
+            await That(entries.Last()).IsEqualTo(testPath);
         }
 
         [Test]
-        public void MockDirectory_GetFileSystemEntries_ShouldNotReturnSubDirectory_WithSearchOption()
+        public async Task MockDirectory_GetFileSystemEntries_ShouldNotReturnSubDirectory_WithSearchOption()
         {
             string testPath = XFS.Path(@"c:\foo\bar.txt");
             string testDir = XFS.Path(@"c:\foo\bar");
@@ -1064,35 +1065,35 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             });
 
             var entries = fileSystem.Directory.GetFileSystemEntries(XFS.Path(@"c:\foo"), "*", SearchOption.TopDirectoryOnly).OrderBy(k => k);
-            Assert.That(entries.Count(), Is.EqualTo(2));
-            Assert.That(entries.First(), Is.EqualTo(testDir));
-            Assert.That(entries.Last(), Is.EqualTo(testPath));
+            await That(entries.Count()).IsEqualTo(2);
+            await That(entries.First()).IsEqualTo(testDir);
+            await That(entries.Last()).IsEqualTo(testPath);
         }
 
         [Test]
-        public void MockDirectory_GetFiles_ShouldThrowArgumentNullException_IfPathParamIsNull()
+        public async Task MockDirectory_GetFiles_ShouldThrowArgumentNullException_IfPathParamIsNull()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
 
-            TestDelegate action = () => fileSystem.Directory.GetFiles(null);
-            Assert.Throws<ArgumentNullException>(action);
+            Action action = () => fileSystem.Directory.GetFiles(null);
+            await That(action).Throws<ArgumentNullException>();
         }
 
         [Test]
-        public void MockDirectory_GetFiles_ShouldThrowDirectoryNotFoundException_IfPathDoesNotExists()
+        public async Task MockDirectory_GetFiles_ShouldThrowDirectoryNotFoundException_IfPathDoesNotExists()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => fileSystem.Directory.GetFiles(XFS.Path(@"c:\Foo"), "*a.txt");
+            Action action = () => fileSystem.Directory.GetFiles(XFS.Path(@"c:\Foo"), "*a.txt");
 
             // Assert
-            Assert.Throws<DirectoryNotFoundException>(action);
+            await That(action).Throws<DirectoryNotFoundException>();
         }
 
         [Test]
-        public void MockDirectory_GetFiles_Returns_Files()
+        public async Task MockDirectory_GetFiles_Returns_Files()
         {
             string testPath = XFS.Path(@"c:\foo\bar.txt");
             string testDir = XFS.Path(@"c:\foo\bar\");
@@ -1103,12 +1104,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             });
 
             var entries = fileSystem.Directory.GetFiles(XFS.Path(@"c:\foo")).OrderBy(k => k);
-            Assert.That(entries.Count(), Is.EqualTo(1));
-            Assert.That(entries.First(), Is.EqualTo(testPath));
+            await That(entries.Count()).IsEqualTo(1);
+            await That(entries.First()).IsEqualTo(testPath);
         }
 
         [Test]
-        public void MockDirectory_GetFiles_Returns_Files_WithRelativePath()
+        public async Task MockDirectory_GetFiles_Returns_Files_WithRelativePath()
         {
             // arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
@@ -1118,11 +1119,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.SetCurrentDirectory(directory);
             fileSystem.AddFile(XFS.Path(@"C:\test.txt"), new MockFileData("Some ASCII text."));
 
-            Assert.That(fileSystem.Directory.GetFiles(XFS.Path(@"..\")).Length, Is.EqualTo(1)); // Assert with relative path
+            await That(fileSystem.Directory.GetFiles(XFS.Path(@"..\")).Length).IsEqualTo(1); // Assert with relative path
         }
 
         [Test]
-        public void MockDirectory_GetFiles_ShouldThrowAnArgumentNullException_IfSearchPatternIsNull()
+        public async Task MockDirectory_GetFiles_ShouldThrowAnArgumentNullException_IfSearchPatternIsNull()
         {
             // Arrange
             var directoryPath = XFS.Path(@"c:\Foo");
@@ -1130,14 +1131,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(directoryPath);
 
             // Act
-            TestDelegate action = () => fileSystem.Directory.GetFiles(directoryPath, null);
+            Action action = () => fileSystem.Directory.GetFiles(directoryPath, null);
 
             // Assert
-            Assert.Throws<ArgumentNullException>(action);
+            await That(action).Throws<ArgumentNullException>();
         }
 
         [Test]
-        public void MockDirectory_GetFiles_ShouldThrowAnArgumentException_IfSearchPatternEndsWithTwoDots()
+        public async Task MockDirectory_GetFiles_ShouldThrowAnArgumentException_IfSearchPatternEndsWithTwoDots()
         {
             // Arrange
             var directoryPath = XFS.Path(@"c:\Foo");
@@ -1145,17 +1146,17 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(directoryPath);
 
             // Act
-            TestDelegate action = () => fileSystem.Directory.GetFiles(directoryPath, "*a..");
+            Action action = () => fileSystem.Directory.GetFiles(directoryPath, "*a..");
 
             // Assert
-            Assert.Throws<ArgumentException>(action);
+            await That(action).Throws<ArgumentException>();
         }
 
         [TestCase(@"..\")]
         [TestCase(@"aaa\vv..\")]
         [TestCase(@"a..\b")]
         [WindowsOnly(WindowsSpecifics.StrictPathRules)]
-        public void MockDirectory_GetFiles_ShouldThrowAnArgumentException_IfSearchPatternContainsTwoDotsFollowedByOneBackslash(string searchPattern)
+        public async Task MockDirectory_GetFiles_ShouldThrowAnArgumentException_IfSearchPatternContainsTwoDotsFollowedByOneBackslash(string searchPattern)
         {
             // Arrange
             var directoryPath = XFS.Path(@"c:\Foo");
@@ -1163,15 +1164,15 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(directoryPath);
 
             // Act
-            TestDelegate action = () => fileSystem.Directory.GetFiles(directoryPath, searchPattern);
+            Action action = () => fileSystem.Directory.GetFiles(directoryPath, searchPattern);
 
             // Assert
-            Assert.Throws<ArgumentException>(action);
+            await That(action).Throws<ArgumentException>();
         }
 
         [TestCase(@"a../b")]
         [TestCase(@"../")]
-        public void MockDirectory_GetFiles_ShouldThrowAnArgumentException_IfSearchPatternContainsTwoDotsFollowedByOneSlash(string searchPattern)
+        public async Task MockDirectory_GetFiles_ShouldThrowAnArgumentException_IfSearchPatternContainsTwoDotsFollowedByOneSlash(string searchPattern)
         {
             // Arrange
             var directoryPath = XFS.Path(@"c:\Foo");
@@ -1179,14 +1180,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(directoryPath);
 
             // Act
-            TestDelegate action = () => fileSystem.Directory.GetFiles(directoryPath, searchPattern);
+            Action action = () => fileSystem.Directory.GetFiles(directoryPath, searchPattern);
 
             // Assert
-            Assert.Throws<ArgumentException>(action);
+            await That(action).Throws<ArgumentException>();
         }
 
         [Test]
-        public void MockDirectory_GetFiles_ShouldFindFilesContainingTwoOrMoreDots()
+        public async Task MockDirectory_GetFiles_ShouldFindFilesContainingTwoOrMoreDots()
         {
             // Arrange
             string testPath = XFS.Path(@"c:\foo..r\bar.txt");
@@ -1199,12 +1200,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = fileSystem.Directory.GetFiles(XFS.Path(@"c:\"), XFS.Path(@"foo..r\*"));
 
             // Assert
-            Assert.That(actualResult, Is.EquivalentTo(new[] { testPath }));
+            await That(actualResult).IsEquivalentTo(new[] { testPath });
         }
 
         [TestCase("aa\t")]
         [WindowsOnly(WindowsSpecifics.StrictPathRules)]
-        public void MockDirectory_GetFiles_ShouldThrowAnArgumentException_IfSearchPatternHasIllegalCharacters(string searchPattern)
+        public async Task MockDirectory_GetFiles_ShouldThrowAnArgumentException_IfSearchPatternHasIllegalCharacters(string searchPattern)
         {
             // Arrange
             var directoryPath = XFS.Path(@"c:\Foo");
@@ -1212,14 +1213,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(directoryPath);
 
             // Act
-            TestDelegate action = () => fileSystem.Directory.GetFiles(directoryPath, searchPattern);
+            Action action = () => fileSystem.Directory.GetFiles(directoryPath, searchPattern);
 
             // Assert
-            Assert.Throws<ArgumentException>(action);
+            await That(action).Throws<ArgumentException>();
         }
 
         [Test]
-        public void MockDirectory_GetRoot_Returns_Root()
+        public async Task MockDirectory_GetRoot_Returns_Root()
         {
             string testDir = XFS.Path(@"c:\foo\bar\");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -1227,11 +1228,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 { testDir,  new MockDirectoryData() }
             });
 
-            Assert.That(fileSystem.Directory.GetDirectoryRoot(XFS.Path(@"C:\foo\bar")), Is.EqualTo(XFS.Path("C:\\")));
+            await That(fileSystem.Directory.GetDirectoryRoot(XFS.Path(@"C:\foo\bar"))).IsEqualTo(XFS.Path("C:\\"));
         }
 
         [Test]
-        public void MockDirectory_GetLogicalDrives_Returns_LogicalDrives()
+        public async Task MockDirectory_GetLogicalDrives_Returns_LogicalDrives()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
                 {
@@ -1244,19 +1245,19 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             if (XFS.IsUnixPlatform())
             {
-                Assert.That(drives.Length, Is.EqualTo(1));
-                Assert.That(drives.Contains("/"), Is.True);
+                await That(drives.Length).IsEqualTo(1);
+                await That(drives.Contains("/")).IsTrue();
             }
             else
             {
-                Assert.That(drives.Length, Is.EqualTo(2));
-                Assert.That(drives.Contains(@"C:\"), Is.True);
-                Assert.That(drives.Contains(@"D:\"), Is.True);
+                await That(drives.Length).IsEqualTo(2);
+                await That(drives.Contains(@"C:\")).IsTrue();
+                await That(drives.Contains(@"D:\")).IsTrue();
             }
         }
 
         [Test]
-        public void MockDirectory_GetDirectories_Returns_Child_Directories()
+        public async Task MockDirectory_GetDirectories_Returns_Child_Directories()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -1267,16 +1268,16 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var directories = fileSystem.Directory.GetDirectories(XFS.Path(@"A:\folder1")).ToArray();
 
             //Check that it does not returns itself
-            Assert.That(directories.Contains(XFS.Path(@"A:\folder1")), Is.False);
+            await That(directories.Contains(XFS.Path(@"A:\folder1"))).IsFalse();
 
             //Check that it correctly returns all child directories
-            Assert.That(directories.Count(), Is.EqualTo(2));
-            Assert.That(directories.Contains(XFS.Path(@"A:\folder1\folder2")), Is.True);
-            Assert.That(directories.Contains(XFS.Path(@"A:\folder1\folder4")), Is.True);
+            await That(directories.Count()).IsEqualTo(2);
+            await That(directories.Contains(XFS.Path(@"A:\folder1\folder2"))).IsTrue();
+            await That(directories.Contains(XFS.Path(@"A:\folder1\folder4"))).IsTrue();
         }
 
         [Test]
-        public void MockDirectory_GetDirectories_WithTopDirectories_ShouldOnlyReturnTopDirectories()
+        public async Task MockDirectory_GetDirectories_WithTopDirectories_ShouldOnlyReturnTopDirectories()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -1290,11 +1291,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = fileSystem.Directory.GetDirectories(XFS.Path(@"C:\Folder\"), "*.foo");
 
             // Assert
-            Assert.That(actualResult, Is.EquivalentTo(new[] { XFS.Path(@"C:\Folder\.foo"), XFS.Path(@"C:\Folder\foo.foo") }));
+            await That(actualResult).IsEquivalentTo(new[] { XFS.Path(@"C:\Folder\.foo"), XFS.Path(@"C:\Folder\foo.foo") });
         }
 
         [Test]
-        public void MockDirectory_GetDirectories_RelativeWithNoSubDirectories_ShouldReturnDirectories()
+        public async Task MockDirectory_GetDirectories_RelativeWithNoSubDirectories_ShouldReturnDirectories()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -1304,12 +1305,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = fileSystem.Directory.GetDirectories("Folder");
 
             // Assert
-            Assert.That(actualResult, Is.Empty);
+            await That(actualResult).IsEmpty();
         }
 
         [TestCase(@"Folder\SubFolder")]
         [TestCase(@"Folder")]
-        public void MockDirectory_GetDirectories_RelativeDirectory_WithoutChildren_ShouldReturnNoChildDirectories(string relativeDirPath)
+        public async Task MockDirectory_GetDirectories_RelativeDirectory_WithoutChildren_ShouldReturnNoChildDirectories(string relativeDirPath)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -1319,12 +1320,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = fileSystem.Directory.GetDirectories(relativeDirPath);
 
             // Assert
-            Assert.That(actualResult, Is.Empty);
+            await That(actualResult).IsEmpty();
         }
 
         [TestCase(@"Folder\SubFolder")]
         [TestCase(@"Folder")]
-        public void MockDirectory_GetDirectories_RelativeDirectory_WithChildren_ShouldReturnChildDirectories(string relativeDirPath)
+        public async Task MockDirectory_GetDirectories_RelativeDirectory_WithChildren_ShouldReturnChildDirectories(string relativeDirPath)
         {
             // Arrange
             var currentDirectory = XFS.Path(@"T:\foo");
@@ -1336,11 +1337,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = fileSystem.Directory.GetDirectories(XFS.Path(relativeDirPath));
 
             // Assert
-            Assert.That(actualResult, Is.EqualTo(new[] { XFS.Path(relativeDirPath + @"\child") }));
+            await That(actualResult).IsEqualTo(new[] { XFS.Path(relativeDirPath + @"\child") });
         }
 
         [Test]
-        public void MockDirectory_GetDirectories_AbsoluteWithNoSubDirectories_ShouldReturnDirectories()
+        public async Task MockDirectory_GetDirectories_AbsoluteWithNoSubDirectories_ShouldReturnDirectories()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -1351,11 +1352,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = fileSystem.Directory.GetDirectories(fullPath);
 
             // Assert
-            Assert.That(actualResult, Is.Empty);
+            await That(actualResult).IsEmpty();
         }
 
         [Test]
-        public void MockDirectory_GetDirectories_WithAllDirectories_ShouldReturnsAllMatchingSubFolders()
+        public async Task MockDirectory_GetDirectories_WithAllDirectories_ShouldReturnsAllMatchingSubFolders()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -1369,11 +1370,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = fileSystem.Directory.GetDirectories(XFS.Path(@"C:\Folder\"), "*.foo", SearchOption.AllDirectories);
 
             // Assert
-            Assert.That(actualResult, Is.EquivalentTo(new[] { XFS.Path(@"C:\Folder\.foo"), XFS.Path(@"C:\Folder\foo.foo"), XFS.Path(@"C:\Folder\.foo\.foo") }));
+            await That(actualResult).IsEquivalentTo(new[] { XFS.Path(@"C:\Folder\.foo"), XFS.Path(@"C:\Folder\foo.foo"), XFS.Path(@"C:\Folder\.foo\.foo") });
         }
 
         [Test]
-        public void MockDirectory_GetDirectories_ShouldThrowWhenPathIsNotMocked()
+        public async Task MockDirectory_GetDirectories_ShouldThrowWhenPathIsNotMocked()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -1390,14 +1391,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             });
 
             // Act
-            TestDelegate action = () => fileSystem.Directory.GetDirectories(XFS.Path(@"c:\d"));
+            Action action = () => fileSystem.Directory.GetDirectories(XFS.Path(@"c:\d"));
 
             // Assert
-            Assert.Throws<DirectoryNotFoundException>(action);
+            await That(action).Throws<DirectoryNotFoundException>();
         }
 
         [Test]
-        public void MockDirectory_EnumerateDirectories_Returns_Child_Directories()
+        public async Task MockDirectory_EnumerateDirectories_Returns_Child_Directories()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -1408,16 +1409,16 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var directories = fileSystem.Directory.EnumerateDirectories(XFS.Path(@"A:\folder1")).ToArray();
 
             //Check that it does not returns itself
-            Assert.That(directories.Contains(XFS.Path(@"A:\folder1")), Is.False);
+            await That(directories.Contains(XFS.Path(@"A:\folder1"))).IsFalse();
 
             //Check that it correctly returns all child directories
-            Assert.That(directories.Count(), Is.EqualTo(2));
-            Assert.That(directories.Contains(XFS.Path(@"A:\folder1\folder2")), Is.True);
-            Assert.That(directories.Contains(XFS.Path(@"A:\folder1\folder4")), Is.True);
+            await That(directories.Count()).IsEqualTo(2);
+            await That(directories.Contains(XFS.Path(@"A:\folder1\folder2"))).IsTrue();
+            await That(directories.Contains(XFS.Path(@"A:\folder1\folder4"))).IsTrue();
         }
 
         [Test]
-        public void MockDirectory_EnumerateDirectories_WithTopDirectories_ShouldOnlyReturnTopDirectories()
+        public async Task MockDirectory_EnumerateDirectories_WithTopDirectories_ShouldOnlyReturnTopDirectories()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -1431,12 +1432,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = fileSystem.Directory.EnumerateDirectories(XFS.Path(@"C:\Folder\"), "*.foo");
 
             // Assert
-            Assert.That(actualResult, Is.EquivalentTo(new[] { XFS.Path(@"C:\Folder\.foo"), XFS.Path(@"C:\Folder\foo.foo") }));
+            await That(actualResult).IsEquivalentTo(new[] { XFS.Path(@"C:\Folder\.foo"), XFS.Path(@"C:\Folder\foo.foo") });
         }
 
 #if FEATURE_ENUMERATION_OPTIONS
         [Test]
-        public void MockDirectory_EnumerateDirectories_WithEnumerationOptionsTopDirectories_ShouldOnlyReturnTopDirectories()
+        public async Task MockDirectory_EnumerateDirectories_WithEnumerationOptionsTopDirectories_ShouldOnlyReturnTopDirectories()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -1455,11 +1456,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = fileSystem.Directory.EnumerateDirectories(XFS.Path(@"C:\Folder\"), "*.foo", enumerationOptions);
 
             // Assert
-            Assert.That(actualResult, Is.EquivalentTo(new[] { XFS.Path(@"C:\Folder\.foo"), XFS.Path(@"C:\Folder\foo.foo") }));
+            await That(actualResult).IsEquivalentTo(new[] { XFS.Path(@"C:\Folder\.foo"), XFS.Path(@"C:\Folder\foo.foo") });
         }
 #endif
         [Test]
-        public void MockDirectory_EnumerateDirectories_WithAllDirectories_ShouldReturnsAllMatchingSubFolders()
+        public async Task MockDirectory_EnumerateDirectories_WithAllDirectories_ShouldReturnsAllMatchingSubFolders()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -1473,11 +1474,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = fileSystem.Directory.EnumerateDirectories(XFS.Path(@"C:\Folder\"), "*.foo", SearchOption.AllDirectories);
 
             // Assert
-            Assert.That(actualResult, Is.EquivalentTo(new[] { XFS.Path(@"C:\Folder\.foo"), XFS.Path(@"C:\Folder\foo.foo"), XFS.Path(@"C:\Folder\.foo\.foo") }));
+            await That(actualResult).IsEquivalentTo(new[] { XFS.Path(@"C:\Folder\.foo"), XFS.Path(@"C:\Folder\foo.foo"), XFS.Path(@"C:\Folder\.foo\.foo") });
         }
 
         [Test]
-        public void MockDirectory_EnumerateDirectories_ShouldThrowWhenPathIsNotMocked()
+        public async Task MockDirectory_EnumerateDirectories_ShouldThrowWhenPathIsNotMocked()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -1494,14 +1495,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             });
 
             // Act
-            TestDelegate action = () => fileSystem.Directory.EnumerateDirectories(XFS.Path(@"c:\d"));
+            Action action = () => fileSystem.Directory.EnumerateDirectories(XFS.Path(@"c:\d"));
 
             // Assert
-            Assert.Throws<DirectoryNotFoundException>(action);
+            await That(action).Throws<DirectoryNotFoundException>();
         }
         
         [TestCaseSource(nameof(GetPrefixTestPaths))]
-        public void MockDirectory_EnumerateDirectories_ShouldReturnPathsPrefixedWithQueryPath(
+        public async Task MockDirectory_EnumerateDirectories_ShouldReturnPathsPrefixedWithQueryPath(
             string queryPath, string expectedPath)
         {
             var fileSystem = new MockFileSystem();
@@ -1509,7 +1510,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             
             var actualResult = fileSystem.Directory.EnumerateDirectories(queryPath);
             
-            Assert.That(actualResult, Is.EqualTo(new[] { expectedPath }));
+            await That(actualResult).IsEqualTo(new[] { expectedPath });
         }
         
         private static IEnumerable<object[]> GetPrefixTestPaths()
@@ -1532,7 +1533,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void Move_DirectoryExistsWithDifferentCase_DirectorySuccessfullyMoved()
+        public async Task Move_DirectoryExistsWithDifferentCase_DirectorySuccessfullyMoved()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -1543,11 +1544,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.Move(XFS.Path(@"C:\old_location"), XFS.Path(@"C:\NewLocation\"));
 
             // Assert
-            Assert.That(fileSystem.File.Exists(XFS.Path(@"C:\NewLocation\Data\someFile.txt")), Is.True);
+            await That(fileSystem.File.Exists(XFS.Path(@"C:\NewLocation\Data\someFile.txt"))).IsTrue();
         }
 
         [TestCaseSource(nameof(GetPathsForMoving))]
-        public void MockDirectory_Move_ShouldMoveDirectories(string sourceDirName, string destDirName, string filePathOne, string filePathTwo)
+        public async Task MockDirectory_Move_ShouldMoveDirectories(string sourceDirName, string destDirName, string filePathOne, string filePathTwo)
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -1560,13 +1561,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.DirectoryInfo.New(sourceDirName).MoveTo(destDirName);
 
             // Assert
-            Assert.That(fileSystem.Directory.Exists(sourceDirName), Is.False);
-            Assert.That(fileSystem.File.Exists(XFS.Path(destDirName + filePathOne)), Is.True);
-            Assert.That(fileSystem.File.Exists(XFS.Path(destDirName + filePathTwo)), Is.True);
+            await That(fileSystem.Directory.Exists(sourceDirName)).IsFalse();
+            await That(fileSystem.File.Exists(XFS.Path(destDirName + filePathOne))).IsTrue();
+            await That(fileSystem.File.Exists(XFS.Path(destDirName + filePathTwo))).IsTrue();
         }
 
         [Test]
-        public void MockDirectory_Move_ShouldMoveFiles()
+        public async Task MockDirectory_Move_ShouldMoveFiles()
         {
             string sourceFilePath = XFS.Path(@"c:\demo.txt");
             string sourceFileContent = "this is some content";
@@ -1580,13 +1581,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileSystem.Directory.Move(sourceFilePath, destFilePath);
 
-            Assert.That(fileSystem.FileExists(destFilePath), Is.True);
-            Assert.That(fileSystem.FileExists(sourceFilePath), Is.False);
-            Assert.That(fileSystem.GetFile(destFilePath).TextContents, Is.EqualTo(sourceFileContent));
+            await That(fileSystem.FileExists(destFilePath)).IsTrue();
+            await That(fileSystem.FileExists(sourceFilePath)).IsFalse();
+            await That(fileSystem.GetFile(destFilePath).TextContents).IsEqualTo(sourceFileContent);
         }
 
         [Test]
-        public void MockDirectory_Move_ShouldMoveDirectoryAttributes()
+        public async Task MockDirectory_Move_ShouldMoveDirectoryAttributes()
         {
             // Arrange
             var sourceDirName = XFS.Path(@"a:\folder1\");
@@ -1607,11 +1608,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             var destDirectoryInfo = fileSystem.DirectoryInfo.New(destDirName);
-            Assert.That(destDirectoryInfo.Attributes.HasFlag(FileAttributes.System), Is.True);
+            await That(destDirectoryInfo.Attributes.HasFlag(FileAttributes.System)).IsTrue();
         }
 
         [Test]
-        public void MockDirectory_Move_ShouldMoveDirectoryWithReadOnlySubDirectory()
+        public async Task MockDirectory_Move_ShouldMoveDirectoryWithReadOnlySubDirectory()
         {
             // Arrange
             var sourceDirName = XFS.Path(@"a:\folder1\");
@@ -1632,12 +1633,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.DirectoryInfo.New(sourceDirName).MoveTo(destDirName);
 
             // Assert
-            Assert.That(fileSystem.Directory.Exists(sourceSubDirName), Is.False);
-            Assert.That(fileSystem.FileExists(destSubDirName), Is.True);
+            await That(fileSystem.Directory.Exists(sourceSubDirName)).IsFalse();
+            await That(fileSystem.FileExists(destSubDirName)).IsTrue();
         }
 
         [Test]
-        public void MockDirectory_Move_ShouldOnlyMoveDirAndFilesWithinDir()
+        public async Task MockDirectory_Move_ShouldOnlyMoveDirAndFilesWithinDir()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -1653,23 +1654,23 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.Move(XFS.Path(@"c:\source\dummy"), XFS.Path(@"c:\destination\dummy"));
 
             // Assert
-            Assert.That(fileSystem.FileExists(XFS.Path(@"c:\source\dummy.txt")), Is.True);
-            Assert.That(fileSystem.Directory.Exists(XFS.Path(@"c:\source\dummy2")), Is.True);
+            await That(fileSystem.FileExists(XFS.Path(@"c:\source\dummy.txt"))).IsTrue();
+            await That(fileSystem.Directory.Exists(XFS.Path(@"c:\source\dummy2"))).IsTrue();
         }
 
         [Test]
-        public void MockDirectory_GetCurrentDirectory_ShouldReturnValueFromFileSystemConstructor()
+        public async Task MockDirectory_GetCurrentDirectory_ShouldReturnValueFromFileSystemConstructor()
         {
             string directory = XFS.Path(@"D:\folder1\folder2");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>(), directory);
 
             var actual = fileSystem.Directory.GetCurrentDirectory();
 
-            Assert.That(actual, Is.EqualTo(directory));
+            await That(actual).IsEqualTo(directory);
         }
 
         [Test]
-        public void MockDirectory_GetCurrentDirectory_ShouldReturnDefaultPathWhenNotSet()
+        public async Task MockDirectory_GetCurrentDirectory_ShouldReturnDefaultPathWhenNotSet()
         {
             string directory = XFS.Path(@"C:\");
 
@@ -1677,62 +1678,62 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var actual = fileSystem.Directory.GetCurrentDirectory();
 
-            Assert.That(actual, Is.EqualTo(directory));
+            await That(actual).IsEqualTo(directory);
         }
 
         [Test]
-        public void MockDirectory_SetCurrentDirectory_ShouldChangeCurrentDirectory()
+        public async Task MockDirectory_SetCurrentDirectory_ShouldChangeCurrentDirectory()
         {
             string directory = XFS.Path(@"D:\folder1\folder2");
             var fileSystem = new MockFileSystem();
 
             // Precondition
-            Assert.That(fileSystem.Directory.GetCurrentDirectory(), Is.Not.EqualTo(directory));
+            await That(fileSystem.Directory.GetCurrentDirectory()).IsNotEqualTo(directory);
 
             fileSystem.Directory.SetCurrentDirectory(directory);
 
-            Assert.That(fileSystem.Directory.GetCurrentDirectory(), Is.EqualTo(directory));
+            await That(fileSystem.Directory.GetCurrentDirectory()).IsEqualTo(directory);
         }
 
         [Test]
-        public void MockDirectory_SetCurrentDirectory_WithRelativePath_ShouldUseFullPath()
+        public async Task MockDirectory_SetCurrentDirectory_WithRelativePath_ShouldUseFullPath()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.Directory.SetCurrentDirectory(".");
 
             var result = fileSystem.Directory.GetCurrentDirectory();
 
-            Assert.That(fileSystem.Path.IsPathRooted(result), Is.True);
+            await That(fileSystem.Path.IsPathRooted(result)).IsTrue();
         }
 
         [Test]
-        public void MockDirectory_GetParent_ShouldThrowArgumentNullExceptionIfPathIsNull()
+        public async Task MockDirectory_GetParent_ShouldThrowArgumentNullExceptionIfPathIsNull()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate act = () => fileSystem.Directory.GetParent(null);
+            Action act = () => fileSystem.Directory.GetParent(null);
 
             // Assert
-            Assert.Throws<ArgumentNullException>(act);
+            await That(act).Throws<ArgumentNullException>();
         }
 
         [Test]
-        public void MockDirectory_GetParent_ShouldThrowArgumentExceptionIfPathIsEmpty()
+        public async Task MockDirectory_GetParent_ShouldThrowArgumentExceptionIfPathIsEmpty()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate act = () => fileSystem.Directory.GetParent(string.Empty);
+            Action act = () => fileSystem.Directory.GetParent(string.Empty);
 
             // Assert
-            Assert.Throws<ArgumentException>(act);
+            await That(act).Throws<ArgumentException>();
         }
 
         [Test]
-        public void MockDirectory_GetParent_ShouldReturnADirectoryInfoIfPathDoesNotExist()
+        public async Task MockDirectory_GetParent_ShouldReturnADirectoryInfoIfPathDoesNotExist()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -1741,25 +1742,25 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = fileSystem.Directory.GetParent(XFS.Path(@"c:\directory\does\not\exist"));
 
             // Assert
-            Assert.That(actualResult, Is.Not.Null);
+            await That(actualResult).IsNotNull();
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.StrictPathRules)]
-        public void MockDirectory_GetParent_ShouldThrowArgumentExceptionIfPathHasIllegalCharacters()
+        public async Task MockDirectory_GetParent_ShouldThrowArgumentExceptionIfPathHasIllegalCharacters()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate act = () => fileSystem.Directory.GetParent(XFS.Path("c:\\director\ty\\has\\illegal\\character"));
+            Action act = () => fileSystem.Directory.GetParent(XFS.Path("c:\\director\ty\\has\\illegal\\character"));
 
             // Assert
-            Assert.Throws<ArgumentException>(act);
+            await That(act).Throws<ArgumentException>();
         }
 
         [Test]
-        public void MockDirectory_GetParent_ShouldReturnNullIfPathIsRoot()
+        public async Task MockDirectory_GetParent_ShouldReturnNullIfPathIsRoot()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -1769,12 +1770,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = fileSystem.Directory.GetParent(XFS.Path(@"c:\"));
 
             // Assert
-            Assert.That(actualResult, Is.Null);
+            await That(actualResult).IsNull();
         }
 
         [Test]
         [UnixOnly(UnixSpecifics.SlashRoot)]
-        public void MockDirectory_GetParent_ShouldReturnRootIfDirectoryIsInRoot()
+        public async Task MockDirectory_GetParent_ShouldReturnRootIfDirectoryIsInRoot()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -1784,7 +1785,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var parent = fileSystem.Directory.GetParent("/bar");
 
             // Assert
-            Assert.That(parent.FullName, Is.EqualTo("/"));
+            await That(parent.FullName).IsEqualTo("/");
         }
 
         public static IEnumerable<string[]> MockDirectory_GetParent_Cases
@@ -1797,7 +1798,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             }
         }
 
-        public void MockDirectory_GetParent_ShouldReturnTheParentWithoutTrailingDirectorySeparatorChar(string path, string expectedResult)
+        public async Task MockDirectory_GetParent_ShouldReturnTheParentWithoutTrailingDirectorySeparatorChar(string path, string expectedResult)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -1807,11 +1808,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = fileSystem.Directory.GetParent(path);
 
             // Assert
-            Assert.That(actualResult.FullName, Is.EqualTo(expectedResult));
+            await That(actualResult.FullName).IsEqualTo(expectedResult);
         }
 
         [Test]
-        public void MockDirectory_Move_ShouldThrowAnIOExceptionIfBothPathAreIdentical()
+        public async Task MockDirectory_Move_ShouldThrowAnIOExceptionIfBothPathAreIdentical()
         {
             // Arrange
             string path = XFS.Path(@"c:\a");
@@ -1819,15 +1820,15 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(path);
 
             // Act
-            TestDelegate action = () => fileSystem.Directory.Move(path, path);
+            Action action = () => fileSystem.Directory.Move(path, path);
 
             // Assert
-            Assert.Throws<IOException>(action, "Source and destination path must be different.");
+            await That(action, "Source and destination path must be different.").Throws<IOException>();
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.Drives)]
-        public void MockDirectory_Move_ShouldThrowAnIOExceptionIfDirectoriesAreOnDifferentVolumes()
+        public async Task MockDirectory_Move_ShouldThrowAnIOExceptionIfDirectoriesAreOnDifferentVolumes()
         {
             // Arrange
             string sourcePath = XFS.Path(@"c:\a");
@@ -1836,14 +1837,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(sourcePath);
 
             // Act
-            TestDelegate action = () => fileSystem.Directory.Move(sourcePath, destPath);
+            Action action = () => fileSystem.Directory.Move(sourcePath, destPath);
 
             // Assert
-            Assert.Throws<IOException>(action, "Source and destination path must have identical roots. Move will not work across volumes.");
+            await That(action, "Source and destination path must have identical roots. Move will not work across volumes.").Throws<IOException>();
         }
 
         [Test]
-        public void MockDirectory_Move_ShouldThrowADirectoryNotFoundExceptionIfDestinationDirectoryDoesNotExist()
+        public async Task MockDirectory_Move_ShouldThrowADirectoryNotFoundExceptionIfDestinationDirectoryDoesNotExist()
         {
             // Arrange
             string sourcePath = XFS.Path(@"c:\a");
@@ -1851,14 +1852,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => fileSystem.Directory.Move(sourcePath, destPath);
+            Action action = () => fileSystem.Directory.Move(sourcePath, destPath);
 
             // Assert
-            Assert.Throws<DirectoryNotFoundException>(action, "Could not find a part of the path 'c:\a'.");
+            await That(action, "Could not find a part of the path 'c:\a'.").Throws<DirectoryNotFoundException>();
         }
 
         [Test]
-        public void MockDirectory_Move_ShouldThrowAnIOExceptionIfDestinationDirectoryExists()
+        public async Task MockDirectory_Move_ShouldThrowAnIOExceptionIfDestinationDirectoryExists()
         {
             // Arrange
             string sourcePath = XFS.Path(@"c:\a");
@@ -1868,14 +1869,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(destPath);
 
             // Act
-            TestDelegate action = () => fileSystem.Directory.Move(sourcePath, destPath);
+            Action action = () => fileSystem.Directory.Move(sourcePath, destPath);
 
             // Assert
-            Assert.Throws<IOException>(action, "Cannot create 'c:\b\' because a file or directory with the same name already exists.'");
+            await That(action, "Cannot create 'c:\b\' because a file or directory with the same name already exists.'").Throws<IOException>();
         }
 
         [Test]
-        public void MockDirectory_EnumerateFiles_ShouldReturnAllFilesBelowPathWhenPatternIsWildcardAndSearchOptionIsAllDirectories()
+        public async Task MockDirectory_EnumerateFiles_ShouldReturnAllFilesBelowPathWhenPatternIsWildcardAndSearchOptionIsAllDirectories()
         {
             // Arrange
             var fileSystem = SetupFileSystem();
@@ -1895,12 +1896,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.EnumerateFiles(XFS.Path(@"c:\a"), "*", SearchOption.AllDirectories);
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 
 #if FEATURE_ENUMERATION_OPTIONS
         [Test]
-        public void MockDirectory_EnumerateFiles_ShouldReturnAllFilesBelowPathWhenPatternIsWildcardAndEnumerationOptionsIsAllDirectories()
+        public async Task MockDirectory_EnumerateFiles_ShouldReturnAllFilesBelowPathWhenPatternIsWildcardAndEnumerationOptionsIsAllDirectories()
         {
             // Arrange
             var fileSystem = SetupFileSystem();
@@ -1925,13 +1926,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.EnumerateFiles(XFS.Path(@"c:\a"), "*", enumerationOptions);
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 
 #endif
 
         [Test]
-        public void MockDirectory_EnumerateFiles_ShouldFilterByExtensionBasedSearchPattern()
+        public async Task MockDirectory_EnumerateFiles_ShouldFilterByExtensionBasedSearchPattern()
         {
             // Arrange
             var fileSystem = SetupFileSystem();
@@ -1946,11 +1947,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.EnumerateFiles(XFS.Path(@"c:\"), "*.gif", SearchOption.AllDirectories);
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 
         [Test]
-        public void MockDirectory_EnumerateFiles_WhenFilterIsUnRooted_ShouldFindFilesInCurrentDirectory()
+        public async Task MockDirectory_EnumerateFiles_WhenFilterIsUnRooted_ShouldFindFilesInCurrentDirectory()
         {
             // Arrange
             var someContent = new MockFileData(String.Empty);
@@ -1973,11 +1974,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.EnumerateFiles(XFS.Path("b"));
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 
         [Test]
-        public void MockDirectory_EnumerateFiles_WhenFilterIsUnRooted_ShouldNotFindFilesInPathOutsideCurrentDirectory()
+        public async Task MockDirectory_EnumerateFiles_WhenFilterIsUnRooted_ShouldNotFindFilesInPathOutsideCurrentDirectory()
         {
             // Arrange
             var someContent = new MockFileData(String.Empty);
@@ -1999,11 +2000,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.EnumerateFiles(XFS.Path("b"));
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 
         [Test]
-        public void MockDirectory_EnumerateFileSystemEntries_ShouldReturnAllFilesBelowPathWhenPatternIsWildcardAndSearchOptionIsAllDirectories()
+        public async Task MockDirectory_EnumerateFileSystemEntries_ShouldReturnAllFilesBelowPathWhenPatternIsWildcardAndSearchOptionIsAllDirectories()
         {
             // Arrange
             var fileSystem = SetupFileSystem();
@@ -2024,11 +2025,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.EnumerateFileSystemEntries(XFS.Path(@"c:\a"), "*", SearchOption.AllDirectories);
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 
         [Test]
-        public void MockDirectory_EnumerateFileSystemEntries_ShouldFilterByExtensionBasedSearchPattern()
+        public async Task MockDirectory_EnumerateFileSystemEntries_ShouldFilterByExtensionBasedSearchPattern()
         {
             // Arrange
             var fileSystem = SetupFileSystem();
@@ -2043,12 +2044,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.EnumerateFileSystemEntries(XFS.Path(@"c:\"), "*.gif", SearchOption.AllDirectories);
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 
 #if FEATURE_ENUMERATION_OPTIONS
         [Test]
-        public void MockDirectory_EnumerateFileSystemEntries_ShouldReturnAllFilesBelowPathWhenPatternIsWildcardAndEnumerationOptionsIsAllDirectories()
+        public async Task MockDirectory_EnumerateFileSystemEntries_ShouldReturnAllFilesBelowPathWhenPatternIsWildcardAndEnumerationOptionsIsAllDirectories()
         {
             // Arrange
             var fileSystem = SetupFileSystem();
@@ -2074,26 +2075,26 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.Directory.EnumerateFileSystemEntries(XFS.Path(@"c:\a"), "*", enumerationOptions);
 
             // Assert
-            Assert.That(result, Is.EquivalentTo(expected));
+            await That(result).IsEqualTo(expected).InAnyOrder();
         }
 #endif
 
         [Test]
-        public void MockDirectory_GetAccessControl_ShouldThrowExceptionOnDirectoryNotFound()
+        public async Task MockDirectory_GetAccessControl_ShouldThrowExceptionOnDirectoryNotFound()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
 #pragma warning disable CA1416
-            Assert.Throws<DirectoryNotFoundException>(() => fileSystem.Directory.GetAccessControl(XFS.Path(@"c:\foo")));
+            await That(() => fileSystem.Directory.GetAccessControl(XFS.Path(@"c:\foo"))).Throws<DirectoryNotFoundException>();
 #pragma warning restore CA1416
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.AccessControlLists)]
         [SupportedOSPlatform("windows")]
-        public void MockDirectory_GetAccessControl_ShouldReturnNewDirectorySecurity()
+        public async Task MockDirectory_GetAccessControl_ShouldReturnNewDirectorySecurity()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -2103,11 +2104,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             DirectorySecurity result = fileSystem.Directory.GetAccessControl(XFS.Path(@"c:\foo\"));
 
             // Assert
-            Assert.That(result, Is.Not.Null);
+            await That(result).IsNotNull();
         }
 
         [Test]
-        public void MockDirectory_SetCreationTime_ShouldNotThrowWithoutTrailingBackslash()
+        public async Task MockDirectory_SetCreationTime_ShouldNotThrowWithoutTrailingBackslash()
         {
             var path = XFS.Path(@"C:\NoTrailingBackslash");
             var fs = new MockFileSystem();
@@ -2138,7 +2139,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
         [Test]
         [TestCaseSource(nameof(Failing_DirectoryMoveFromToPaths))]
-        public void Move_Directory_Throws_When_Target_Directory_Parent_Does_Not_Exist(
+        public async Task Move_Directory_Throws_When_Target_Directory_Parent_Does_Not_Exist(
             string sourceDirName,
             string targetDirName)
         {
@@ -2147,12 +2148,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.CreateDirectory(sourceDirName);
 
             // Act
-            Assert.Throws<DirectoryNotFoundException>(() =>
-                fileSystem.Directory.Move(sourceDirName, targetDirName));
+            await That(() => fileSystem.Directory.Move(sourceDirName, targetDirName))
+                .Throws<DirectoryNotFoundException>();
 
             // Assert
-            Assert.That(fileSystem.Directory.Exists(targetDirName), Is.False);
-            Assert.That(fileSystem.Directory.Exists(sourceDirName), Is.True);
+            await That(fileSystem.Directory.Exists(targetDirName)).IsFalse();
+            await That(fileSystem.Directory.Exists(sourceDirName)).IsTrue();
         }
 
         private static IEnumerable<TestCaseData> Success_DirectoryMoveFromToPaths
@@ -2176,7 +2177,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
         [Test]
         [TestCaseSource(nameof(Success_DirectoryMoveFromToPaths))]
-        public void Move_Directory_DoesNotThrow_When_Target_Directory_Parent_Exists(
+        public async Task Move_Directory_DoesNotThrow_When_Target_Directory_Parent_Exists(
             string sourceDirName,
             string targetDirName)
         {
@@ -2185,12 +2186,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.Directory.CreateDirectory(sourceDirName);
 
             // Act
-            Assert.DoesNotThrow(() =>
-                fileSystem.Directory.Move(sourceDirName, targetDirName));
+            await That(() => fileSystem.Directory.Move(sourceDirName, targetDirName)).DoesNotThrow();
 
             // Assert
-            Assert.That(fileSystem.Directory.Exists(targetDirName), Is.True);
-            Assert.That(fileSystem.Directory.Exists(sourceDirName), Is.False);
+            await That(fileSystem.Directory.Exists(targetDirName)).IsTrue();
+            await That(fileSystem.Directory.Exists(sourceDirName)).IsFalse();
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDriveInfoFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDriveInfoFactoryTests.cs
@@ -11,7 +11,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockDriveInfoFactoryTests
     {
         [Test]
-        public void MockDriveInfoFactory_GetDrives_ShouldReturnDrives()
+        public async Task MockDriveInfoFactory_GetDrives_ShouldReturnDrives()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -26,11 +26,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualNames = actualResults.Select(d => d.Name);
 
             // Assert
-            Assert.That(actualNames, Is.EquivalentTo(new[] { @"C:\", @"Z:\", @"d:\" }));
+            await That(actualNames).IsEquivalentTo(new[] { @"C:\", @"Z:\", @"d:\" });
         }
 
         [Test]
-        public void MockDriveInfoFactory_GetDrives_ShouldReturnDrivesWithNoDuplicates()
+        public async Task MockDriveInfoFactory_GetDrives_ShouldReturnDrivesWithNoDuplicates()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -47,11 +47,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualNames = actualResults.Select(d => d.Name);
 
             // Assert
-            Assert.That(actualNames, Is.EquivalentTo(new[] { @"C:\", @"Z:\", @"d:\" }));
+            await That(actualNames).IsEquivalentTo(new[] { @"C:\", @"Z:\", @"d:\" });
         }
 
         [Test]
-        public void MockDriveInfoFactory_GetDrives_ShouldReturnOnlyLocalDrives()
+        public async Task MockDriveInfoFactory_GetDrives_ShouldReturnOnlyLocalDrives()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -67,11 +67,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualNames = actualResults.Select(d => d.Name);
 
             // Assert
-            Assert.That(actualNames, Is.EquivalentTo(new[] { @"C:\", @"Z:\", @"d:\" }));
+            await That(actualNames).IsEquivalentTo(new[] { @"C:\", @"Z:\", @"d:\" });
         }
 
         [Test]
-        public void MockDriveInfoFactory_New_WithDriveShouldReturnDrive()
+        public async Task MockDriveInfoFactory_New_WithDriveShouldReturnDrive()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -81,11 +81,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = factory.New(@"Z:\");
 
             // Assert
-            Assert.That(actualResult.Name, Is.EquivalentTo(@"Z:\"));
+            await That(actualResult.Name).IsEquivalentTo(@"Z:\");
         }
 
         [Test]
-        public void MockDriveInfoFactory_New_WithPathShouldReturnDrive()
+        public async Task MockDriveInfoFactory_New_WithPathShouldReturnDrive()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -95,17 +95,17 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = factory.New(@"Z:\foo\bar\");
 
             // Assert
-            Assert.That(actualResult.Name, Is.EquivalentTo(@"Z:\"));
+            await That(actualResult.Name).IsEquivalentTo(@"Z:\");
         }
 
         [Test]
-        public void MockDriveInfoFactory_Wrap_WithNull_ShouldReturnNull()
+        public async Task MockDriveInfoFactory_Wrap_WithNull_ShouldReturnNull()
         {
             var fileSystem = new MockFileSystem();
 
             var result = fileSystem.DriveInfo.Wrap(null);
 
-            Assert.That(result, Is.Null);
+            await That(result).IsNull();
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDriveInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDriveInfoTests.cs
@@ -11,7 +11,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     {
         [TestCase(@"c:")]
         [TestCase(@"c:\")]
-        public void MockDriveInfo_Constructor_ShouldInitializeLocalWindowsDrives(string driveName)
+        public async Task MockDriveInfo_Constructor_ShouldInitializeLocalWindowsDrives(string driveName)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -22,11 +22,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var driveInfo = new MockDriveInfo(fileSystem, path);
 
             // Assert
-            Assert.That(driveInfo.Name, Is.EqualTo(@"c:\"));
+            await That(driveInfo.Name).IsEqualTo(@"c:\");
         }
 
         [Test]
-        public void MockDriveInfo_Constructor_ShouldInitializeLocalWindowsDrives_SpecialForWindows()
+        public async Task MockDriveInfo_Constructor_ShouldInitializeLocalWindowsDrives_SpecialForWindows()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -36,25 +36,25 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var driveInfo = new MockDriveInfo(fileSystem, "c");
 
             // Assert
-            Assert.That(driveInfo.Name, Is.EqualTo(@"c:\"));
+            await That(driveInfo.Name).IsEqualTo(@"c:\");
         }
 
         [TestCase(@"\\unc\share")]
         [TestCase(@"\\unctoo")]
-        public void MockDriveInfo_Constructor_ShouldThrowExceptionIfUncPath(string driveName)
+        public async Task MockDriveInfo_Constructor_ShouldThrowExceptionIfUncPath(string driveName)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => new MockDriveInfo(fileSystem, XFS.Path(driveName));
+            Action action = () => new MockDriveInfo(fileSystem, XFS.Path(driveName));
 
             // Assert
-            Assert.Throws<ArgumentException>(action);
+            await That(action).Throws<ArgumentException>();
         }
 
         [Test]
-        public void MockDriveInfo_RootDirectory_ShouldReturnTheDirectoryBase()
+        public async Task MockDriveInfo_RootDirectory_ShouldReturnTheDirectoryBase()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -66,7 +66,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualDirectory = driveInfo.RootDirectory;
 
             // Assert
-            Assert.That(actualDirectory.FullName, Is.EqualTo(expectedDirectory));
+            await That(actualDirectory.FullName).IsEqualTo(expectedDirectory);
         }
 
         [TestCase("c:", "c:\\")]
@@ -74,7 +74,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [TestCase("d:", "d:\\")]
         [TestCase("e:", "e:\\")]
         [TestCase("f:", "f:\\")]
-        public void MockDriveInfo_ToString_ShouldReturnTheDrivePath(string path, string expectedPath)
+        public async Task MockDriveInfo_ToString_ShouldReturnTheDrivePath(string path, string expectedPath)
         {
             // Arrange
             var directoryPath = XFS.Path(path);
@@ -83,11 +83,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var mockDriveInfo = new MockDriveInfo(new MockFileSystem(), directoryPath);
 
             // Assert
-            Assert.That(mockDriveInfo.ToString(), Is.EqualTo(expectedPath));
+            await That(mockDriveInfo.ToString()).IsEqualTo(expectedPath);
         }
 
         [Test]
-        public void MockDriveInfo_AvailableFreeSpace_ShouldReturnAvailableFreeSpaceOfDriveInMemoryFileSystem()
+        public async Task MockDriveInfo_AvailableFreeSpace_ShouldReturnAvailableFreeSpaceOfDriveInMemoryFileSystem()
         {
             // Arrange
             var availableFreeSpace = 1024L;
@@ -102,11 +102,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = driveInfo.AvailableFreeSpace;
 
             // Assert
-            Assert.That(result, Is.EqualTo(availableFreeSpace));
+            await That(result).IsEqualTo(availableFreeSpace);
         }
 
         [Test]
-        public void MockDriveInfo_DriveFormat_ShouldReturnDriveFormatOfDriveInMemoryFileSystem()
+        public async Task MockDriveInfo_DriveFormat_ShouldReturnDriveFormatOfDriveInMemoryFileSystem()
         {
             // Arrange
             var driveFormat = "NTFS";
@@ -121,11 +121,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = driveInfo.DriveFormat;
 
             // Assert
-            Assert.That(result, Is.EqualTo(driveFormat));
+            await That(result).IsEqualTo(driveFormat);
         }
 
         [Test]
-        public void MockDriveInfo_DriveType_ShouldReturnDriveTypeOfDriveInMemoryFileSystem()
+        public async Task MockDriveInfo_DriveType_ShouldReturnDriveTypeOfDriveInMemoryFileSystem()
         {
             // Arrange
             var driveType = DriveType.Fixed;
@@ -140,12 +140,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = driveInfo.DriveType;
 
             // Assert
-            Assert.That(result, Is.EqualTo(driveType));
+            await That(result).IsEqualTo(driveType);
         }
 
         [TestCase(true)]
         [TestCase(false)]
-        public void MockDriveInfo_IsReady_ShouldReturnIsReadyOfDriveInMemoryFileSystem(bool isReady)
+        public async Task MockDriveInfo_IsReady_ShouldReturnIsReadyOfDriveInMemoryFileSystem(bool isReady)
         {
             // Arrange
             var driveData = new MockDriveData { IsReady = isReady };
@@ -159,11 +159,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = driveInfo.IsReady;
 
             // Assert
-            Assert.That(result, Is.EqualTo(isReady));
+            await That(result).IsEqualTo(isReady);
         }
 
         [Test]
-        public void MockDriveInfo_TotalFreeSpace_ShouldReturnTotalFreeSpaceOfDriveInMemoryFileSystem()
+        public async Task MockDriveInfo_TotalFreeSpace_ShouldReturnTotalFreeSpaceOfDriveInMemoryFileSystem()
         {
             // Arrange
             var totalFreeSpace = 4096L;
@@ -178,11 +178,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = driveInfo.TotalFreeSpace;
 
             // Assert
-            Assert.That(result, Is.EqualTo(totalFreeSpace));
+            await That(result).IsEqualTo(totalFreeSpace);
         }
 
         [Test]
-        public void MockDriveInfo_TotalSize_ShouldReturnTotalSizeOfDriveInMemoryFileSystem()
+        public async Task MockDriveInfo_TotalSize_ShouldReturnTotalSizeOfDriveInMemoryFileSystem()
         {
             // Arrange
             var totalSize = 8192L;
@@ -197,11 +197,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = driveInfo.TotalSize;
 
             // Assert
-            Assert.That(result, Is.EqualTo(totalSize));
+            await That(result).IsEqualTo(totalSize);
         }
 
         [Test]
-        public void MockDriveInfo_VolumeLabel_ShouldReturnVolumeLabelOfDriveInMemoryFileSystem()
+        public async Task MockDriveInfo_VolumeLabel_ShouldReturnVolumeLabelOfDriveInMemoryFileSystem()
         {
             // Arrange
             var volumeLabel = "Windows";
@@ -216,7 +216,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = driveInfo.VolumeLabel;
 
             // Assert
-            Assert.That(result, Is.EqualTo(volumeLabel));
+            await That(result).IsEqualTo(volumeLabel);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileAdjustTimesTest.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileAdjustTimesTest.cs
@@ -9,7 +9,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockFileAdjustTimesTest
     {
         [Test]
-        public void MockFile_AfterAppendAllText_ShouldUpdateLastAccessAndLastWriteTime()
+        public async Task MockFile_AfterAppendAllText_ShouldUpdateLastAccessAndLastWriteTime()
         {
             var creationTime = DateTime.UtcNow.AddDays(10);
             var updateTime = creationTime.AddDays(10);
@@ -23,13 +23,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualLastAccessTime = fileSystem.File.GetLastAccessTimeUtc("foo.txt");
             var actualLastWriteTime = fileSystem.File.GetLastWriteTimeUtc("foo.txt");
 
-            Assert.That(actualCreationTime, Is.EqualTo(creationTime));
-            Assert.That(actualLastAccessTime, Is.EqualTo(updateTime));
-            Assert.That(actualLastWriteTime, Is.EqualTo(updateTime));
+            await That(actualCreationTime).IsEqualTo(creationTime);
+            await That(actualLastAccessTime).IsEqualTo(updateTime);
+            await That(actualLastWriteTime).IsEqualTo(updateTime);
         }
 
         [Test]
-        public void MockFile_AfterCopy_ShouldUpdateCreationAndLastAccessTimeOfDestination()
+        public async Task MockFile_AfterCopy_ShouldUpdateCreationAndLastAccessTimeOfDestination()
         {
             var creationTime = DateTime.UtcNow.AddDays(10);
             var updateTime = creationTime.AddDays(10);
@@ -46,16 +46,16 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualSourceLastWriteTime = fileSystem.File.GetLastWriteTimeUtc("foo.txt");
             var actualDestinationLastWriteTime = fileSystem.File.GetLastWriteTimeUtc("bar.txt");
 
-            Assert.That(actualSourceCreationTime, Is.EqualTo(creationTime));
-            Assert.That(actualDestinationCreationTime, Is.EqualTo(updateTime));
-            Assert.That(actualSourceLastAccessTime, Is.EqualTo(creationTime));
-            Assert.That(actualDestinationLastAccessTime, Is.EqualTo(updateTime));
-            Assert.That(actualSourceLastWriteTime, Is.EqualTo(creationTime));
-            Assert.That(actualDestinationLastWriteTime, Is.EqualTo(creationTime));
+            await That(actualSourceCreationTime).IsEqualTo(creationTime);
+            await That(actualDestinationCreationTime).IsEqualTo(updateTime);
+            await That(actualSourceLastAccessTime).IsEqualTo(creationTime);
+            await That(actualDestinationLastAccessTime).IsEqualTo(updateTime);
+            await That(actualSourceLastWriteTime).IsEqualTo(creationTime);
+            await That(actualDestinationLastWriteTime).IsEqualTo(creationTime);
         }
 
         [Test]
-        public void MockFile_AfterMove_ShouldUpdateLastAccessTime()
+        public async Task MockFile_AfterMove_ShouldUpdateLastAccessTime()
         {
             var creationTime = DateTime.UtcNow.AddDays(10);
             var updateTime = creationTime.AddDays(10);
@@ -69,15 +69,15 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualLastAccessTime = fileSystem.File.GetLastAccessTimeUtc("bar.txt");
             var actualLastWriteTime = fileSystem.File.GetLastWriteTimeUtc("bar.txt");
 
-            Assert.That(actualCreationTime, Is.EqualTo(creationTime));
-            Assert.That(actualLastAccessTime, Is.EqualTo(updateTime));
-            Assert.That(actualLastWriteTime, Is.EqualTo(creationTime));
+            await That(actualCreationTime).IsEqualTo(creationTime);
+            await That(actualLastAccessTime).IsEqualTo(updateTime);
+            await That(actualLastWriteTime).IsEqualTo(creationTime);
         }
 
         [TestCase(FileMode.Open, FileAccess.ReadWrite)]
         [TestCase(FileMode.OpenOrCreate, FileAccess.Write)]
         [TestCase(FileMode.Append, FileAccess.Write)]
-        public void MockFile_AfterOpen_WithWriteAccess_ShouldUpdateLastAccessAndLastWriteTime(FileMode fileMode, FileAccess fileAccess)
+        public async Task MockFile_AfterOpen_WithWriteAccess_ShouldUpdateLastAccessAndLastWriteTime(FileMode fileMode, FileAccess fileAccess)
         {
             var creationTime = DateTime.UtcNow.AddDays(10);
             var updateTime = creationTime.AddDays(10);
@@ -91,14 +91,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualLastAccessTime = fileSystem.File.GetLastAccessTimeUtc("foo.txt");
             var actualLastWriteTime = fileSystem.File.GetLastWriteTimeUtc("foo.txt");
 
-            Assert.That(actualCreationTime, Is.EqualTo(creationTime));
-            Assert.That(actualLastAccessTime, Is.EqualTo(updateTime));
-            Assert.That(actualLastWriteTime, Is.EqualTo(updateTime));
+            await That(actualCreationTime).IsEqualTo(creationTime);
+            await That(actualLastAccessTime).IsEqualTo(updateTime);
+            await That(actualLastWriteTime).IsEqualTo(updateTime);
         }
 
         [TestCase(FileMode.Open, FileAccess.Read)]
         [TestCase(FileMode.OpenOrCreate, FileAccess.Read)]
-        public void MockFile_AfterOpen_WithReadOnlyAccess_ShouldUpdateLastAccessTime(FileMode fileMode, FileAccess fileAccess)
+        public async Task MockFile_AfterOpen_WithReadOnlyAccess_ShouldUpdateLastAccessTime(FileMode fileMode, FileAccess fileAccess)
         {
             var creationTime = DateTime.UtcNow.AddDays(10);
             var updateTime = creationTime.AddDays(10);
@@ -112,13 +112,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualLastAccessTime = fileSystem.File.GetLastAccessTimeUtc("foo.txt");
             var actualLastWriteTime = fileSystem.File.GetLastWriteTimeUtc("foo.txt");
 
-            Assert.That(actualCreationTime, Is.EqualTo(creationTime));
-            Assert.That(actualLastAccessTime, Is.EqualTo(updateTime));
-            Assert.That(actualLastWriteTime, Is.EqualTo(creationTime));
+            await That(actualCreationTime).IsEqualTo(creationTime);
+            await That(actualLastAccessTime).IsEqualTo(updateTime);
+            await That(actualLastWriteTime).IsEqualTo(creationTime);
         }
 
         [Test]
-        public void MockFile_AfterReadAllBytes_ShouldUpdateLastAccessTime()
+        public async Task MockFile_AfterReadAllBytes_ShouldUpdateLastAccessTime()
         {
             var creationTime = DateTime.UtcNow.AddDays(10);
             var updateTime = creationTime.AddDays(10);
@@ -132,13 +132,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualLastAccessTime = fileSystem.File.GetLastAccessTimeUtc("foo.txt");
             var actualLastWriteTime = fileSystem.File.GetLastWriteTimeUtc("foo.txt");
 
-            Assert.That(actualCreationTime, Is.EqualTo(creationTime));
-            Assert.That(actualLastAccessTime, Is.EqualTo(updateTime));
-            Assert.That(actualLastWriteTime, Is.EqualTo(creationTime));
+            await That(actualCreationTime).IsEqualTo(creationTime);
+            await That(actualLastAccessTime).IsEqualTo(updateTime);
+            await That(actualLastWriteTime).IsEqualTo(creationTime);
         }
 
         [Test]
-        public void MockFile_AfterReadAllLines_ShouldUpdateLastAccessTime()
+        public async Task MockFile_AfterReadAllLines_ShouldUpdateLastAccessTime()
         {
             var creationTime = DateTime.UtcNow.AddDays(10);
             var updateTime = creationTime.AddDays(10);
@@ -152,13 +152,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualLastAccessTime = fileSystem.File.GetLastAccessTimeUtc("foo.txt");
             var actualLastWriteTime = fileSystem.File.GetLastWriteTimeUtc("foo.txt");
 
-            Assert.That(actualCreationTime, Is.EqualTo(creationTime));
-            Assert.That(actualLastAccessTime, Is.EqualTo(updateTime));
-            Assert.That(actualLastWriteTime, Is.EqualTo(creationTime));
+            await That(actualCreationTime).IsEqualTo(creationTime);
+            await That(actualLastAccessTime).IsEqualTo(updateTime);
+            await That(actualLastWriteTime).IsEqualTo(creationTime);
         }
 
         [Test]
-        public void MockFile_AfterReadAllText_ShouldUpdateLastAccessTime()
+        public async Task MockFile_AfterReadAllText_ShouldUpdateLastAccessTime()
         {
             var creationTime = DateTime.UtcNow.AddDays(10);
             var updateTime = creationTime.AddDays(10);
@@ -172,13 +172,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualLastAccessTime = fileSystem.File.GetLastAccessTimeUtc("foo.txt");
             var actualLastWriteTime = fileSystem.File.GetLastWriteTimeUtc("foo.txt");
 
-            Assert.That(actualCreationTime, Is.EqualTo(creationTime));
-            Assert.That(actualLastAccessTime, Is.EqualTo(updateTime));
-            Assert.That(actualLastWriteTime, Is.EqualTo(creationTime));
+            await That(actualCreationTime).IsEqualTo(creationTime);
+            await That(actualLastAccessTime).IsEqualTo(updateTime);
+            await That(actualLastWriteTime).IsEqualTo(creationTime);
         }
 
         [Test]
-        public void MockFile_AfterSetAttributes_ShouldUpdateLastAccessTime()
+        public async Task MockFile_AfterSetAttributes_ShouldUpdateLastAccessTime()
         {
             var creationTime = DateTime.UtcNow.AddDays(10);
             var updateTime = creationTime.AddDays(10);
@@ -192,15 +192,15 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualLastAccessTime = fileSystem.File.GetLastAccessTimeUtc("foo.txt");
             var actualLastWriteTime = fileSystem.File.GetLastWriteTimeUtc("foo.txt");
 
-            Assert.That(actualCreationTime, Is.EqualTo(creationTime));
-            Assert.That(actualLastAccessTime, Is.EqualTo(updateTime));
-            Assert.That(actualLastWriteTime, Is.EqualTo(creationTime));
+            await That(actualCreationTime).IsEqualTo(creationTime);
+            await That(actualLastAccessTime).IsEqualTo(updateTime);
+            await That(actualLastWriteTime).IsEqualTo(creationTime);
         }
 
         [Test]
         [SupportedOSPlatform("windows")]
         [WindowsOnly(WindowsSpecifics.AccessControlLists)]
-        public void MockFile_AfterSetAccessControl_ShouldUpdateLastAccessTime()
+        public async Task MockFile_AfterSetAccessControl_ShouldUpdateLastAccessTime()
         {
             var creationTime = DateTime.UtcNow.AddDays(10);
             var updateTime = creationTime.AddDays(10);
@@ -214,13 +214,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualLastAccessTime = fileSystem.File.GetLastAccessTimeUtc("foo.txt");
             var actualLastWriteTime = fileSystem.File.GetLastWriteTimeUtc("foo.txt");
 
-            Assert.That(actualCreationTime, Is.EqualTo(creationTime));
-            Assert.That(actualLastAccessTime, Is.EqualTo(creationTime));
-            Assert.That(actualLastWriteTime, Is.EqualTo(creationTime));
+            await That(actualCreationTime).IsEqualTo(creationTime);
+            await That(actualLastAccessTime).IsEqualTo(creationTime);
+            await That(actualLastWriteTime).IsEqualTo(creationTime);
         }
 
         [Test]
-        public void MockFile_AfterWriteAllBytes_ShouldUpdateLastAccessAndLastWriteTime()
+        public async Task MockFile_AfterWriteAllBytes_ShouldUpdateLastAccessAndLastWriteTime()
         {
             var creationTime = DateTime.UtcNow.AddDays(10);
             var updateTime = creationTime.AddDays(10);
@@ -234,13 +234,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualLastAccessTime = fileSystem.File.GetLastAccessTimeUtc("foo.txt");
             var actualLastWriteTime = fileSystem.File.GetLastWriteTimeUtc("foo.txt");
 
-            Assert.That(actualCreationTime, Is.EqualTo(creationTime));
-            Assert.That(actualLastAccessTime, Is.EqualTo(updateTime));
-            Assert.That(actualLastWriteTime, Is.EqualTo(updateTime));
+            await That(actualCreationTime).IsEqualTo(creationTime);
+            await That(actualLastAccessTime).IsEqualTo(updateTime);
+            await That(actualLastWriteTime).IsEqualTo(updateTime);
         }
 
         [Test]
-        public void MockFile_AfterWriteAllText_ShouldUpdateLastAccessAndLastWriteTime()
+        public async Task MockFile_AfterWriteAllText_ShouldUpdateLastAccessAndLastWriteTime()
         {
             var creationTime = DateTime.UtcNow.AddDays(10);
             var updateTime = creationTime.AddDays(10);
@@ -254,13 +254,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualLastAccessTime = fileSystem.File.GetLastAccessTimeUtc("foo.txt");
             var actualLastWriteTime = fileSystem.File.GetLastWriteTimeUtc("foo.txt");
 
-            Assert.That(actualCreationTime, Is.EqualTo(creationTime));
-            Assert.That(actualLastAccessTime, Is.EqualTo(updateTime));
-            Assert.That(actualLastWriteTime, Is.EqualTo(updateTime));
+            await That(actualCreationTime).IsEqualTo(creationTime);
+            await That(actualLastAccessTime).IsEqualTo(updateTime);
+            await That(actualLastWriteTime).IsEqualTo(updateTime);
         }
 
         [Test]
-        public void MockFileStream_OpenRead_ShouldUpdateLastAccessTime()
+        public async Task MockFileStream_OpenRead_ShouldUpdateLastAccessTime()
         {
             var creationTime = DateTime.UtcNow.AddDays(10);
             var updateTime = creationTime.AddDays(10);
@@ -274,13 +274,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualLastAccessTime = fileSystem.File.GetLastAccessTimeUtc("foo.txt");
             var actualLastWriteTime = fileSystem.File.GetLastWriteTimeUtc("foo.txt");
 
-            Assert.That(actualCreationTime, Is.EqualTo(creationTime));
-            Assert.That(actualLastAccessTime, Is.EqualTo(updateTime));
-            Assert.That(actualLastWriteTime, Is.EqualTo(creationTime));
+            await That(actualCreationTime).IsEqualTo(creationTime);
+            await That(actualLastAccessTime).IsEqualTo(updateTime);
+            await That(actualLastWriteTime).IsEqualTo(creationTime);
         }
 
         [Test]
-        public void MockFileStream_OpenWrite_ShouldUpdateLastAccessAndLastWriteTime()
+        public async Task MockFileStream_OpenWrite_ShouldUpdateLastAccessAndLastWriteTime()
         {
             var creationTime = DateTime.UtcNow.AddDays(10);
             var updateTime = creationTime.AddDays(10);
@@ -294,9 +294,9 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualLastAccessTime = fileSystem.File.GetLastAccessTimeUtc("foo.txt");
             var actualLastWriteTime = fileSystem.File.GetLastWriteTimeUtc("foo.txt");
 
-            Assert.That(actualCreationTime, Is.EqualTo(creationTime));
-            Assert.That(actualLastAccessTime, Is.EqualTo(updateTime));
-            Assert.That(actualLastWriteTime, Is.EqualTo(updateTime));
+            await That(actualCreationTime).IsEqualTo(creationTime);
+            await That(actualLastAccessTime).IsEqualTo(updateTime);
+            await That(actualLastWriteTime).IsEqualTo(updateTime);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileAppendAllLinesTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileAppendAllLinesTests.cs
@@ -9,7 +9,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockFileAppendAllLinesTests
     {
         [Test]
-        public void MockFile_AppendAllLines_ShouldPersistNewLinesToExistingFile()
+        public async Task MockFile_AppendAllLines_ShouldPersistNewLinesToExistingFile()
         {
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
@@ -24,12 +24,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             file.AppendAllLines(path, new[] { "line 1", "line 2", "line 3" });
 
             // Assert
-            Assert.That(file.ReadAllText(path),
-              Is.EqualTo("Demo text contentline 1" + Environment.NewLine + "line 2" + Environment.NewLine + "line 3" + Environment.NewLine));
+            await That(file.ReadAllText(path))
+                .IsEqualTo("Demo text contentline 1" + Environment.NewLine + "line 2" + Environment.NewLine + "line 3" + Environment.NewLine);
         }
 
         [Test]
-        public void MockFile_AppendAllLines_ShouldPersistNewLinesToNewFile()
+        public async Task MockFile_AppendAllLines_ShouldPersistNewLinesToNewFile()
         {
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
@@ -43,35 +43,35 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             file.AppendAllLines(path, new[] { "line 1", "line 2", "line 3" });
 
             // Assert
-            Assert.That(file.ReadAllText(path),
-              Is.EqualTo("line 1" + Environment.NewLine + "line 2" + Environment.NewLine + "line 3" + Environment.NewLine));
+            await That(file.ReadAllText(path))
+                .IsEqualTo("line 1" + Environment.NewLine + "line 2" + Environment.NewLine + "line 3" + Environment.NewLine);
         }
 
         [Test]
-        public void MockFile_AppendAllLines_ShouldThrowArgumentExceptionIfPathIsZeroLength()
+        public async Task MockFile_AppendAllLines_ShouldThrowArgumentExceptionIfPathIsZeroLength()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => fileSystem.File.AppendAllLines(string.Empty, new[] { "does not matter" });
+            Action action = () => fileSystem.File.AppendAllLines(string.Empty, new[] { "does not matter" });
 
             // Assert
-            Assert.Throws<ArgumentException>(action);
+            await That(action).Throws<ArgumentException>();
         }
 
         [TestCase(" ")]
         [TestCase("   ")]
-        public void MockFile_AppendAllLines_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        public async Task MockFile_AppendAllLines_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => fileSystem.File.AppendAllLines(path, new[] { "does not matter" });
+            Action action = () => fileSystem.File.AppendAllLines(path, new[] { "does not matter" });
 
             // Assert
-            Assert.Throws<ArgumentException>(action);
+            await That(action).Throws<ArgumentException>();
         }
 
         [TestCase("\"")]
@@ -79,44 +79,44 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [TestCase(">")]
         [TestCase("|")]
         [WindowsOnly(WindowsSpecifics.StrictPathRules)]
-        public void MockFile_AppendAllLines_ShouldThrowArgumentExceptionIfPathContainsInvalidChar(string path)
+        public async Task MockFile_AppendAllLines_ShouldThrowArgumentExceptionIfPathContainsInvalidChar(string path)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => fileSystem.File.AppendAllLines(path, new[] { "does not matter" });
+            Action action = () => fileSystem.File.AppendAllLines(path, new[] { "does not matter" });
 
             // Assert
-            Assert.Throws<ArgumentException>(action);
+            await That(action).Throws<ArgumentException>();
         }
 
         [Test]
-        public void MockFile_AppendAllLines_ShouldThrowArgumentNullExceptionIfContentIsNull()
+        public async Task MockFile_AppendAllLines_ShouldThrowArgumentNullExceptionIfContentIsNull()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => fileSystem.File.AppendAllLines("foo", null);
+            Action action = () => fileSystem.File.AppendAllLines("foo", null);
 
             // Assert
-            var exception = Assert.Throws<ArgumentNullException>(action);
-            Assert.That(exception.ParamName, Is.EqualTo("contents"));
+            var exception = await That(action).Throws<ArgumentNullException>();
+            await That(exception.ParamName).IsEqualTo("contents");
         }
 
         [Test]
-        public void MockFile_AppendAllLines_ShouldThrowArgumentNullExceptionIfEncodingIsNull()
+        public async Task MockFile_AppendAllLines_ShouldThrowArgumentNullExceptionIfEncodingIsNull()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => fileSystem.File.AppendAllLines("foo.txt", new[] { "bar" }, null);
+            Action action = () => fileSystem.File.AppendAllLines("foo.txt", new[] { "bar" }, null);
 
             // Assert
-            var exception = Assert.Throws<ArgumentNullException>(action);
-            Assert.That(exception.ParamName, Is.EqualTo("encoding"));
+            var exception = await That(action).Throws<ArgumentNullException>();
+            await That(exception.ParamName).IsEqualTo("encoding");
         }
 
 #if FEATURE_ASYNC_FILE
@@ -136,8 +136,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             await file.AppendAllLinesAsync(path, new[] { "line 1", "line 2", "line 3" });
 
             // Assert
-            Assert.That(file.ReadAllText(path),
-              Is.EqualTo("Demo text contentline 1" + Environment.NewLine + "line 2" + Environment.NewLine + "line 3" + Environment.NewLine));
+            await That(file.ReadAllText(path))
+                .IsEqualTo("Demo text contentline 1" + Environment.NewLine + "line 2" + Environment.NewLine + "line 3" + Environment.NewLine);
         }
 
         [Test]
@@ -155,12 +155,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             await file.AppendAllLinesAsync(path, new[] { "line 1", "line 2", "line 3" });
 
             // Assert
-            Assert.That(file.ReadAllText(path),
-              Is.EqualTo("line 1" + Environment.NewLine + "line 2" + Environment.NewLine + "line 3" + Environment.NewLine));
+            await That(file.ReadAllText(path))
+                .IsEqualTo("line 1" + Environment.NewLine + "line 2" + Environment.NewLine + "line 3" + Environment.NewLine);
         }
 
         [Test]
-        public void MockFile_AppendAllLinesAsync_ShouldThrowOperationCanceledExceptionIfCancelled()
+        public async Task MockFile_AppendAllLinesAsync_ShouldThrowOperationCanceledExceptionIfCancelled()
         {
             // Arrange
             const string path = "test.txt";
@@ -170,42 +170,42 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             });
 
             // Act
-            Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            async Task Act() =>
                 await fileSystem.File.AppendAllLinesAsync(
                     path,
                     new[] { "line 2" },
-                    new CancellationToken(canceled: true))
-            );
+                    new CancellationToken(canceled: true));
+            await That(Act).Throws<OperationCanceledException>();
 
             // Assert
-            Assert.That(fileSystem.File.ReadAllText(path), Is.EqualTo("line 1"));
+            await That(fileSystem.File.ReadAllText(path)).IsEqualTo("line 1");
         }
 
         [Test]
-        public void MockFile_AppendAllLinesAsync_ShouldThrowArgumentExceptionIfPathIsZeroLength()
+        public async Task MockFile_AppendAllLinesAsync_ShouldThrowArgumentExceptionIfPathIsZeroLength()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            AsyncTestDelegate action = async () => await fileSystem.File.AppendAllLinesAsync(string.Empty, new[] { "does not matter" });
+            Func<Task> action = async () => await fileSystem.File.AppendAllLinesAsync(string.Empty, new[] { "does not matter" });
 
             // Assert
-            Assert.ThrowsAsync<ArgumentException>(action);
+            await That(action).Throws<ArgumentException>();
         }
 
         [TestCase(" ")]
         [TestCase("   ")]
-        public void MockFile_AppendAllLinesAsync_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        public async Task MockFile_AppendAllLinesAsync_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            AsyncTestDelegate action = async () => await fileSystem.File.AppendAllLinesAsync(path, new[] { "does not matter" });
+            Func<Task> action = async () => await fileSystem.File.AppendAllLinesAsync(path, new[] { "does not matter" });
 
             // Assert
-            Assert.ThrowsAsync<ArgumentException>(action);
+            await That(action).Throws<ArgumentException>();
         }
 
         [TestCase("\"")]
@@ -213,44 +213,44 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [TestCase(">")]
         [TestCase("|")]
         [WindowsOnly(WindowsSpecifics.StrictPathRules)]
-        public void MockFile_AppendAllLinesAsync_ShouldThrowArgumentExceptionIfPathContainsInvalidChar(string path)
+        public async Task MockFile_AppendAllLinesAsync_ShouldThrowArgumentExceptionIfPathContainsInvalidChar(string path)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            AsyncTestDelegate action = async () => await fileSystem.File.AppendAllLinesAsync(path, new[] { "does not matter" });
+            Func<Task> action = async () => await fileSystem.File.AppendAllLinesAsync(path, new[] { "does not matter" });
 
             // Assert
-            Assert.ThrowsAsync<ArgumentException>(action);
+            await That(action).Throws<ArgumentException>();
         }
 
         [Test]
-        public void MockFile_AppendAllLinesAsync_ShouldThrowArgumentNullExceptionIfContentIsNull()
+        public async Task MockFile_AppendAllLinesAsync_ShouldThrowArgumentNullExceptionIfContentIsNull()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            AsyncTestDelegate action = async () => await fileSystem.File.AppendAllLinesAsync("foo", null);
+            Func<Task> action = async () => await fileSystem.File.AppendAllLinesAsync("foo", null);
 
             // Assert
-            var exception = Assert.ThrowsAsync<ArgumentNullException>(action);
-            Assert.That(exception.ParamName, Is.EqualTo("contents"));
+            var exception = await That(action).Throws<ArgumentNullException>();
+            await That(exception.ParamName).IsEqualTo("contents");
         }
 
         [Test]
-        public void MockFile_AppendAllLinesAsync_ShouldThrowArgumentNullExceptionIfEncodingIsNull()
+        public async Task MockFile_AppendAllLinesAsync_ShouldThrowArgumentNullExceptionIfEncodingIsNull()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            AsyncTestDelegate action = async () => await fileSystem.File.AppendAllLinesAsync("foo.txt", new[] { "bar" }, null);
+            Func<Task> action = async () => await fileSystem.File.AppendAllLinesAsync("foo.txt", new[] { "bar" }, null);
 
             // Assert
-            var exception = Assert.ThrowsAsync<ArgumentNullException>(action);
-            Assert.That(exception.ParamName, Is.EqualTo("encoding"));
+            var exception = await That(action).Throws<ArgumentNullException>();
+            await That(exception.ParamName).IsEqualTo("encoding");
         }
 #endif
     }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileAppendAllTextTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileAppendAllTextTests.cs
@@ -15,7 +15,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockFileAppendAllTextTests
     {
         [Test]
-        public void MockFile_AppendAllText_ShouldPersistNewText()
+        public async Task MockFile_AppendAllText_ShouldPersistNewText()
         {
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
@@ -30,12 +30,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             file.AppendAllText(path, "+ some text");
 
             // Assert
-            Assert.That(file.ReadAllText(path),
-              Is.EqualTo("Demo text content+ some text"));
+            await That(file.ReadAllText(path))
+              .IsEqualTo("Demo text content+ some text");
         }
 
         [Test]
-        public void MockFile_AppendAllText_ShouldPersistNewTextWithDifferentEncoding()
+        public async Task MockFile_AppendAllText_ShouldPersistNewTextWithDifferentEncoding()
         {
             // Arrange
             const string Path = @"c:\something\demo.txt";
@@ -50,12 +50,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             file.AppendAllText(Path, "BB", Encoding.UTF8);
 
             // Assert
-            Assert.That(fileSystem.GetFile(Path).Contents,
-                Is.EqualTo(new byte[] { 255, 254, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0, 66, 66 }));
+            await That(fileSystem.GetFile(Path).Contents)
+              .IsEqualTo(new byte[] { 255, 254, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0, 66, 66 });
         }
 
         [Test]
-        public void MockFile_AppendAllText_ShouldCreateIfNotExist()
+        public async Task MockFile_AppendAllText_ShouldCreateIfNotExist()
         {
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
@@ -68,12 +68,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.File.AppendAllText(path, " some text");
 
             // Assert
-            Assert.That(fileSystem.File.ReadAllText(path),
-              Is.EqualTo("Demo text content some text"));
+            await That(fileSystem.File.ReadAllText(path))
+              .IsEqualTo("Demo text content some text");
         }
 
         [Test]
-        public void MockFile_AppendAllText_ShouldCreateIfNotExistWithBom()
+        public async Task MockFile_AppendAllText_ShouldCreateIfNotExistWithBom()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
@@ -84,12 +84,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.File.AppendAllText(path, "AA", Encoding.UTF32);
 
             // Assert
-            Assert.That(fileSystem.GetFile(path).Contents,
-                Is.EqualTo(new byte[] { 255, 254, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0 }));
+            await That(fileSystem.GetFile(path).Contents)
+              .IsEqualTo(new byte[] { 255, 254, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0 });
         }
 
         [Test]
-        public void MockFile_AppendAllText_ShouldFailIfNotExistButDirectoryAlsoNotExist()
+        public async Task MockFile_AppendAllText_ShouldFailIfNotExistButDirectoryAlsoNotExist()
         {
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
@@ -103,19 +103,19 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             Exception ex;
-            ex = Assert.Throws<DirectoryNotFoundException>(() => fileSystem.File.AppendAllText(path, "some text"));
-            Assert.That(ex.Message,
-                Is.EqualTo(String.Format(CultureInfo.InvariantCulture, "Could not find a part of the path '{0}'.", path)));
+            ex = await That(() => fileSystem.File.AppendAllText(path, "some text")).Throws<DirectoryNotFoundException>();
+            await That(ex.Message)
+              .IsEqualTo(String.Format(CultureInfo.InvariantCulture, "Could not find a part of the path '{0}'.", path));
 
             ex =
-                Assert.Throws<DirectoryNotFoundException>(
-                    () => fileSystem.File.AppendAllText(path, "some text", Encoding.Unicode));
-            Assert.That(ex.Message,
-                Is.EqualTo(String.Format(CultureInfo.InvariantCulture, "Could not find a part of the path '{0}'.", path)));
+                await That(
+                    () => fileSystem.File.AppendAllText(path, "some text", Encoding.Unicode)).Throws<DirectoryNotFoundException>();
+            await That(ex.Message)
+              .IsEqualTo(String.Format(CultureInfo.InvariantCulture, "Could not find a part of the path '{0}'.", path));
         }
 
         [Test]
-        public void MockFile_AppendAllText_ShouldPersistNewTextWithCustomEncoding()
+        public async Task MockFile_AppendAllText_ShouldPersistNewTextWithCustomEncoding()
         {
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
@@ -137,18 +137,18 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 0, 32, 0, 116, 0, 101, 0, 120, 0, 116
             };
 
-            Assert.That(file.ReadAllBytes(path), Is.EqualTo(expected));
+            await That(file.ReadAllBytes(path)).IsEqualTo(expected);
         }
 
         [Test]
-        public void MockFile_AppendAllText_ShouldWorkWithRelativePath()
+        public async Task MockFile_AppendAllText_ShouldWorkWithRelativePath()
         {
             var file = "file.txt";
             var fileSystem = new MockFileSystem();
 
             fileSystem.File.AppendAllText(file, "Foo");
 
-            Assert.That(fileSystem.File.Exists(file));
+            await That(fileSystem.File.Exists(file)).IsTrue();
         }
 
 #if FEATURE_ASYNC_FILE
@@ -168,12 +168,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             await file.AppendAllTextAsync(path, "+ some text");
 
             // Assert
-            Assert.That(file.ReadAllText(path),
-              Is.EqualTo("Demo text content+ some text"));
+            await That(file.ReadAllText(path))
+              .IsEqualTo("Demo text content+ some text");
         }
 
         [Test]
-        public void MockFile_AppendAllTextAsync_ShouldThrowOperationCanceledExceptionIfCancelled()
+        public async Task MockFile_AppendAllTextAsync_ShouldThrowOperationCanceledExceptionIfCancelled()
         {
             // Arrange
             const string path = "test.txt";
@@ -183,15 +183,15 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             });
 
             // Act
-            Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            async Task Act() =>
                 await fileSystem.File.AppendAllTextAsync(
                     path,
                     "line 2",
-                    new CancellationToken(canceled: true))
-            );
+                    new CancellationToken(canceled: true));
+            await That(Act).Throws<OperationCanceledException>();
 
             // Assert
-            Assert.That(fileSystem.File.ReadAllText(path), Is.EqualTo("line 1"));
+            await That(fileSystem.File.ReadAllText(path)).IsEqualTo("line 1");
         }
 
         [Test]
@@ -210,8 +210,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             await file.AppendAllTextAsync(Path, "BB", Encoding.UTF8);
 
             // Assert
-            Assert.That(fileSystem.GetFile(Path).Contents,
-                Is.EqualTo(new byte[] { 255, 254, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0, 66, 66 }));
+            await That(fileSystem.GetFile(Path).Contents)
+              .IsEqualTo(new byte[] { 255, 254, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0, 66, 66 });
         }
 
         [Test]
@@ -228,8 +228,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             await fileSystem.File.AppendAllTextAsync(path, " some text");
 
             // Assert
-            Assert.That(fileSystem.File.ReadAllText(path),
-              Is.EqualTo("Demo text content some text"));
+            await That(fileSystem.File.ReadAllText(path))
+              .IsEqualTo("Demo text content some text");
         }
 
         [Test]
@@ -244,12 +244,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             await fileSystem.File.AppendAllTextAsync(path, "AA", Encoding.UTF32);
 
             // Assert
-            Assert.That(fileSystem.GetFile(path).Contents,
-                Is.EqualTo(new byte[] { 255, 254, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0 }));
+            await That(fileSystem.GetFile(path).Contents)
+              .IsEqualTo(new byte[] { 255, 254, 0, 0, 65, 0, 0, 0, 65, 0, 0, 0 });
         }
 
         [Test]
-        public void MockFile_AppendAllTextAsync_ShouldFailIfNotExistButDirectoryAlsoNotExist()
+        public async Task MockFile_AppendAllTextAsync_ShouldFailIfNotExistButDirectoryAlsoNotExist()
         {
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
@@ -263,15 +263,15 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             Exception ex;
-            ex = Assert.ThrowsAsync<DirectoryNotFoundException>(async () => await fileSystem.File.AppendAllTextAsync(path, "some text"));
-            Assert.That(ex.Message,
-                Is.EqualTo(String.Format(CultureInfo.InvariantCulture, "Could not find a part of the path '{0}'.", path)));
+            Func<Task> action = async () => await fileSystem.File.AppendAllTextAsync(path, "some text");
+            ex = await That(action).Throws<DirectoryNotFoundException>();
+            await That(ex.Message)
+              .IsEqualTo(String.Format(CultureInfo.InvariantCulture, "Could not find a part of the path '{0}'.", path));
 
-            ex =
-                Assert.ThrowsAsync<DirectoryNotFoundException>(
-                    async () => await fileSystem.File.AppendAllTextAsync(path, "some text", Encoding.Unicode));
-            Assert.That(ex.Message,
-                Is.EqualTo(String.Format(CultureInfo.InvariantCulture, "Could not find a part of the path '{0}'.", path)));
+            async Task Act() => await fileSystem.File.AppendAllTextAsync(path, "some text", Encoding.Unicode);
+            ex = await That(Act).Throws<DirectoryNotFoundException>();
+            await That(ex.Message)
+              .IsEqualTo(String.Format(CultureInfo.InvariantCulture, "Could not find a part of the path '{0}'.", path));
         }
 
         [Test]
@@ -297,7 +297,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 0, 32, 0, 116, 0, 101, 0, 120, 0, 116
             };
 
-            Assert.That(file.ReadAllBytes(path), Is.EqualTo(expected));
+            await That(file.ReadAllBytes(path)).IsEqualTo(expected);
         }
 
         [Test]
@@ -308,7 +308,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             await fileSystem.File.AppendAllTextAsync(file, "Foo");
 
-            Assert.That(fileSystem.File.Exists(file));
+            await That(fileSystem.File.Exists(file)).IsTrue();
         }
 #endif
     }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileArgumentPathTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileArgumentPathTests.cs
@@ -58,17 +58,17 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [TestCaseSource(nameof(GetFileSystemActionsForArgumentNullException))]
-        public void Operations_ShouldThrowArgumentNullExceptionIfPathIsNull(Action<IFile> action)
+        public async Task Operations_ShouldThrowArgumentNullExceptionIfPathIsNull(Action<IFile> action)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate wrapped = () => action(fileSystem.File);
+            Action wrapped = () => action(fileSystem.File);
 
             // Assert
-            var exception = Assert.Throws<ArgumentNullException>(wrapped);
-            Assert.That(exception.ParamName, Is.EqualTo("path"));
+            var exception = await That(wrapped).Throws<ArgumentNullException>();
+            await That(exception.ParamName).IsEqualTo("path");
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileCopyTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileCopyTests.cs
@@ -10,7 +10,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     {
 
         [Test]
-        public void MockFile_Copy_ShouldOverwriteFileWhenOverwriteFlagIsTrue()
+        public async Task MockFile_Copy_ShouldOverwriteFileWhenOverwriteFlagIsTrue()
         {
             string sourceFileName = XFS.Path(@"c:\source\demo.txt");
             var sourceContents = new MockFileData("Source content");
@@ -24,11 +24,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.File.Copy(sourceFileName, destFileName, true);
 
             var copyResult = fileSystem.GetFile(destFileName);
-            Assert.That(sourceContents.Contents, Is.EqualTo(copyResult.Contents));
+            await That(sourceContents.Contents).IsEqualTo(copyResult.Contents);
         }
 
         [Test]
-        public void MockFile_Copy_ShouldAdjustTimestampsOnDestination()
+        public async Task MockFile_Copy_ShouldAdjustTimestampsOnDestination()
         {
             var sourceFileName = XFS.Path(@"c:\source\demo.txt");
             var destFileName = XFS.Path(@"c:\source\demo_copy.txt");
@@ -39,13 +39,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var sourceFileInfo = mockFileSystem.FileInfo.New(sourceFileName);
             var destFileInfo = mockFileSystem.FileInfo.New(destFileName);
-            Assert.That(destFileInfo.LastWriteTime, Is.EqualTo(sourceFileInfo.LastWriteTime));
-            Assert.That(DateTime.Now - destFileInfo.CreationTime, Is.LessThanOrEqualTo( TimeSpan.FromSeconds(1)));
-            Assert.That(destFileInfo.LastAccessTime, Is.EqualTo(destFileInfo.CreationTime));
+            await That(destFileInfo.LastWriteTime).IsEqualTo(sourceFileInfo.LastWriteTime);
+            await That(DateTime.Now - destFileInfo.CreationTime).IsLessThanOrEqualTo( TimeSpan.FromSeconds(1));
+            await That(destFileInfo.LastAccessTime).IsEqualTo(destFileInfo.CreationTime);
         }
 
         [Test]
-        public void MockFile_Copy_ShouldCloneContents()
+        public async Task MockFile_Copy_ShouldCloneContents()
         {
             var sourceFileName = XFS.Path(@"c:\source\demo.txt");
             var destFileName = XFS.Path(@"c:\source\demo_copy.txt");
@@ -62,11 +62,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 binaryWriter.Write("Modified");
             }
 
-            Assert.That(mockFileSystem.File.ReadAllText(destFileName), Is.EqualTo("Original"));
+            await That(mockFileSystem.File.ReadAllText(destFileName)).IsEqualTo("Original");
         }
 
         [Test]
-        public void MockFile_Copy_ShouldCloneBinaryContents()
+        public async Task MockFile_Copy_ShouldCloneBinaryContents()
         {
             var sourceFileName = XFS.Path(@"c:\source\demo.bin");
             var destFileName = XFS.Path(@"c:\source\demo_copy.bin");
@@ -84,11 +84,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 binaryWriter.Write("Modified");
             }
 
-            Assert.That(mockFileSystem.File.ReadAllBytes(destFileName), Is.EqualTo(original));
+            await That(mockFileSystem.File.ReadAllBytes(destFileName)).IsEqualTo(original);
         }
 
         [Test]
-        public void MockFile_Copy_ShouldCreateFileAtNewDestination()
+        public async Task MockFile_Copy_ShouldCreateFileAtNewDestination()
         {
             string sourceFileName = XFS.Path(@"c:\source\demo.txt");
             var sourceContents = new MockFileData("Source content");
@@ -101,11 +101,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.File.Copy(sourceFileName, destFileName, false);
 
             var copyResult = fileSystem.GetFile(destFileName);
-            Assert.That(sourceContents.Contents, Is.EqualTo(copyResult.Contents));
+            await That(sourceContents.Contents).IsEqualTo(copyResult.Contents);
         }
 
         [Test]
-        public void MockFile_Copy_ShouldThrowExceptionWhenFileExistsAtDestination()
+        public async Task MockFile_Copy_ShouldThrowExceptionWhenFileExistsAtDestination()
         {
             string sourceFileName = XFS.Path(@"c:\source\demo.txt");
             var sourceContents = new MockFileData("Source content");
@@ -116,12 +116,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 {destFileName, new MockFileData("Destination content")}
             });
 
-            Assert.Throws<IOException>(() => fileSystem.File.Copy(sourceFileName, destFileName), XFS.Path(@"The file c:\destination\demo.txt already exists."));
+            await That(() => fileSystem.File.Copy(sourceFileName, destFileName), XFS.Path(@"The file c:\destination\demo.txt already exists.")).Throws<IOException>();
         }
 
         [TestCase(@"c:\source\demo.txt", @"c:\source\doesnotexist\demo.txt")]
         [TestCase(@"c:\source\demo.txt", @"c:\doesnotexist\demo.txt")]
-        public void MockFile_Copy_ShouldThrowExceptionWhenFolderInDestinationDoesNotExist(string sourceFilePath, string destFilePath)
+        public async Task MockFile_Copy_ShouldThrowExceptionWhenFolderInDestinationDoesNotExist(string sourceFilePath, string destFilePath)
         {
             string sourceFileName = XFS.Path(sourceFilePath);
             string destFileName = XFS.Path(destFilePath);
@@ -130,34 +130,34 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 {sourceFileName, string.Empty}
             });
 
-            Assert.Throws<DirectoryNotFoundException>(() => fileSystem.File.Copy(sourceFileName, destFileName), string.Format(CultureInfo.InvariantCulture, @"Could not find a part of the path '{0}'.", destFilePath));
+            await That(() => fileSystem.File.Copy(sourceFileName, destFileName), string.Format(CultureInfo.InvariantCulture, @"Could not find a part of the path '{0}'.", destFilePath)).Throws<DirectoryNotFoundException>();
         }
 
         [Test]
-        public void MockFile_Copy_ShouldThrowArgumentNullExceptionWhenSourceIsNull_Message()
+        public async Task MockFile_Copy_ShouldThrowArgumentNullExceptionWhenSourceIsNull_Message()
         {
             string destFilePath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
 
-            var exception = Assert.Throws<ArgumentNullException>(() => fileSystem.File.Copy(null, destFilePath));
+            var exception = await That(() => fileSystem.File.Copy(null, destFilePath)).Throws<ArgumentNullException>();
 
-            Assert.That(exception.Message, Does.StartWith("File name cannot be null."));
+            await That(exception.Message).StartsWith("File name cannot be null.");
         }
 
         [Test]
-        public void MockFile_Copy_ShouldThrowArgumentNullExceptionWhenSourceIsNull_ParamName()
+        public async Task MockFile_Copy_ShouldThrowArgumentNullExceptionWhenSourceIsNull_ParamName()
         {
             string destFilePath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
 
-            var exception = Assert.Throws<ArgumentNullException>(() => fileSystem.File.Copy(null, destFilePath));
+            var exception = await That(() => fileSystem.File.Copy(null, destFilePath)).Throws<ArgumentNullException>();
 
-            Assert.That(exception.ParamName, Is.EqualTo("sourceFileName"));
+            await That(exception.ParamName).IsEqualTo("sourceFileName");
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.StrictPathRules)]
-        public void MockFile_Copy_ShouldThrowArgumentExceptionWhenSourceFileNameContainsInvalidChars_Message()
+        public async Task MockFile_Copy_ShouldThrowArgumentExceptionWhenSourceFileNameContainsInvalidChars_Message()
         {
             var destFilePath = @"c:\something\demo.txt";
             var fileSystem = new MockFileSystem();
@@ -168,16 +168,16 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 var sourceFilePath = @"c:\something\demo.txt" + invalidChar;
 
                 var exception =
-                    Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(sourceFilePath, destFilePath));
+                    await That(() => fileSystem.File.Copy(sourceFilePath, destFilePath)).Throws<ArgumentException>();
 
-                Assert.That(exception.Message, Is.EqualTo("Illegal characters in path."),
-                    string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
+                await That(exception.Message).IsEqualTo("Illegal characters in path.")
+                    .Because(string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
             }
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.StrictPathRules)]
-        public void MockFile_Copy_ShouldThrowArgumentExceptionWhenSourcePathContainsInvalidChars_Message()
+        public async Task MockFile_Copy_ShouldThrowArgumentExceptionWhenSourcePathContainsInvalidChars_Message()
         {
             var destFilePath = @"c:\something\demo.txt";
             var fileSystem = new MockFileSystem();
@@ -187,16 +187,16 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 var sourceFilePath = @"c:\some" + invalidChar + @"thing\demo.txt";
 
                 var exception =
-                    Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(sourceFilePath, destFilePath));
+                    await That(() => fileSystem.File.Copy(sourceFilePath, destFilePath)).Throws<ArgumentException>();
 
-                Assert.That(exception.Message, Is.EqualTo("Illegal characters in path."),
-                    string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
+                await That(exception.Message).IsEqualTo("Illegal characters in path.")
+                    .Because(string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
             }
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.StrictPathRules)]
-        public void MockFile_Copy_ShouldThrowArgumentExceptionWhenTargetPathContainsInvalidChars_Message()
+        public async Task MockFile_Copy_ShouldThrowArgumentExceptionWhenTargetPathContainsInvalidChars_Message()
         {
             var sourceFilePath = @"c:\something\demo.txt";
             var fileSystem = new MockFileSystem();
@@ -206,16 +206,16 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 var destFilePath = @"c:\some" + invalidChar + @"thing\demo.txt";
 
                 var exception =
-                    Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(sourceFilePath, destFilePath));
+                    await That(() => fileSystem.File.Copy(sourceFilePath, destFilePath)).Throws<ArgumentException>();
 
-                Assert.That(exception.Message, Is.EqualTo("Illegal characters in path."),
-                    string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
+                await That(exception.Message).IsEqualTo("Illegal characters in path.")
+                    .Because(string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
             }
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.StrictPathRules)]
-        public void MockFile_Copy_ShouldThrowArgumentExceptionWhenTargetFileNameContainsInvalidChars_Message()
+        public async Task MockFile_Copy_ShouldThrowArgumentExceptionWhenTargetFileNameContainsInvalidChars_Message()
         {
             var sourceFilePath = @"c:\something\demo.txt";
             var fileSystem = new MockFileSystem();
@@ -226,168 +226,168 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 var destFilePath = @"c:\something\demo.txt" + invalidChar;
 
                 var exception =
-                    Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(sourceFilePath, destFilePath));
+                    await That(() => fileSystem.File.Copy(sourceFilePath, destFilePath)).Throws<ArgumentException>();
 
-                Assert.That(exception.Message, Is.EqualTo("Illegal characters in path."),
-                    string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
+                await That(exception.Message).IsEqualTo("Illegal characters in path.")
+                    .Because(string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
             }
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.Drives)]
-        public void MockFile_Copy_ShouldThrowNotSupportedExceptionWhenSourcePathContainsInvalidUseOfDriveSeparator()
+        public async Task MockFile_Copy_ShouldThrowNotSupportedExceptionWhenSourcePathContainsInvalidUseOfDriveSeparator()
         {
             var badSourcePath = @"C::\something\demo.txt";
             var destinationPath = @"C:\elsewhere\demo.txt";
             var fileSystem = new MockFileSystem();
 
-            TestDelegate action = () => fileSystem.File.Copy(badSourcePath, destinationPath);
+            Action action = () => fileSystem.File.Copy(badSourcePath, destinationPath);
 
-            Assert.Throws<NotSupportedException>(action);
+            await That(action).Throws<NotSupportedException>();
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.Drives)]
-        public void MockFile_Copy_ShouldThrowNotSupportedExceptionWhenSourcePathContainsInvalidDriveLetter()
+        public async Task MockFile_Copy_ShouldThrowNotSupportedExceptionWhenSourcePathContainsInvalidDriveLetter()
         {
             var badSourcePath = @"0:\something\demo.txt";
             var destinationPath = @"C:\elsewhere\demo.txt";
             var fileSystem = new MockFileSystem();
 
-            TestDelegate action = () => fileSystem.File.Copy(badSourcePath, destinationPath);
+            Action action = () => fileSystem.File.Copy(badSourcePath, destinationPath);
 
-            Assert.Throws<NotSupportedException>(action);
+            await That(action).Throws<NotSupportedException>();
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.Drives)]
-        public void MockFile_Copy_ShouldThrowNotSupportedExceptionWhenDestinationPathContainsInvalidUseOfDriveSeparator()
+        public async Task MockFile_Copy_ShouldThrowNotSupportedExceptionWhenDestinationPathContainsInvalidUseOfDriveSeparator()
         {
             var sourcePath = @"C:\something\demo.txt";
             var badDestinationPath = @"C:\elsewhere:\demo.txt";
             var fileSystem = new MockFileSystem();
 
-            TestDelegate action = () => fileSystem.File.Copy(sourcePath, badDestinationPath);
+            Action action = () => fileSystem.File.Copy(sourcePath, badDestinationPath);
 
-            Assert.Throws<NotSupportedException>(action);
+            await That(action).Throws<NotSupportedException>();
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.Drives)]
-        public void MockFile_Copy_ShouldThrowNotSupportedExceptionWhenDestinationPathContainsInvalidDriveLetter()
+        public async Task MockFile_Copy_ShouldThrowNotSupportedExceptionWhenDestinationPathContainsInvalidDriveLetter()
         {
             var sourcePath = @"C:\something\demo.txt";
             var badDestinationPath = @"^:\elsewhere\demo.txt";
             var fileSystem = new MockFileSystem();
 
-            TestDelegate action = () => fileSystem.File.Copy(sourcePath, badDestinationPath);
+            Action action = () => fileSystem.File.Copy(sourcePath, badDestinationPath);
 
-            Assert.Throws<NotSupportedException>(action);
+            await That(action).Throws<NotSupportedException>();
         }
 
         [Test]
-        public void MockFile_Copy_ShouldThrowArgumentExceptionWhenSourceIsEmpty_Message()
+        public async Task MockFile_Copy_ShouldThrowArgumentExceptionWhenSourceIsEmpty_Message()
         {
             string destFilePath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
 
-            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(string.Empty, destFilePath));
+            var exception = await That(() => fileSystem.File.Copy(string.Empty, destFilePath)).Throws<ArgumentException>();
 
-            Assert.That(exception.Message, Does.StartWith("Empty file name is not legal."));
+            await That(exception.Message).StartsWith("Empty file name is not legal.");
         }
 
         [Test]
-        public void MockFile_Copy_ShouldThrowArgumentExceptionWhenSourceIsEmpty_ParamName()
+        public async Task MockFile_Copy_ShouldThrowArgumentExceptionWhenSourceIsEmpty_ParamName()
         {
             string destFilePath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
 
-            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(string.Empty, destFilePath));
+            var exception = await That(() => fileSystem.File.Copy(string.Empty, destFilePath)).Throws<ArgumentException>();
 
-            Assert.That(exception.ParamName, Is.EqualTo("sourceFileName"));
+            await That(exception.ParamName).IsEqualTo("sourceFileName");
         }
 
         [Test]
-        public void MockFile_Copy_ShouldThrowArgumentExceptionWhenSourceIsStringOfBlanks()
+        public async Task MockFile_Copy_ShouldThrowArgumentExceptionWhenSourceIsStringOfBlanks()
         {
             string sourceFilePath = "   ";
             string destFilePath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
 
-            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(sourceFilePath, destFilePath));
+            var exception = await That(() => fileSystem.File.Copy(sourceFilePath, destFilePath)).Throws<ArgumentException>();
 
-            Assert.That(exception.Message, Does.StartWith("The path is not of a legal form."));
+            await That(exception.Message).StartsWith("The path is not of a legal form.");
         }
 
         [Test]
-        public void MockFile_Copy_ShouldThrowArgumentNullExceptionWhenTargetIsNull_Message()
+        public async Task MockFile_Copy_ShouldThrowArgumentNullExceptionWhenTargetIsNull_Message()
         {
             string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
 
-            var exception = Assert.Throws<ArgumentNullException>(() => fileSystem.File.Copy(sourceFilePath, null));
+            var exception = await That(() => fileSystem.File.Copy(sourceFilePath, null)).Throws<ArgumentNullException>();
 
-            Assert.That(exception.Message, Does.StartWith("File name cannot be null."));
+            await That(exception.Message).StartsWith("File name cannot be null.");
         }
 
         [Test]
-        public void MockFile_Copy_ShouldThrowArgumentNullExceptionWhenTargetIsNull_ParamName()
+        public async Task MockFile_Copy_ShouldThrowArgumentNullExceptionWhenTargetIsNull_ParamName()
         {
             string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
 
-            var exception = Assert.Throws<ArgumentNullException>(() => fileSystem.File.Copy(sourceFilePath, null));
+            var exception = await That(() => fileSystem.File.Copy(sourceFilePath, null)).Throws<ArgumentNullException>();
 
-            Assert.That(exception.ParamName, Is.EqualTo("destFileName"));
+            await That(exception.ParamName).IsEqualTo("destFileName");
         }
 
         [Test]
-        public void MockFile_Copy_ShouldThrowArgumentExceptionWhenTargetIsStringOfBlanks()
+        public async Task MockFile_Copy_ShouldThrowArgumentExceptionWhenTargetIsStringOfBlanks()
         {
             string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
             string destFilePath = "   ";
             var fileSystem = new MockFileSystem();
 
-            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(sourceFilePath, destFilePath));
+            var exception = await That(() => fileSystem.File.Copy(sourceFilePath, destFilePath)).Throws<ArgumentException>();
 
-            Assert.That(exception.Message, Does.StartWith("The path is not of a legal form."));
+            await That(exception.Message).StartsWith("The path is not of a legal form.");
         }
 
         [Test]
-        public void MockFile_Copy_ShouldThrowArgumentExceptionWhenTargetIsEmpty_Message()
+        public async Task MockFile_Copy_ShouldThrowArgumentExceptionWhenTargetIsEmpty_Message()
         {
             string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
 
-            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Copy(sourceFilePath, string.Empty));
+            var exception = await That(() => fileSystem.File.Copy(sourceFilePath, string.Empty)).Throws<ArgumentException>();
 
-            Assert.That(exception.Message, Does.StartWith("Empty file name is not legal."));
+            await That(exception.Message).StartsWith("Empty file name is not legal.");
         }
 
         [Test]
-        public void MockFile_Copy_ShouldThrowFileNotFoundExceptionWhenSourceDoesNotExist()
+        public async Task MockFile_Copy_ShouldThrowFileNotFoundExceptionWhenSourceDoesNotExist()
         {
             string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
 
-            TestDelegate action = () => fileSystem.File.Copy(sourceFilePath, XFS.Path(@"c:\something\demo2.txt"));
+            Action action = () => fileSystem.File.Copy(sourceFilePath, XFS.Path(@"c:\something\demo2.txt"));
 
-            Assert.Throws<FileNotFoundException>(action);
+            await That(action).Throws<FileNotFoundException>();
         }
 
         [Test]
-        public void MockFile_Copy_ShouldThrowFileNotFoundExceptionWhenSourceDoesNotExist_EvenWhenCopyingToItself()
+        public async Task MockFile_Copy_ShouldThrowFileNotFoundExceptionWhenSourceDoesNotExist_EvenWhenCopyingToItself()
         {
             string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
 
-            TestDelegate action = () => fileSystem.File.Copy(sourceFilePath, XFS.Path(@"c:\something\demo.txt"));
+            Action action = () => fileSystem.File.Copy(sourceFilePath, XFS.Path(@"c:\something\demo.txt"));
 
-            Assert.Throws<FileNotFoundException>(action);
+            await That(action).Throws<FileNotFoundException>();
         }
 
         [Test]
-        public void MockFile_Copy_ShouldWorkWithRelativePaths()
+        public async Task MockFile_Copy_ShouldWorkWithRelativePaths()
         {
             var sourceFile = "source_file.txt";
             var destinationFile = "destination_file.txt";
@@ -396,11 +396,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.File.Create(sourceFile).Close();
             fileSystem.File.Copy(sourceFile, destinationFile);
 
-            Assert.That(fileSystem.File.Exists(destinationFile));
+            await That(fileSystem.File.Exists(destinationFile)).IsTrue();
         }
 
         [Test]
-        public void MockFile_Copy_ShouldThrowIOExceptionForInvalidFileShare()
+        public async Task MockFile_Copy_ShouldThrowIOExceptionForInvalidFileShare()
         {
             string sourceFileName = XFS.Path(@"c:\source\demo.txt");
             var sourceContents = new MockFileData("Source content")
@@ -413,9 +413,9 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             });
             fileSystem.AddDirectory(XFS.Path(@"c:\something"));
 
-            TestDelegate action = () => fileSystem.File.Copy(sourceFileName, XFS.Path(@"c:\something\demo.txt"));
+            Action action = () => fileSystem.File.Copy(sourceFileName, XFS.Path(@"c:\something\demo.txt"));
 
-            Assert.Throws<IOException>(action);
+            await That(action).Throws<IOException>();
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileCreateTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileCreateTests.cs
@@ -13,7 +13,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockFileCreateTests
     {
         [Test]
-        public void Mockfile_Create_ShouldCreateNewStream()
+        public async Task Mockfile_Create_ShouldCreateNewStream()
         {
             string fullPath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
@@ -21,15 +21,15 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var sut = new MockFile(fileSystem);
 
-            Assert.That(fileSystem.FileExists(fullPath), Is.False);
+            await That(fileSystem.FileExists(fullPath)).IsFalse();
 
             sut.Create(fullPath).Dispose();
 
-            Assert.That(fileSystem.FileExists(fullPath), Is.True);
+            await That(fileSystem.FileExists(fullPath)).IsTrue();
         }
 
         [Test]
-        public void Mockfile_Create_CanWriteToNewStream()
+        public async Task Mockfile_Create_CanWriteToNewStream()
         {
             string fullPath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
@@ -45,11 +45,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var mockFileData = fileSystem.GetFile(fullPath);
             var fileData = mockFileData.Contents;
 
-            Assert.That(fileData, Is.EqualTo(data));
+            await That(fileData).IsEqualTo(data);
         }
 
         [Test]
-        public void Mockfile_Create_OverwritesExistingFile()
+        public async Task Mockfile_Create_OverwritesExistingFile()
         {
             string path = XFS.Path(@"c:\some\file.txt");
             var fileSystem = new MockFileSystem();
@@ -73,11 +73,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var actualContents = fileSystem.GetFile(path).Contents;
 
-            Assert.That(actualContents, Is.EqualTo(expectedContents));
+            await That(actualContents).IsEqualTo(expectedContents);
         }
 
         [Test]
-        public void Mockfile_Create_ShouldThrowUnauthorizedAccessExceptionIfPathIsReadOnly()
+        public async Task Mockfile_Create_ShouldThrowUnauthorizedAccessExceptionIfPathIsReadOnly()
         {
             // Arrange
             string path = XFS.Path(@"c:\something\read-only.txt");
@@ -88,21 +88,21 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             mockFile.SetAttributes(path, FileAttributes.ReadOnly);
 
             // Assert
-            var exception = Assert.Throws<UnauthorizedAccessException>(() => mockFile.Create(path).Dispose());
-            Assert.That(exception.Message, Is.EqualTo(string.Format(CultureInfo.InvariantCulture, "Access to the path '{0}' is denied.", path)));
+            var exception = await That(() => mockFile.Create(path).Dispose()).Throws<UnauthorizedAccessException>();
+            await That(exception.Message).IsEqualTo(string.Format(CultureInfo.InvariantCulture, "Access to the path '{0}' is denied.", path));
         }
 
         [Test]
-        public void Mockfile_Create_ShouldThrowArgumentExceptionIfPathIsZeroLength()
+        public async Task Mockfile_Create_ShouldThrowArgumentExceptionIfPathIsZeroLength()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => fileSystem.File.Create("");
+            Action action = () => fileSystem.File.Create("");
 
             // Assert
-            Assert.Throws<ArgumentException>(action);
+            await That(action).Throws<ArgumentException>();
         }
 
         [TestCase("\"")]
@@ -110,63 +110,63 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [TestCase(">")]
         [TestCase("|")]
         [WindowsOnly(WindowsSpecifics.StrictPathRules)]
-        public void MockFile_Create_ShouldThrowArgumentNullExceptionIfPathIsNull1(string path)
+        public async Task MockFile_Create_ShouldThrowArgumentNullExceptionIfPathIsNull1(string path)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => fileSystem.File.Create(path);
+            Action action = () => fileSystem.File.Create(path);
 
             // Assert
-            Assert.Throws<ArgumentException>(action);
+            await That(action).Throws<ArgumentException>();
         }
 
         [TestCase(" ")]
         [TestCase("   ")]
-        public void MockFile_Create_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        public async Task MockFile_Create_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => fileSystem.File.Create(path);
+            Action action = () => fileSystem.File.Create(path);
 
             // Assert
-            Assert.Throws<ArgumentException>(action);
+            await That(action).Throws<ArgumentException>();
         }
 
         [Test]
-        public void MockFile_Create_ShouldThrowArgumentNullExceptionIfPathIsNull()
+        public async Task MockFile_Create_ShouldThrowArgumentNullExceptionIfPathIsNull()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => fileSystem.File.Create(null);
+            Action action = () => fileSystem.File.Create(null);
 
             // Assert
-            var exception = Assert.Throws<ArgumentNullException>(action);
-            Assert.That(exception.Message, Does.StartWith("Path cannot be null."));
+            var exception = await That(action).Throws<ArgumentNullException>();
+            await That(exception.Message).StartsWith("Path cannot be null.");
         }
 
         [Test]
-        public void MockFile_Create_ShouldThrowDirectoryNotFoundExceptionIfCreatingAndParentPathDoesNotExist()
+        public async Task MockFile_Create_ShouldThrowDirectoryNotFoundExceptionIfCreatingAndParentPathDoesNotExist()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
             var file = XFS.Path("C:\\path\\NotFound.ext");
 
             // Act
-            TestDelegate action = () => fileSystem.File.Create(file);
+            Action action = () => fileSystem.File.Create(file);
 
             // Assert
-            var exception = Assert.Throws<DirectoryNotFoundException>(action);
-            Assert.That(exception.Message, Does.StartWith("Could not find a part of the path"));
+            var exception = await That(action).Throws<DirectoryNotFoundException>();
+            await That(exception.Message).StartsWith("Could not find a part of the path");
         }
 
         [Test]
-        public void MockFile_Create_TruncateShouldWriteNewContents()
+        public async Task MockFile_Create_TruncateShouldWriteNewContents()
         {
             // Arrange
             string testFileName = XFS.Path(@"c:\someFile.txt");
@@ -190,11 +190,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             }
 
             // Assert
-            Assert.That(fileSystem.File.ReadAllText(testFileName), Is.EqualTo("new_text"));
+            await That(fileSystem.File.ReadAllText(testFileName)).IsEqualTo("new_text");
         }
 
         [Test]
-        public void MockFile_Create_TruncateShouldClearFileContentsOnOpen()
+        public async Task MockFile_Create_TruncateShouldClearFileContentsOnOpen()
         {
             // Arrange
             string testFileName = XFS.Path(@"c:\someFile.txt");
@@ -215,11 +215,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             }
 
             // Assert
-            Assert.That(fileSystem.File.ReadAllText(testFileName), Is.EqualTo(string.Empty));
+            await That(fileSystem.File.ReadAllText(testFileName)).IsEqualTo(string.Empty);
         }
 
         [Test]
-        public void MockFile_Create_DeleteOnCloseOption_FileExistsWhileStreamIsOpen()
+        public async Task MockFile_Create_DeleteOnCloseOption_FileExistsWhileStreamIsOpen()
         {
             var root = XFS.Path(@"C:\");
             var filePath = XFS.Path(@"C:\test.txt");
@@ -228,12 +228,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             using (fileSystem.File.Create(filePath, 4096, FileOptions.DeleteOnClose))
             {
-                Assert.That(fileSystem.File.Exists(filePath), Is.True);
+                await That(fileSystem.File.Exists(filePath)).IsTrue();
             }
         }
 
         [Test]
-        public void MockFile_Create_DeleteOnCloseOption_FileDeletedWhenStreamIsClosed()
+        public async Task MockFile_Create_DeleteOnCloseOption_FileDeletedWhenStreamIsClosed()
         {
             var root = XFS.Path(@"C:\");
             var filePath = XFS.Path(@"C:\test.txt");
@@ -244,11 +244,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             {
             }
 
-            Assert.That(fileSystem.File.Exists(filePath), Is.False);
+            await That(fileSystem.File.Exists(filePath)).IsFalse();
         }
 
         [Test]
-        public void MockFile_Create_EncryptedOption_FileNotYetEncryptedWhenStreamIsOpen()
+        public async Task MockFile_Create_EncryptedOption_FileNotYetEncryptedWhenStreamIsOpen()
         {
             var root = XFS.Path(@"C:\");
             var filePath = XFS.Path(@"C:\test.txt");
@@ -258,12 +258,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             using (var stream = fileSystem.File.Create(filePath, 4096, FileOptions.Encrypted))
             {
                 var fileInfo = fileSystem.FileInfo.New(filePath);
-                Assert.That(fileInfo.Attributes.HasFlag(FileAttributes.Encrypted), Is.False);
+                await That(fileInfo.Attributes.HasFlag(FileAttributes.Encrypted)).IsFalse();
             }
         }
 
         [Test]
-        public void MockFile_Create_EncryptedOption_EncryptsFileWhenStreamIsClose()
+        public async Task MockFile_Create_EncryptedOption_EncryptsFileWhenStreamIsClose()
         {
             var root = XFS.Path(@"C:\");
             var filePath = XFS.Path(@"C:\test.txt");
@@ -275,22 +275,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             }
 
             var fileInfo = fileSystem.FileInfo.New(filePath);
-            Assert.That(fileInfo.Attributes.HasFlag(FileAttributes.Encrypted), Is.True);
+            await That(fileInfo.Attributes.HasFlag(FileAttributes.Encrypted)).IsTrue();
         }
 
         [Test]
-        public void MockFile_Create_ShouldWorkWithRelativePath()
+        public async Task MockFile_Create_ShouldWorkWithRelativePath()
         {
             var relativeFile = "file.txt";
             var fileSystem = new MockFileSystem();
 
             fileSystem.File.Create(relativeFile).Close();
 
-            Assert.That(fileSystem.File.Exists(relativeFile));
+            await That(fileSystem.File.Exists(relativeFile)).IsTrue();
         }
 
         [Test]
-        public void MockFile_Create_CanReadFromNewStream()
+        public async Task MockFile_Create_CanReadFromNewStream()
         {
             string fullPath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
@@ -298,7 +298,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             using (var stream = fileSystem.File.Create(fullPath))
             {
-                Assert.That(stream.CanRead, Is.True);
+                await That(stream.CanRead).IsTrue();
             }
         }
     }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileDeleteTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileDeleteTests.cs
@@ -8,7 +8,7 @@
     public class MockFileDeleteTests
     {
         [Test]
-        public void MockFile_Delete_ShouldDeleteFile()
+        public async Task MockFile_Delete_ShouldDeleteFile()
         {
             var fileSystem = new MockFileSystem();
             var path = XFS.Path("C:\\some_folder\\test");
@@ -19,35 +19,35 @@
             fileSystem.File.Delete(path);
             var fileCount2 = fileSystem.Directory.GetFiles(directory, "*").Length;
 
-            Assert.That(fileCount1, Is.EqualTo(1), "File should have existed");
-            Assert.That(fileCount2, Is.EqualTo(0), "File should have been deleted");
+            await That(fileCount1).IsEqualTo(1).Because("File should have existed");
+            await That(fileCount2).IsEqualTo(0).Because("File should have been deleted");
         }
 
         [TestCase(" ")]
         [TestCase("   ")]
-        public void MockFile_Delete_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        public async Task MockFile_Delete_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => fileSystem.File.Delete(path);
+            Action action = () => fileSystem.File.Delete(path);
 
             // Assert
-            Assert.Throws<ArgumentException>(action);
+            await That(action).Throws<ArgumentException>();
         }
 
         [Test]
-        public void MockFile_Delete_ShouldThrowDirectoryNotFoundExceptionIfParentFolderAbsent()
+        public async Task MockFile_Delete_ShouldThrowDirectoryNotFoundExceptionIfParentFolderAbsent()
         {
             var fileSystem = new MockFileSystem();
             var path = XFS.Path("C:\\test\\somefile.txt");
 
-            Assert.Throws<DirectoryNotFoundException>(() => fileSystem.File.Delete(path));
+            await That(() => fileSystem.File.Delete(path)).Throws<DirectoryNotFoundException>();
         }
 
         [Test]
-        public void MockFile_Delete_ShouldSilentlyReturnIfNonExistingFileInExistingFolder()
+        public async Task MockFile_Delete_ShouldSilentlyReturnIfNonExistingFileInExistingFolder()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
             {
@@ -57,7 +57,7 @@
             string filePath = XFS.Path("C:\\temp\\somefile.txt");
 
             // Delete() returns void, so there is nothing to check here beside absense of an exception
-            Assert.DoesNotThrow(() => fileSystem.File.Delete(filePath));
+            await That(() => fileSystem.File.Delete(filePath)).DoesNotThrow();
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileExistsTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileExistsTests.cs
@@ -9,7 +9,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockFileExistsTests
     {
         [Test]
-        public void MockFile_Exists_ShouldReturnTrueForSamePath()
+        public async Task MockFile_Exists_ShouldReturnTrueForSamePath()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -21,12 +21,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.File.Exists(XFS.Path(@"C:\something\other.gif"));
 
             // Assert
-            Assert.That(result, Is.True);
+            await That(result).IsTrue();
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.CaseInsensitivity)]
-        public void MockFile_Exists_ShouldReturnTrueForPathVaryingByCase()
+        public async Task MockFile_Exists_ShouldReturnTrueForPathVaryingByCase()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -38,12 +38,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.File.Exists(@"C:\SomeThing\DEMO.txt");
 
             // Assert
-            Assert.That(result, Is.True);
+            await That(result).IsTrue();
         }
 
         [Test]
         [UnixOnly(UnixSpecifics.CaseSensitivity)]
-        public void MockFile_Exists_ShouldReturnFalseForPathVaryingByCase()
+        public async Task MockFile_Exists_ShouldReturnFalseForPathVaryingByCase()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -55,11 +55,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.File.Exists("/SomeThing/DEMO.txt");
 
             // Assert
-            Assert.That(result, Is.False);
+            await That(result).IsFalse();
         }
 
         [Test]
-        public void MockFile_Exists_ShouldReturnFalseForEntirelyDifferentPath()
+        public async Task MockFile_Exists_ShouldReturnFalseForEntirelyDifferentPath()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -72,11 +72,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.File.Exists(XFS.Path(@"C:\SomeThing\DoesNotExist.gif"));
 
             // Assert
-            Assert.That(result, Is.False);
+            await That(result).IsFalse();
         }
 
         [Test]
-        public void MockFile_Exists_ShouldReturnFalseForNullPath()
+        public async Task MockFile_Exists_ShouldReturnFalseForNullPath()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -85,11 +85,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.File.Exists(null);
 
             // Assert
-            Assert.That(result, Is.False);
+            await That(result).IsFalse();
         }
 
         [Test]
-        public void MockFile_Exists_ShouldReturnFalseForEmptyStringPath()
+        public async Task MockFile_Exists_ShouldReturnFalseForEmptyStringPath()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -98,11 +98,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.File.Exists(string.Empty);
 
             // Assert
-            Assert.That(result, Is.False);
+            await That(result).IsFalse();
         }
 
         [Test]
-        public void MockFile_Exists_ShouldReturnFalseForInvalidCharactersInPath()
+        public async Task MockFile_Exists_ShouldReturnFalseForInvalidCharactersInPath()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -111,11 +111,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.File.Exists(@"C:""*/:<>?|abc");
 
             // Assert
-            Assert.That(result, Is.False);
+            await That(result).IsFalse();
         }
 
         [Test]
-        public void MockFile_Exists_ShouldReturnFalseForDirectories()
+        public async Task MockFile_Exists_ShouldReturnFalseForDirectories()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -128,7 +128,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.File.Exists(XFS.Path(@"C:\something\"));
 
             // Assert
-            Assert.That(result, Is.False);
+            await That(result).IsFalse();
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetAccessControlTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetAccessControlTests.cs
@@ -13,35 +13,35 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     {
         [TestCase(" ")]
         [TestCase("   ")]
-        public void MockFile_GetAccessControl_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        public async Task MockFile_GetAccessControl_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => fileSystem.File.GetAccessControl(path);
+            Action action = () => fileSystem.File.GetAccessControl(path);
 
             // Assert
-            var exception = Assert.Throws<ArgumentException>(action);
-            Assert.That(exception.ParamName, Is.EqualTo("path"));
+            var exception = await That(action).Throws<ArgumentException>();
+            await That(exception.ParamName).IsEqualTo("path");
         }
 
         [Test]
-        public void MockFile_GetAccessControl_ShouldThrowFileNotFoundExceptionIfFileDoesNotExistInMockData()
+        public async Task MockFile_GetAccessControl_ShouldThrowFileNotFoundExceptionIfFileDoesNotExistInMockData()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
             var expectedFileName = XFS.Path(@"c:\a.txt");
 
             // Act
-            TestDelegate action = () => fileSystem.File.GetAccessControl(expectedFileName);
+            Action action = () => fileSystem.File.GetAccessControl(expectedFileName);
 
             // Assert
-            Assert.Throws<FileNotFoundException>(action);
+            await That(action).Throws<FileNotFoundException>();
         }
 
         [Test]
-        public void MockFile_GetAccessControl_ShouldReturnAccessControlOfFileData()
+        public async Task MockFile_GetAccessControl_ShouldReturnAccessControlOfFileData()
         {
             // Arrange
             var expectedFileSecurity = new FileSecurity();
@@ -62,7 +62,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSecurity = fileSystem.File.GetAccessControl(filePath);
 
             // Assert
-            Assert.That(fileSecurity, Is.EqualTo(expectedFileSecurity));
+            await That(fileSecurity).IsEqualTo(expectedFileSecurity);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetCreationTimeTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetCreationTimeTests.cs
@@ -7,21 +7,21 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     {
         [TestCase(" ")]
         [TestCase("   ")]
-        public void MockFile_GetCreationTime_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        public async Task MockFile_GetCreationTime_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => fileSystem.File.GetCreationTime(path);
+            Action action = () => fileSystem.File.GetCreationTime(path);
 
             // Assert
-            var exception = Assert.Throws<ArgumentException>(action);
-            Assert.That(exception.ParamName, Is.EqualTo("path"));
+            var exception = await That(action).Throws<ArgumentException>();
+            await That(exception.ParamName).IsEqualTo("path");
         }
 
         [Test]
-        public void MockFile_GetCreationTime_ShouldReturnDefaultTimeIfFileDoesNotExist()
+        public async Task MockFile_GetCreationTime_ShouldReturnDefaultTimeIfFileDoesNotExist()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -30,11 +30,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualCreationTime = fileSystem.File.GetCreationTime(@"c:\does\not\exist.txt");
 
             // Assert
-            Assert.That(actualCreationTime, Is.EqualTo(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc).ToLocalTime()));
+            await That(actualCreationTime).IsEqualTo(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc).ToLocalTime());
         }
 
         [Test]
-        public void MockFile_GetCreationTime_ShouldBeSet()
+        public async Task MockFile_GetCreationTime_ShouldBeSet()
         {
             var now = DateTime.Now.AddDays(10);
             var fileSystem = new MockFileSystem()
@@ -43,8 +43,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.File.GetCreationTime("foo.txt");
 
-            Assert.That(result.Kind, Is.EqualTo(DateTimeKind.Local));
-            Assert.That(result, Is.EqualTo(now.ToLocalTime()));
+            await That(result.Kind).IsEqualTo(DateTimeKind.Local);
+            await That(result).IsEqualTo(now.ToLocalTime());
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetCreationTimeUtcTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetCreationTimeUtcTests.cs
@@ -7,21 +7,21 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     {
         [TestCase(" ")]
         [TestCase("   ")]
-        public void MockFile_GetCreationTimeUtc_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        public async Task MockFile_GetCreationTimeUtc_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => fileSystem.File.GetCreationTimeUtc(path);
+            Action action = () => fileSystem.File.GetCreationTimeUtc(path);
 
             // Assert
-            var exception = Assert.Throws<ArgumentException>(action);
-            Assert.That(exception.ParamName, Is.EqualTo("path"));
+            var exception = await That(action).Throws<ArgumentException>();
+            await That(exception.ParamName).IsEqualTo("path");
         }
 
         [Test]
-        public void MockFile_GetCreationTimeUtc_ShouldReturnDefaultTimeIfFileDoesNotExist()
+        public async Task MockFile_GetCreationTimeUtc_ShouldReturnDefaultTimeIfFileDoesNotExist()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -30,11 +30,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualCreationTime = fileSystem.File.GetCreationTimeUtc(@"c:\does\not\exist.txt");
 
             // Assert
-            Assert.That(actualCreationTime, Is.EqualTo(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc)));
+            await That(actualCreationTime).IsEqualTo(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc));
         }
 
         [Test]
-        public void MockFile_GetCreationTimeUtc_ShouldBeSet()
+        public async Task MockFile_GetCreationTimeUtc_ShouldBeSet()
         {
             var now = DateTime.Now.AddDays(10);
             var fileSystem = new MockFileSystem()
@@ -43,8 +43,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.File.GetCreationTimeUtc("foo.txt");
 
-            Assert.That(result.Kind, Is.EqualTo(DateTimeKind.Utc));
-            Assert.That(result, Is.EqualTo(now.ToUniversalTime()));
+            await That(result.Kind).IsEqualTo(DateTimeKind.Utc);
+            await That(result).IsEqualTo(now.ToUniversalTime());
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetLastAccessTimeTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetLastAccessTimeTests.cs
@@ -7,21 +7,21 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     {
         [TestCase(" ")]
         [TestCase("   ")]
-        public void MockFile_GetLastAccessTime_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        public async Task MockFile_GetLastAccessTime_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => fileSystem.File.GetLastAccessTime(path);
+            Action action = () => fileSystem.File.GetLastAccessTime(path);
 
             // Assert
-            var exception = Assert.Throws<ArgumentException>(action);
-            Assert.That(exception.ParamName, Is.EqualTo("path"));
+            var exception = await That(action).Throws<ArgumentException>();
+            await That(exception.ParamName).IsEqualTo("path");
         }
 
         [Test]
-        public void MockFile_GetLastAccessTime_ShouldReturnDefaultTimeIfFileDoesNotExist()
+        public async Task MockFile_GetLastAccessTime_ShouldReturnDefaultTimeIfFileDoesNotExist()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -30,11 +30,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualLastAccessTime = fileSystem.File.GetLastAccessTime(@"c:\does\not\exist.txt");
 
             // Assert
-            Assert.That(actualLastAccessTime, Is.EqualTo(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc).ToLocalTime()));
+            await That(actualLastAccessTime).IsEqualTo(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc).ToLocalTime());
         }
 
         [Test]
-        public void MockFile_GetLastAccessTime_ShouldBeSet()
+        public async Task MockFile_GetLastAccessTime_ShouldBeSet()
         {
             var now = DateTime.Now.AddDays(10);
             var fileSystem = new MockFileSystem()
@@ -43,8 +43,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.File.GetLastAccessTime("foo.txt");
 
-            Assert.That(result.Kind, Is.EqualTo(DateTimeKind.Local));
-            Assert.That(result, Is.EqualTo(now.ToLocalTime()));
+            await That(result.Kind).IsEqualTo(DateTimeKind.Local);
+            await That(result).IsEqualTo(now.ToLocalTime());
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetLastAccessTimeUtcTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetLastAccessTimeUtcTests.cs
@@ -7,21 +7,21 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     {
         [TestCase(" ")]
         [TestCase("   ")]
-        public void MockFile_GetLastAccessTimeUtc_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        public async Task MockFile_GetLastAccessTimeUtc_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => fileSystem.File.GetLastAccessTimeUtc(path);
+            Action action = () => fileSystem.File.GetLastAccessTimeUtc(path);
 
             // Assert
-            var exception = Assert.Throws<ArgumentException>(action);
-            Assert.That(exception.ParamName, Is.EqualTo("path"));
+            var exception = await That(action).Throws<ArgumentException>();
+            await That(exception.ParamName).IsEqualTo("path");
         }
 
         [Test]
-        public void MockFile_GetLastAccessTimeUtc_ShouldReturnDefaultTimeIfFileDoesNotExist()
+        public async Task MockFile_GetLastAccessTimeUtc_ShouldReturnDefaultTimeIfFileDoesNotExist()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -30,11 +30,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualLastAccessTime = fileSystem.File.GetLastAccessTimeUtc(@"c:\does\not\exist.txt");
 
             // Assert
-            Assert.That(actualLastAccessTime, Is.EqualTo(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc)));
+            await That(actualLastAccessTime).IsEqualTo(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc));
         }
 
         [Test]
-        public void MockFile_GetLastAccessTimeUtc_ShouldBeSet()
+        public async Task MockFile_GetLastAccessTimeUtc_ShouldBeSet()
         {
             var now = DateTime.Now.AddDays(10);
             var fileSystem = new MockFileSystem()
@@ -43,8 +43,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.File.GetLastAccessTimeUtc("foo.txt");
 
-            Assert.That(result.Kind, Is.EqualTo(DateTimeKind.Utc));
-            Assert.That(result, Is.EqualTo(now.ToUniversalTime()));
+            await That(result.Kind).IsEqualTo(DateTimeKind.Utc);
+            await That(result).IsEqualTo(now.ToUniversalTime());
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetLastWriteTimeTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetLastWriteTimeTests.cs
@@ -7,21 +7,21 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     {
         [TestCase(" ")]
         [TestCase("   ")]
-        public void MockFile_GetLastWriteTime_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        public async Task MockFile_GetLastWriteTime_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => fileSystem.File.GetLastWriteTime(path);
+            Action action = () => fileSystem.File.GetLastWriteTime(path);
 
             // Assert
-            var exception = Assert.Throws<ArgumentException>(action);
-            Assert.That(exception.ParamName, Is.EqualTo("path"));
+            var exception = await That(action).Throws<ArgumentException>();
+            await That(exception.ParamName).IsEqualTo("path");
         }
 
         [Test]
-        public void MockFile_GetLastWriteTime_ShouldReturnDefaultTimeIfFileDoesNotExist()
+        public async Task MockFile_GetLastWriteTime_ShouldReturnDefaultTimeIfFileDoesNotExist()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -30,11 +30,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualLastWriteTime = fileSystem.File.GetLastWriteTime(@"c:\does\not\exist.txt");
 
             // Assert
-            Assert.That(actualLastWriteTime, Is.EqualTo(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc).ToLocalTime()));
+            await That(actualLastWriteTime).IsEqualTo(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc).ToLocalTime());
         }
 
         [Test]
-        public void MockFile_GetLastWriteTime_ShouldBeSet()
+        public async Task MockFile_GetLastWriteTime_ShouldBeSet()
         {
             var now = DateTime.Now.AddDays(10);
             var fileSystem = new MockFileSystem()
@@ -43,8 +43,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.File.GetLastWriteTime("foo.txt");
 
-            Assert.That(result.Kind, Is.EqualTo(DateTimeKind.Local));
-            Assert.That(result, Is.EqualTo(now.ToLocalTime()));
+            await That(result.Kind).IsEqualTo(DateTimeKind.Local);
+            await That(result).IsEqualTo(now.ToLocalTime());
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetLastWriteTimeUtcTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetLastWriteTimeUtcTests.cs
@@ -6,21 +6,21 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     {
         [TestCase(" ")]
         [TestCase("   ")]
-        public void MockFile_GetLastWriteTimeUtc_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        public async Task MockFile_GetLastWriteTimeUtc_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => fileSystem.File.GetLastWriteTimeUtc(path);
+            Action action = () => fileSystem.File.GetLastWriteTimeUtc(path);
 
             // Assert
-            var exception = Assert.Throws<ArgumentException>(action);
-            Assert.That(exception.ParamName, Is.EqualTo("path"));
+            var exception = await That(action).Throws<ArgumentException>();
+            await That(exception.ParamName).IsEqualTo("path");
         }
 
         [Test]
-        public void MockFile_GetLastWriteTimeUtc_ShouldReturnDefaultTimeIfFileDoesNotExist()
+        public async Task MockFile_GetLastWriteTimeUtc_ShouldReturnDefaultTimeIfFileDoesNotExist()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -29,11 +29,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualLastWriteTime = fileSystem.File.GetLastWriteTimeUtc(@"c:\does\not\exist.txt");
 
             // Assert
-            Assert.That(actualLastWriteTime, Is.EqualTo(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc)));
+            await That(actualLastWriteTime).IsEqualTo(new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc));
         }
 
         [Test]
-        public void MockFile_GetLastWriteTimeUtc_ShouldBeSet()
+        public async Task MockFile_GetLastWriteTimeUtc_ShouldBeSet()
         {
             var now = DateTime.Now.AddDays(10);
             var fileSystem = new MockFileSystem()
@@ -42,8 +42,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.File.GetLastWriteTimeUtc("foo.txt");
 
-            Assert.That(result.Kind, Is.EqualTo(DateTimeKind.Utc));
-            Assert.That(result, Is.EqualTo(now.ToUniversalTime()));
+            await That(result.Kind).IsEqualTo(DateTimeKind.Utc);
+            await That(result).IsEqualTo(now.ToUniversalTime());
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetUnixFileModeTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileGetUnixFileModeTests.cs
@@ -14,7 +14,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockFileGetUnixFileModeTests
     {
         [Test]
-        public void MockFile_GetUnixFileMode_ShouldReturnDefaultAccessMode()
+        public async Task MockFile_GetUnixFileMode_ShouldReturnDefaultAccessMode()
         {
             // Arrange
             var expected = UnixFileMode.UserRead | 
@@ -31,11 +31,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.File.GetUnixFileMode(XFS.Path(@"C:\something\some.txt"));
 
             // Assert
-            Assert.That(result, Is.EqualTo(expected));
+            await That(result).IsEqualTo(expected);
         }
         
         [Test]
-        public void MockFile_GetUnixFileMode_ShouldReturnSpecifiedAccessMode([Values] UnixFileMode unixFileMode)
+        public async Task MockFile_GetUnixFileMode_ShouldReturnSpecifiedAccessMode([Values] UnixFileMode unixFileMode)
         {
             // Arrange
             var mockFileData = new MockFileData("Demo text content")
@@ -52,7 +52,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.File.GetUnixFileMode(XFS.Path(@"C:\something\some.txt"));
 
             // Assert
-            Assert.That(result, Is.EqualTo(unixFileMode));
+            await That(result).IsEqualTo(unixFileMode);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoAccessControlTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoAccessControlTests.cs
@@ -12,7 +12,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockFileInfoAccessControlTests
     {
         [Test]
-        public void MockFileInfo_GetAccessControl_ShouldReturnAccessControlOfFileData()
+        public async Task MockFileInfo_GetAccessControl_ShouldReturnAccessControlOfFileData()
         {
             // Arrange
             var expectedFileSecurity = new FileSecurity();
@@ -35,11 +35,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSecurity = fileInfo.GetAccessControl();
 
             // Assert
-            Assert.That(fileSecurity, Is.EqualTo(expectedFileSecurity));
+            await That(fileSecurity).IsEqualTo(expectedFileSecurity);
         }
 
         [Test]
-        public void MockFile_SetAccessControl_ShouldSetAccessControlOfFileData()
+        public async Task MockFile_SetAccessControl_ShouldSetAccessControlOfFileData()
         {
             // Arrange
             var filePath = XFS.Path(@"c:\a.txt");
@@ -59,7 +59,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             var accessControl = fileInfo.GetAccessControl();
-            Assert.That(accessControl, Is.EqualTo(expectedAccessControl));
+            await That(accessControl).IsEqualTo(expectedAccessControl);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoFactoryTests.cs
@@ -7,7 +7,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockFileInfoFactoryTests
     {
         [Test]
-        public void MockFileInfoFactory_New_ShouldReturnFileInfoForExistingFile()
+        public async Task MockFileInfoFactory_New_ShouldReturnFileInfoForExistingFile()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -21,11 +21,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileInfoFactory.New(@"c:\a.txt");
 
             // Assert
-            Assert.That(result, Is.Not.Null);
+            await That(result).IsNotNull();
         }
 
         [Test]
-        public void MockFileInfoFactory_New_ShouldReturnFileInfoForNonExistentFile()
+        public async Task MockFileInfoFactory_New_ShouldReturnFileInfoForNonExistentFile()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -39,28 +39,28 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileInfoFactory.New(@"c:\foo.txt");
 
             // Assert
-            Assert.That(result, Is.Not.Null);
+            await That(result).IsNotNull();
         }
 
         [Test]
-        public void MockFileInfoFactory_Wrap_WithNull_ShouldReturnNull()
+        public async Task MockFileInfoFactory_Wrap_WithNull_ShouldReturnNull()
         {
             var fileSystem = new MockFileSystem();
 
             var result = fileSystem.FileInfo.Wrap(null);
 
-            Assert.That(result, Is.Null);
+            await That(result).IsNull();
         }
 
         [Test]
-        public void MockFileInfoFactory_Wrap_ShouldKeepNameAndFullName()
+        public async Task MockFileInfoFactory_Wrap_ShouldKeepNameAndFullName()
         {
             var fs = new MockFileSystem();
             var fileInfo = new FileInfo(@"C:\subfolder\file");
             var wrappedFileInfo = fs.FileInfo.Wrap(fileInfo);
 
-            Assert.That(wrappedFileInfo.FullName, Is.EqualTo(fileInfo.FullName));
-            Assert.That(wrappedFileInfo.Name, Is.EqualTo(fileInfo.Name));
+            await That(wrappedFileInfo.FullName).IsEqualTo(fileInfo.FullName);
+            await That(wrappedFileInfo.Name).IsEqualTo(fileInfo.Name);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoSymlinkTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoSymlinkTests.cs
@@ -15,7 +15,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 #if FEATURE_CREATE_SYMBOLIC_LINK
 
         [Test]
-        public void MockFileInfo_ResolveLinkTarget_ShouldReturnPathOfTargetLink()
+        public async Task MockFileInfo_ResolveLinkTarget_ShouldReturnPathOfTargetLink()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.File.WriteAllText("bar", "some content");
@@ -23,11 +23,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.FileInfo.New("foo").ResolveLinkTarget(false);
 
-            Assert.That(result.Name, Is.EqualTo("bar"));
+            await That(result.Name).IsEqualTo("bar");
         }
 
         [Test]
-        public void MockFileInfo_ResolveLinkTarget_WithFinalTarget_ShouldReturnPathOfTargetLink()
+        public async Task MockFileInfo_ResolveLinkTarget_WithFinalTarget_ShouldReturnPathOfTargetLink()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.File.WriteAllText("bar", "some content");
@@ -36,11 +36,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.FileInfo.New("foo1").ResolveLinkTarget(true);
 
-            Assert.That(result.Name, Is.EqualTo("bar"));
+            await That(result.Name).IsEqualTo("bar");
         }
 
         [Test]
-        public void MockFileInfo_ResolveLinkTarget_WithoutFinalTarget_ShouldReturnFirstLink()
+        public async Task MockFileInfo_ResolveLinkTarget_WithoutFinalTarget_ShouldReturnFirstLink()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.File.WriteAllText("bar", "some content");
@@ -49,20 +49,20 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.FileInfo.New("foo1").ResolveLinkTarget(false);
 
-            Assert.That(result.Name, Is.EqualTo("foo"));
+            await That(result.Name).IsEqualTo("foo");
         }
 
         [Test]
-        public void MockFileInfo_ResolveLinkTarget_WithoutTargetLink_ShouldThrowIOException()
+        public async Task MockFileInfo_ResolveLinkTarget_WithoutTargetLink_ShouldThrowIOException()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.File.WriteAllText("bar", "some content");
             fileSystem.File.CreateSymbolicLink("foo", "bar");
 
-            Assert.Throws<IOException>(() =>
+            await That(() =>
             {
                 fileSystem.FileInfo.New("bar").ResolveLinkTarget(false);
-            });
+            }).Throws<IOException>();
         }
 #endif
     }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileInfoTests.cs
@@ -10,18 +10,18 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockFileInfoTests
     {
         [Test]
-        public void MockFileInfo_NullPath_ThrowArgumentNullException()
+        public async Task MockFileInfo_NullPath_ThrowArgumentNullException()
         {
             var fileSystem = new MockFileSystem();
 
-            TestDelegate action = () => new MockFileInfo(fileSystem, null);
+            Action action = () => new MockFileInfo(fileSystem, null);
 
-            Assert.Throws<ArgumentNullException>(action);
+            await That(action).Throws<ArgumentNullException>();
 
         }
 
         [Test]
-        public void MockFileInfo_Exists_ShouldReturnTrueIfFileExistsInMemoryFileSystem()
+        public async Task MockFileInfo_Exists_ShouldReturnTrueIfFileExistsInMemoryFileSystem()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -32,11 +32,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.Exists;
 
-            Assert.That(result, Is.True);
+            await That(result).IsTrue();
         }
 
         [Test]
-        public void MockFileInfo_Exists_ShouldReturnFalseIfFileDoesNotExistInMemoryFileSystem()
+        public async Task MockFileInfo_Exists_ShouldReturnFalseIfFileDoesNotExistInMemoryFileSystem()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -47,11 +47,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.Exists;
 
-            Assert.That(result, Is.False);
+            await That(result).IsFalse();
         }
 
         [Test]
-        public void MockFileInfo_Exists_ShouldReturnFalseIfPathLeadsToDirectory()
+        public async Task MockFileInfo_Exists_ShouldReturnFalseIfPathLeadsToDirectory()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -61,11 +61,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.Exists;
 
-            Assert.That(result, Is.False);
+            await That(result).IsFalse();
         }
 
         [Test]
-        public void MockFileInfo_Length_ShouldReturnLengthOfFileInMemoryFileSystem()
+        public async Task MockFileInfo_Length_ShouldReturnLengthOfFileInMemoryFileSystem()
         {
             const string fileContent = "Demo text content";
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -77,11 +77,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.Length;
 
-            Assert.That(result, Is.EqualTo(fileContent.Length));
+            await That(result).IsEqualTo(fileContent.Length);
         }
 
         [Test]
-        public void MockFileInfo_Length_ShouldThrowFileNotFoundExceptionIfFileDoesNotExistInMemoryFileSystem()
+        public async Task MockFileInfo_Length_ShouldThrowFileNotFoundExceptionIfFileDoesNotExistInMemoryFileSystem()
         {
             const string fileContent = "Demo text content";
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -91,13 +91,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             });
             var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\foo.txt"));
 
-            var ex = Assert.Throws<FileNotFoundException>(() => fileInfo.Length.ToString(CultureInfo.InvariantCulture));
+            var ex = await That(() => fileInfo.Length.ToString(CultureInfo.InvariantCulture)).Throws<FileNotFoundException>();
 
-            Assert.That(ex.FileName, Is.EqualTo(XFS.Path(@"c:\foo.txt")));
+            await That(ex.FileName).IsEqualTo(XFS.Path(@"c:\foo.txt"));
         }
 
         [Test]
-        public void MockFileInfo_Length_ShouldThrowFileNotFoundExceptionIfPathLeadsToDirectory()
+        public async Task MockFileInfo_Length_ShouldThrowFileNotFoundExceptionIfPathLeadsToDirectory()
         {
             const string fileContent = "Demo text content";
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -106,13 +106,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             });
             var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\a\b"));
 
-            var ex = Assert.Throws<FileNotFoundException>(() => fileInfo.Length.ToString(CultureInfo.InvariantCulture));
+            var ex = await That(() => fileInfo.Length.ToString(CultureInfo.InvariantCulture)).Throws<FileNotFoundException>();
 
-            Assert.That(ex.FileName, Is.EqualTo(XFS.Path(@"c:\a\b")));
+            await That(ex.FileName).IsEqualTo(XFS.Path(@"c:\a\b"));
         }
 
         [Test]
-        public void MockFileInfo_CreationTimeUtc_ShouldReturnCreationTimeUtcOfFileInMemoryFileSystem()
+        public async Task MockFileInfo_CreationTimeUtc_ShouldReturnCreationTimeUtcOfFileInMemoryFileSystem()
         {
             var creationTime = DateTime.Now.AddHours(-4);
             var fileData = new MockFileData("Demo text content") { CreationTime = creationTime };
@@ -124,22 +124,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.CreationTimeUtc;
 
-            Assert.That(result, Is.EqualTo(creationTime.ToUniversalTime()));
+            await That(result).IsEqualTo(creationTime.ToUniversalTime());
         }
 
         [Test]
-        public void MockFileInfo_CreationTimeUtc_ShouldReturnDefaultTimeForNonExistingFile()
+        public async Task MockFileInfo_CreationTimeUtc_ShouldReturnDefaultTimeForNonExistingFile()
         {
             var fileSystem = new MockFileSystem();
             var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\non\existing\file.txt"));
 
             var result = fileInfo.CreationTimeUtc;
 
-            Assert.That(result, Is.EqualTo(MockFileData.DefaultDateTimeOffset.UtcDateTime));
+            await That(result).IsEqualTo(MockFileData.DefaultDateTimeOffset.UtcDateTime);
         }
 
         [Test]
-        public void MockFileInfo_CreationTimeUtc_ShouldSetCreationTimeUtcOfFileInMemoryFileSystem()
+        public async Task MockFileInfo_CreationTimeUtc_ShouldSetCreationTimeUtcOfFileInMemoryFileSystem()
         {
             var creationTime = DateTime.Now.AddHours(-4);
             var fileData = new MockFileData("Demo text content") { CreationTime = creationTime };
@@ -152,12 +152,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var newUtcTime = DateTime.UtcNow;
             fileInfo.CreationTimeUtc = newUtcTime;
 
-            Assert.That(fileInfo.CreationTimeUtc, Is.EqualTo(newUtcTime));
+            await That(fileInfo.CreationTimeUtc).IsEqualTo(newUtcTime);
         }
 
 
         [Test]
-        public void MockFileInfo_CreationTime_ShouldReturnCreationTimeOfFileInMemoryFileSystem()
+        public async Task MockFileInfo_CreationTime_ShouldReturnCreationTimeOfFileInMemoryFileSystem()
         {
             var creationTime = DateTime.Now.AddHours(-4);
             var fileData = new MockFileData("Demo text content") { CreationTime = creationTime };
@@ -169,22 +169,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.CreationTime;
 
-            Assert.That(result, Is.EqualTo(creationTime));
+            await That(result).IsEqualTo(creationTime);
         }
 
         [Test]
-        public void MockFileInfo_CreationTime_ShouldReturnDefaultTimeForNonExistingFile()
+        public async Task MockFileInfo_CreationTime_ShouldReturnDefaultTimeForNonExistingFile()
         {
             var fileSystem = new MockFileSystem();
             var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\non\existing\file.txt"));
 
             var result = fileInfo.CreationTime;
 
-            Assert.That(result, Is.EqualTo(MockFileData.DefaultDateTimeOffset.LocalDateTime));
+            await That(result).IsEqualTo(MockFileData.DefaultDateTimeOffset.LocalDateTime);
         }
 
         [Test]
-        public void MockFileInfo_CreationTime_ShouldSetCreationTimeOfFileInMemoryFileSystem()
+        public async Task MockFileInfo_CreationTime_ShouldSetCreationTimeOfFileInMemoryFileSystem()
         {
             var creationTime = DateTime.Now.AddHours(-4);
             var fileData = new MockFileData("Demo text content") { CreationTime = creationTime };
@@ -197,30 +197,30 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileInfo.CreationTime = newTime;
 
-            Assert.That(fileInfo.CreationTime, Is.EqualTo(newTime));
+            await That(fileInfo.CreationTime).IsEqualTo(newTime);
         }
 
         [Test]
-        public void MockFileInfo_Attributes_ShouldReturnMinusOneForNonExistingFile()
+        public async Task MockFileInfo_Attributes_ShouldReturnMinusOneForNonExistingFile()
         {
             var fileSystem = new MockFileSystem();
             var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\a.txt"));
             FileAttributes expected = (FileAttributes)(-1);
 
-            Assert.That(fileInfo.Attributes, Is.EqualTo(expected));
+            await That(fileInfo.Attributes).IsEqualTo(expected);
         }
 
         [Test]
-        public void MockFileInfo_Attributes_SetterShouldThrowFileNotFoundExceptionOnNonExistingFileOrDirectory()
+        public async Task MockFileInfo_Attributes_SetterShouldThrowFileNotFoundExceptionOnNonExistingFileOrDirectory()
         {
             var fileSystem = new MockFileSystem();
             var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\non\existing\file.txt"));
 
-            Assert.Throws<FileNotFoundException>(() => fileInfo.Attributes = FileAttributes.Hidden);
+            await That(() => fileInfo.Attributes = FileAttributes.Hidden).Throws<FileNotFoundException>();
         }
 
         [Test]
-        public void MockFileInfo_IsReadOnly_ShouldSetReadOnlyAttributeOfFileInMemoryFileSystem()
+        public async Task MockFileInfo_IsReadOnly_ShouldSetReadOnlyAttributeOfFileInMemoryFileSystem()
         {
             var fileData = new MockFileData("Demo text content");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -231,11 +231,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileInfo.IsReadOnly = true;
 
-            Assert.That(fileData.Attributes & FileAttributes.ReadOnly, Is.EqualTo(FileAttributes.ReadOnly));
+            await That(fileData.Attributes & FileAttributes.ReadOnly).IsEqualTo(FileAttributes.ReadOnly);
         }
 
         [Test]
-        public void MockFileInfo_IsReadOnly_ShouldSetNotReadOnlyAttributeOfFileInMemoryFileSystem()
+        public async Task MockFileInfo_IsReadOnly_ShouldSetNotReadOnlyAttributeOfFileInMemoryFileSystem()
         {
             var fileData = new MockFileData("Demo text content") { Attributes = FileAttributes.ReadOnly };
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -246,11 +246,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileInfo.IsReadOnly = false;
 
-            Assert.That(fileData.Attributes & FileAttributes.ReadOnly, Is.Not.EqualTo(FileAttributes.ReadOnly));
+            await That(fileData.Attributes & FileAttributes.ReadOnly).IsNotEqualTo(FileAttributes.ReadOnly);
         }
 
         [Test]
-        public void MockFileInfo_AppendText_ShouldAddTextToFileInMemoryFileSystem()
+        public async Task MockFileInfo_AppendText_ShouldAddTextToFileInMemoryFileSystem()
         {
             var fileData = new MockFileData("Demo text content");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -268,11 +268,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 newcontents = newfile.ReadToEnd();
             }
 
-            Assert.That(newcontents, Is.EqualTo($"Demo text contentThis should be at the end{Environment.NewLine}"));
+            await That(newcontents).IsEqualTo($"Demo text contentThis should be at the end{Environment.NewLine}");
         }
 
         [Test]
-        public void MockFileInfo_AppendText_ShouldCreateFileIfMissing()
+        public async Task MockFileInfo_AppendText_ShouldCreateFileIfMissing()
         {
             var fileSystem = new MockFileSystem();
             var targetFile = XFS.Path(@"c:\a.txt");
@@ -287,12 +287,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 newcontents = newfile.ReadToEnd();
             }
 
-            Assert.That(fileSystem.File.Exists(targetFile), Is.True);
-            Assert.That(newcontents, Is.EqualTo($"This should be the contents{Environment.NewLine}"));
+            await That(fileSystem.File.Exists(targetFile)).IsTrue();
+            await That(newcontents).IsEqualTo($"This should be the contents{Environment.NewLine}");
         }
 
         [Test]
-        public void MockFileInfo_OpenWrite_ShouldAddDataToFileInMemoryFileSystem()
+        public async Task MockFileInfo_OpenWrite_ShouldAddDataToFileInMemoryFileSystem()
         {
             var fileData = new MockFileData("Demo text content");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -314,11 +314,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 newcontents = newfile.ReadToEnd();
             }
 
-            Assert.That(newcontents, Is.EqualTo("ABCDEtext content"));
+            await That(newcontents).IsEqualTo("ABCDEtext content");
         }
 
         [Test]
-        public void MockFileInfo_Encrypt_ShouldSetEncryptedAttributeOfFileInMemoryFileSystem()
+        public async Task MockFileInfo_Encrypt_ShouldSetEncryptedAttributeOfFileInMemoryFileSystem()
         {
             var fileData = new MockFileData("Demo text content");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -329,11 +329,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileInfo.Encrypt();
 
-            Assert.That(fileData.Attributes & FileAttributes.Encrypted, Is.EqualTo(FileAttributes.Encrypted));
+            await That(fileData.Attributes & FileAttributes.Encrypted).IsEqualTo(FileAttributes.Encrypted);
         }
 
         [Test]
-        public void MockFileInfo_Decrypt_ShouldUnsetEncryptedAttributeOfFileInMemoryFileSystem()
+        public async Task MockFileInfo_Decrypt_ShouldUnsetEncryptedAttributeOfFileInMemoryFileSystem()
         {
             var fileData = new MockFileData("Demo text content");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -345,11 +345,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileInfo.Decrypt();
 
-            Assert.That(fileData.Attributes & FileAttributes.Encrypted, Is.Not.EqualTo(FileAttributes.Encrypted));
+            await That(fileData.Attributes & FileAttributes.Encrypted).IsNotEqualTo(FileAttributes.Encrypted);
         }
 
         [Test]
-        public void MockFileInfo_LastAccessTimeUtc_ShouldReturnLastAccessTimeUtcOfFileInMemoryFileSystem()
+        public async Task MockFileInfo_LastAccessTimeUtc_ShouldReturnLastAccessTimeUtcOfFileInMemoryFileSystem()
         {
             var lastAccessTime = DateTime.Now.AddHours(-4);
             var fileData = new MockFileData("Demo text content") { LastAccessTime = lastAccessTime };
@@ -361,22 +361,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.LastAccessTimeUtc;
 
-            Assert.That(result, Is.EqualTo(lastAccessTime.ToUniversalTime()));
+            await That(result).IsEqualTo(lastAccessTime.ToUniversalTime());
         }
 
         [Test]
-        public void MockFileInfo_LastAccessTimeUtc_ShouldReturnDefaultTimeForNonExistingFile()
+        public async Task MockFileInfo_LastAccessTimeUtc_ShouldReturnDefaultTimeForNonExistingFile()
         {
             var fileSystem = new MockFileSystem();
             var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\non\existing\file.txt"));
 
             var result = fileInfo.LastAccessTimeUtc;
 
-            Assert.That(result, Is.EqualTo(MockFileData.DefaultDateTimeOffset.UtcDateTime));
+            await That(result).IsEqualTo(MockFileData.DefaultDateTimeOffset.UtcDateTime);
         }
 
         [Test]
-        public void MockFileInfo_LastAccessTimeUtc_ShouldSetCreationTimeUtcOfFileInMemoryFileSystem()
+        public async Task MockFileInfo_LastAccessTimeUtc_ShouldSetCreationTimeUtcOfFileInMemoryFileSystem()
         {
             var lastAccessTime = DateTime.Now.AddHours(-4);
             var fileData = new MockFileData("Demo text content") { LastAccessTime = lastAccessTime };
@@ -389,22 +389,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var newUtcTime = DateTime.UtcNow;
             fileInfo.LastAccessTimeUtc = newUtcTime;
 
-            Assert.That(fileInfo.LastAccessTimeUtc, Is.EqualTo(newUtcTime));
+            await That(fileInfo.LastAccessTimeUtc).IsEqualTo(newUtcTime);
         }
 
         [Test]
-        public void MockFileInfo_LastWriteTime_ShouldReturnDefaultTimeForNonExistingFile()
+        public async Task MockFileInfo_LastWriteTime_ShouldReturnDefaultTimeForNonExistingFile()
         {
             var fileSystem = new MockFileSystem();
             var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\non\existing\file.txt"));
 
             var result = fileInfo.LastWriteTime;
 
-            Assert.That(result, Is.EqualTo(MockFileData.DefaultDateTimeOffset.LocalDateTime));
+            await That(result).IsEqualTo(MockFileData.DefaultDateTimeOffset.LocalDateTime);
         }
 
         [Test]
-        public void MockFileInfo_LastWriteTimeUtc_ShouldReturnLastWriteTimeUtcOfFileInMemoryFileSystem()
+        public async Task MockFileInfo_LastWriteTimeUtc_ShouldReturnLastWriteTimeUtcOfFileInMemoryFileSystem()
         {
             var lastWriteTime = DateTime.Now.AddHours(-4);
             var fileData = new MockFileData("Demo text content") { LastWriteTime = lastWriteTime };
@@ -416,22 +416,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileInfo.LastWriteTimeUtc;
 
-            Assert.That(result, Is.EqualTo(lastWriteTime.ToUniversalTime()));
+            await That(result).IsEqualTo(lastWriteTime.ToUniversalTime());
         }
 
         [Test]
-        public void MockFileInfo_LastWriteTimeUtc_ShouldReturnDefaultTimeForNonExistingFile()
+        public async Task MockFileInfo_LastWriteTimeUtc_ShouldReturnDefaultTimeForNonExistingFile()
         {
             var fileSystem = new MockFileSystem();
             var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\non\existing\file.txt"));
 
             var result = fileInfo.LastWriteTimeUtc;
 
-            Assert.That(result, Is.EqualTo(MockFileData.DefaultDateTimeOffset.UtcDateTime));
+            await That(result).IsEqualTo(MockFileData.DefaultDateTimeOffset.UtcDateTime);
         }
 
         [Test]
-        public void MockFileInfo_LastWriteTimeUtc_ShouldSetLastWriteTimeUtcOfFileInMemoryFileSystem()
+        public async Task MockFileInfo_LastWriteTimeUtc_ShouldSetLastWriteTimeUtcOfFileInMemoryFileSystem()
         {
             var lastWriteTime = DateTime.Now.AddHours(-4);
             var fileData = new MockFileData("Demo text content") { LastWriteTime = lastWriteTime };
@@ -444,53 +444,53 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var newUtcTime = DateTime.UtcNow;
             fileInfo.LastWriteTimeUtc = newUtcTime;
 
-            Assert.That(fileInfo.LastWriteTimeUtc, Is.EqualTo(newUtcTime));
+            await That(fileInfo.LastWriteTimeUtc).IsEqualTo(newUtcTime);
         }
 
         [Test]
-        public void MockFileInfo_GetExtension_ShouldReturnExtension()
+        public async Task MockFileInfo_GetExtension_ShouldReturnExtension()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
             var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\a.txt"));
 
             var result = fileInfo.Extension;
 
-            Assert.That(result, Is.EqualTo(".txt"));
+            await That(result).IsEqualTo(".txt");
         }
 
         [Test]
-        public void MockFileInfo_GetExtensionWithoutExtension_ShouldReturnEmptyString()
+        public async Task MockFileInfo_GetExtensionWithoutExtension_ShouldReturnEmptyString()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>());
             var fileInfo = new MockFileInfo(fileSystem, XFS.Path(@"c:\a"));
 
             var result = fileInfo.Extension;
 
-            Assert.That(result, Is.Empty);
+            await That(result).IsEmpty();
         }
 
         [Test]
-        public void MockFileInfo_GetDirectoryName_ShouldReturnCompleteDirectoryPath()
+        public async Task MockFileInfo_GetDirectoryName_ShouldReturnCompleteDirectoryPath()
         {
             var fileInfo = new MockFileInfo(new MockFileSystem(), XFS.Path(@"c:\temp\level1\level2\file.txt"));
 
             var result = fileInfo.DirectoryName;
 
-            Assert.That(result, Is.EqualTo(XFS.Path(@"c:\temp\level1\level2")));
+            await That(result).IsEqualTo(XFS.Path(@"c:\temp\level1\level2"));
         }
 
         [Test]
-        public void MockFileInfo_GetDirectory_ShouldReturnDirectoryInfoWithCorrectPath()
+        public async Task MockFileInfo_GetDirectory_ShouldReturnDirectoryInfoWithCorrectPath()
         {
             var fileInfo = new MockFileInfo(new MockFileSystem(), XFS.Path(@"c:\temp\level1\level2\file.txt"));
 
             var result = fileInfo.Directory;
 
-            Assert.That(result.FullName, Is.EqualTo(XFS.Path(@"c:\temp\level1\level2")));
+            await That(result.FullName).IsEqualTo(XFS.Path(@"c:\temp\level1\level2"));
         }
 
         [Test]
-        public void MockFileInfo_OpenRead_ShouldReturnByteContentOfFile()
+        public async Task MockFileInfo_OpenRead_ShouldReturnByteContentOfFile()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.AddFile(XFS.Path(@"c:\temp\file.txt"), new MockFileData(new byte[] { 1, 2 }));
@@ -505,11 +505,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 #pragma warning restore CA2022
             }
 
-            Assert.That(result, Is.EqualTo(new byte[] { 1, 2 }));
+            await That(result).IsEqualTo(new byte[] { 1, 2 });
         }
 
         [Test]
-        public void MockFileInfo_OpenText_ShouldReturnStringContentOfFile()
+        public async Task MockFileInfo_OpenText_ShouldReturnStringContentOfFile()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.AddFile(XFS.Path(@"c:\temp\file.txt"), new MockFileData(@"line 1\r\nline 2"));
@@ -521,11 +521,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 result = streamReader.ReadToEnd();
             }
 
-            Assert.That(result, Is.EqualTo(@"line 1\r\nline 2"));
+            await That(result).IsEqualTo(@"line 1\r\nline 2");
         }
 
         [Test]
-        public void MockFileInfo_MoveTo_NonExistentDestination_ShouldUpdateFileInfoDirectoryAndFullName()
+        public async Task MockFileInfo_MoveTo_NonExistentDestination_ShouldUpdateFileInfoDirectoryAndFullName()
         {
             var fileSystem = new MockFileSystem();
             var sourcePath = XFS.Path(@"c:\temp\file.txt");
@@ -537,12 +537,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileInfo.MoveTo(destinationPath);
 
-            Assert.That(fileInfo.DirectoryName, Is.EqualTo(destinationFolder));
-            Assert.That(fileInfo.FullName, Is.EqualTo(destinationPath));
+            await That(fileInfo.DirectoryName).IsEqualTo(destinationFolder);
+            await That(fileInfo.FullName).IsEqualTo(destinationPath);
         }
 
         [Test]
-        public void MockFileInfo_MoveTo_NonExistentDestinationFolder_ShouldThrowDirectoryNotFoundException()
+        public async Task MockFileInfo_MoveTo_NonExistentDestinationFolder_ShouldThrowDirectoryNotFoundException()
         {
             var fileSystem = new MockFileSystem();
             var sourcePath = XFS.Path(@"c:\temp\file.txt");
@@ -550,11 +550,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddFile(sourcePath, new MockFileData("1"));
             var fileInfo = fileSystem.FileInfo.New(sourcePath);
 
-            Assert.Throws<DirectoryNotFoundException>(() => fileInfo.MoveTo(destinationPath));
+            await That(() => fileInfo.MoveTo(destinationPath)).Throws<DirectoryNotFoundException>();
         }
 
         [Test]
-        public void MockFileInfo_MoveTo_ExistingDestination_ShouldThrowExceptionAboutFileAlreadyExisting()
+        public async Task MockFileInfo_MoveTo_ExistingDestination_ShouldThrowExceptionAboutFileAlreadyExisting()
         {
             var fileSystem = new MockFileSystem();
             var sourcePath = XFS.Path(@"c:\temp\file.txt");
@@ -563,11 +563,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileInfo = fileSystem.FileInfo.New(sourcePath);
             fileSystem.AddFile(destinationPath, new MockFileData("2"));
 
-            Assert.Throws<IOException>(() => fileInfo.MoveTo(destinationPath));
+            await That(() => fileInfo.MoveTo(destinationPath)).Throws<IOException>();
         }
 
         [Test]
-        public void MockFileInfo_MoveTo_SameSourceAndTargetIsANoOp()
+        public async Task MockFileInfo_MoveTo_SameSourceAndTargetIsANoOp()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.AddFile(XFS.Path(@"c:\temp\file.txt"), new MockFileData(@"line 1\r\nline 2"));
@@ -576,39 +576,39 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileInfo.MoveTo(destination);
 
-            Assert.That(fileInfo.FullName, Is.EqualTo(destination));
-            Assert.That(fileInfo.Exists, Is.True);
+            await That(fileInfo.FullName).IsEqualTo(destination);
+            await That(fileInfo.Exists).IsTrue();
         }
 
         [Test]
-        public void MockFileInfo_MoveTo_SameSourceAndTargetThrowsExceptionIfSourceDoesNotExist()
+        public async Task MockFileInfo_MoveTo_SameSourceAndTargetThrowsExceptionIfSourceDoesNotExist()
         {
             var fileSystem = new MockFileSystem();
             var fileInfo = fileSystem.FileInfo.New(XFS.Path(@"c:\temp\file.txt"));
             string destination = XFS.Path(XFS.Path(@"c:\temp\file.txt"));
 
-            TestDelegate action = () => fileInfo.MoveTo(destination);
+            Action action = () => fileInfo.MoveTo(destination);
 
-            Assert.Throws<FileNotFoundException>(action);
+            await That(action).Throws<FileNotFoundException>();
         }
 
         [Test]
-        public void MockFileInfo_MoveTo_ThrowsExceptionIfSourceDoesNotExist()
+        public async Task MockFileInfo_MoveTo_ThrowsExceptionIfSourceDoesNotExist()
         {
             var fileSystem = new MockFileSystem();
             var fileInfo = fileSystem.FileInfo.New(XFS.Path(@"c:\temp\file.txt"));
             string destination = XFS.Path(XFS.Path(@"c:\temp\file2.txt"));
 
-            TestDelegate action = () => fileInfo.MoveTo(destination);
+            Action action = () => fileInfo.MoveTo(destination);
 
-            Assert.Throws<FileNotFoundException>(action);
+            await That(action).Throws<FileNotFoundException>();
         }
 
 
 
 #if FEATURE_FILE_MOVE_WITH_OVERWRITE
         [Test]
-        public void MockFileInfo_MoveToWithOverwrite_ShouldSucceedWhenTargetAlreadyExists()
+        public async Task MockFileInfo_MoveToWithOverwrite_ShouldSucceedWhenTargetAlreadyExists()
         {
             string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
             string sourceFileContent = "this is some content";
@@ -621,12 +621,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileSystem.FileInfo.New(sourceFilePath).MoveTo(destFilePath, overwrite: true);
 
-            Assert.That(fileSystem.File.ReadAllText(destFilePath), Is.EqualTo(sourceFileContent));
+            await That(fileSystem.File.ReadAllText(destFilePath)).IsEqualTo(sourceFileContent);
         }
 #endif
 
         [Test]
-        public void MockFileInfo_MoveToOnlyCaseChanging_ShouldSucceed()
+        public async Task MockFileInfo_MoveToOnlyCaseChanging_ShouldSucceed()
         {
             string sourceFilePath = XFS.Path(@"c:\temp\file.txt");
             string destFilePath = XFS.Path(@"c:\temp\FILE.txt");
@@ -638,27 +638,27 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileInfo = fileSystem.FileInfo.New(sourceFilePath);
             fileInfo.MoveTo(destFilePath);
 
-            Assert.That(fileInfo.FullName, Is.EqualTo(destFilePath));
-            Assert.That(fileInfo.Exists, Is.True);
+            await That(fileInfo.FullName).IsEqualTo(destFilePath);
+            await That(fileInfo.Exists).IsTrue();
         }
 
         [Test]
-        public void MockFileInfo_CopyTo_ThrowsExceptionIfSourceDoesNotExist()
+        public async Task MockFileInfo_CopyTo_ThrowsExceptionIfSourceDoesNotExist()
         {
             var fileSystem = new MockFileSystem();
             var fileInfo = fileSystem.FileInfo.New(XFS.Path(@"c:\temp\file.txt"));
             string destination = XFS.Path(XFS.Path(@"c:\temp\file2.txt"));
 
-            TestDelegate action = () => fileInfo.CopyTo(destination);
+            Action action = () => fileInfo.CopyTo(destination);
 
-            Assert.Throws<FileNotFoundException>(action);
+            await That(action).Throws<FileNotFoundException>();
         }
 
         [TestCase(@"..\..\..\c.txt")]
         [TestCase(@"c:\a\b\c.txt")]
         [TestCase(@"c:\a\c.txt")]
         [TestCase(@"c:\c.txt")]
-        public void MockFileInfo_ToString_ShouldReturnOriginalFilePath(string path)
+        public async Task MockFileInfo_ToString_ShouldReturnOriginalFilePath(string path)
         {
             //Arrange
             var filePath = XFS.Path(path);
@@ -667,7 +667,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var mockFileInfo = new MockFileInfo(new MockFileSystem(), filePath);
 
             //Assert
-            Assert.That(mockFileInfo.ToString(), Is.EqualTo(filePath));
+            await That(mockFileInfo.ToString()).IsEqualTo(filePath);
         }
 
 
@@ -675,7 +675,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         /// Normalize, tested with Path.GetFullPath and new FileInfo().FullName;
         /// </summary>
         [TestCaseSource(nameof(New_Paths_NormalizePaths_Cases))]
-        public void New_Paths_NormalizePaths(string input, string expected)
+        public async Task New_Paths_NormalizePaths(string input, string expected)
         {
             // Arrange
             var mockFs = new MockFileSystem();
@@ -685,7 +685,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockFileInfo.FullName;
 
             // Assert
-            Assert.That(result, Is.EqualTo(expected));
+            await That(result).IsEqualTo(expected);
         }
 
         public static IEnumerable<string[]> New_Paths_NormalizePaths_Cases
@@ -700,7 +700,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFileInfo_Replace_ShouldReplaceFileContents()
+        public async Task MockFileInfo_Replace_ShouldReplaceFileContents()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -714,11 +714,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Act
             fileInfo1.Replace(path2, null);
 
-            Assert.That(fileInfo2.OpenText().ReadToEnd(), Is.EqualTo("1"));
+            await That(fileInfo2.OpenText().ReadToEnd()).IsEqualTo("1");
         }
 
         [Test]
-        public void MockFileInfo_Replace_ShouldCreateBackup()
+        public async Task MockFileInfo_Replace_ShouldCreateBackup()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -733,11 +733,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Act
             fileInfo1.Replace(path2, path3);
 
-            Assert.That(fileInfo3.OpenText().ReadToEnd(), Is.EqualTo("2"));
+            await That(fileInfo3.OpenText().ReadToEnd()).IsEqualTo("2");
         }
 
         [Test]
-        public void MockFileInfo_Replace_ShouldThrowIfDirectoryOfBackupPathDoesNotExist()
+        public async Task MockFileInfo_Replace_ShouldThrowIfDirectoryOfBackupPathDoesNotExist()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -749,11 +749,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileInfo1 = fileSystem.FileInfo.New(path1);
 
             // Act
-            Assert.Throws<DirectoryNotFoundException>(() => fileInfo1.Replace(path2, path3));
+            await That(() => fileInfo1.Replace(path2, path3)).Throws<DirectoryNotFoundException>();
         }
 
         [Test]
-        public void MockFileInfo_Replace_ShouldReturnDestinationFileInfo()
+        public async Task MockFileInfo_Replace_ShouldReturnDestinationFileInfo()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -767,11 +767,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Act
             var result = fileInfo1.Replace(path2, null);
 
-            Assert.That(result.FullName, Is.EqualTo(fileInfo2.FullName));
+            await That(result.FullName).IsEqualTo(fileInfo2.FullName);
         }
 
         [Test]
-        public void MockFileInfo_Replace_ShouldThrowIfSourceFileDoesNotExist()
+        public async Task MockFileInfo_Replace_ShouldThrowIfSourceFileDoesNotExist()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -780,11 +780,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddFile(path2, new MockFileData("1"));
             var fileInfo = fileSystem.FileInfo.New(path1);
 
-            Assert.Throws<FileNotFoundException>(() => fileInfo.Replace(path2, null));
+            await That(() => fileInfo.Replace(path2, null)).Throws<FileNotFoundException>();
         }
 
         [Test]
-        public void MockFileInfo_Replace_ShouldThrowIfDestinationFileDoesNotExist()
+        public async Task MockFileInfo_Replace_ShouldThrowIfDestinationFileDoesNotExist()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -793,11 +793,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddFile(path1, new MockFileData("1"));
             var fileInfo = fileSystem.FileInfo.New(path1);
 
-            Assert.Throws<FileNotFoundException>(() => fileInfo.Replace(path2, null));
+            await That(() => fileInfo.Replace(path2, null)).Throws<FileNotFoundException>();
         }
 
         [Test]
-        public void MockFileInfo_Exists_ShouldReturnCachedData()
+        public async Task MockFileInfo_Exists_ShouldReturnCachedData()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -808,11 +808,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddFile(path1, new MockFileData("1"));
 
             // Assert
-            Assert.That(fileInfo.Exists, Is.False);
+            await That(fileInfo.Exists).IsFalse();
         }
 
         [Test]
-        public void MockFileInfo_Exists_ShouldUpdateCachedDataOnRefresh()
+        public async Task MockFileInfo_Exists_ShouldUpdateCachedDataOnRefresh()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -824,11 +824,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileInfo.Refresh();
 
             // Assert
-            Assert.That(fileInfo.Exists, Is.True);
+            await That(fileInfo.Exists).IsTrue();
         }
 
         [Test]
-        public void MockFileInfo_Create_ShouldUpdateCachedDataAndReturnTrueForExists()
+        public async Task MockFileInfo_Create_ShouldUpdateCachedDataAndReturnTrueForExists()
         {
             IFileSystem fileSystem = new MockFileSystem();
             var path = XFS.Path(@"c:\temp\file1.txt");
@@ -839,11 +839,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             var result = fileInfo.Exists;
-            Assert.That(result, Is.True);
+            await That(result).IsTrue();
         }
 
         [Test]
-        public void MockFileInfo_CreateText_ShouldUpdateCachedDataAndReturnTrueForExists()
+        public async Task MockFileInfo_CreateText_ShouldUpdateCachedDataAndReturnTrueForExists()
         {
             IFileSystem fileSystem = new MockFileSystem();
             var path = XFS.Path(@"c:\temp\file1.txt");
@@ -853,11 +853,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileInfo.CreateText().Dispose();
 
             // Assert
-            Assert.That(fileInfo.Exists, Is.True);
+            await That(fileInfo.Exists).IsTrue();
         }
 
         [Test]
-        public void MockFileInfo_Delete_ShouldUpdateCachedDataAndReturnFalseForExists()
+        public async Task MockFileInfo_Delete_ShouldUpdateCachedDataAndReturnFalseForExists()
         {
             var fileSystem = new MockFileSystem();
             var path = XFS.Path(@"c:\temp\file1.txt");
@@ -867,11 +867,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileInfo.Delete();
 
             // Assert
-            Assert.That(fileInfo.Exists, Is.False);
+            await That(fileInfo.Exists).IsFalse();
         }
 
         [Test]
-        public void MockFileInfo_Delete_ShouldThrowIfFileAccessShareHasNoWriteOrDeleteAccess()
+        public async Task MockFileInfo_Delete_ShouldThrowIfFileAccessShareHasNoWriteOrDeleteAccess()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.AddFile(
@@ -880,11 +880,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var fi = fileSystem.FileInfo.New(@"c:\bar\foo.txt");
 
-            Assert.Throws(typeof(System.IO.IOException), () => fi.Delete());
+            await That(() => fi.Delete()).Throws<IOException>();
         }
 
         [Test]
-        public void MockFileInfo_LastAccessTimeUtcWithUnspecifiedDateTimeKind_ShouldSetLastAccessTimeUtcOfFileInFileSystem()
+        public async Task MockFileInfo_LastAccessTimeUtcWithUnspecifiedDateTimeKind_ShouldSetLastAccessTimeUtcOfFileInFileSystem()
         {
             var date = DateTime.SpecifyKind(DateTime.Now.AddHours(-4), DateTimeKind.Unspecified);
             var fileSystem = new MockFileSystem();
@@ -895,12 +895,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 LastAccessTimeUtc = date
             };
 
-            Assert.That(fileInfo.LastAccessTimeUtc, Is.EqualTo(date));
-            Assert.That(fileInfo.LastAccessTimeUtc.Kind, Is.Not.EqualTo(DateTimeKind.Unspecified));
+            await That(fileInfo.LastAccessTimeUtc).IsEqualTo(date);
+            await That(fileInfo.LastAccessTimeUtc.Kind).IsNotEqualTo(DateTimeKind.Unspecified);
         }
 
         [Test]
-        public void MockFileInfo_LastAccessTimeWithUnspecifiedDateTimeKind_ShouldSetLastAccessTimeOfFileInFileSystem()
+        public async Task MockFileInfo_LastAccessTimeWithUnspecifiedDateTimeKind_ShouldSetLastAccessTimeOfFileInFileSystem()
         {
             var date = DateTime.SpecifyKind(DateTime.Now.AddHours(-4), DateTimeKind.Unspecified);
             var fileSystem = new MockFileSystem();
@@ -911,12 +911,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 LastAccessTime = date
             };
 
-            Assert.That(fileInfo.LastAccessTime, Is.EqualTo(date));
-            Assert.That(fileInfo.LastAccessTime.Kind, Is.Not.EqualTo(DateTimeKind.Unspecified));
+            await That(fileInfo.LastAccessTime).IsEqualTo(date);
+            await That(fileInfo.LastAccessTime.Kind).IsNotEqualTo(DateTimeKind.Unspecified);
         }
 
         [Test]
-        public void MockFileInfo_CreationTimeUtcWithUnspecifiedDateTimeKind_ShouldSetCreationTimeUtcOfFileInFileSystem()
+        public async Task MockFileInfo_CreationTimeUtcWithUnspecifiedDateTimeKind_ShouldSetCreationTimeUtcOfFileInFileSystem()
         {
             var date = DateTime.SpecifyKind(DateTime.Now.AddHours(-4), DateTimeKind.Unspecified);
             var fileSystem = new MockFileSystem();
@@ -927,12 +927,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 CreationTimeUtc = date
             };
 
-            Assert.That(fileInfo.CreationTimeUtc, Is.EqualTo(date));
-            Assert.That(fileInfo.CreationTimeUtc.Kind, Is.Not.EqualTo(DateTimeKind.Unspecified));
+            await That(fileInfo.CreationTimeUtc).IsEqualTo(date);
+            await That(fileInfo.CreationTimeUtc.Kind).IsNotEqualTo(DateTimeKind.Unspecified);
         }
 
         [Test]
-        public void MockFileInfo_CreationTimeWithUnspecifiedDateTimeKind_ShouldSetCreationTimeOfFileInFileSystem()
+        public async Task MockFileInfo_CreationTimeWithUnspecifiedDateTimeKind_ShouldSetCreationTimeOfFileInFileSystem()
         {
             var date = DateTime.SpecifyKind(DateTime.Now.AddHours(-4), DateTimeKind.Unspecified);
             var fileSystem = new MockFileSystem();
@@ -943,12 +943,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 CreationTime = date
             };
 
-            Assert.That(fileInfo.CreationTime, Is.EqualTo(date));
-            Assert.That(fileInfo.CreationTime.Kind, Is.Not.EqualTo(DateTimeKind.Unspecified));
+            await That(fileInfo.CreationTime).IsEqualTo(date);
+            await That(fileInfo.CreationTime.Kind).IsNotEqualTo(DateTimeKind.Unspecified);
         }
 
         [Test]
-        public void MockFileInfo_LastWriteTimeUtcWithUnspecifiedDateTimeKind_ShouldSetLastWriteTimeUtcOfFileInFileSystem()
+        public async Task MockFileInfo_LastWriteTimeUtcWithUnspecifiedDateTimeKind_ShouldSetLastWriteTimeUtcOfFileInFileSystem()
         {
             var date = DateTime.SpecifyKind(DateTime.Now.AddHours(-4), DateTimeKind.Unspecified);
             var fileSystem = new MockFileSystem();
@@ -959,12 +959,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 LastWriteTimeUtc = date
             };
 
-            Assert.That(fileInfo.LastWriteTimeUtc, Is.EqualTo(date));
-            Assert.That(fileInfo.LastWriteTimeUtc.Kind, Is.Not.EqualTo(DateTimeKind.Unspecified));
+            await That(fileInfo.LastWriteTimeUtc).IsEqualTo(date);
+            await That(fileInfo.LastWriteTimeUtc.Kind).IsNotEqualTo(DateTimeKind.Unspecified);
         }
 
         [Test]
-        public void MockFileInfo_LastWriteTimeWithUnspecifiedDateTimeKind_ShouldSetLastWriteTimeOfFileInFileSystem()
+        public async Task MockFileInfo_LastWriteTimeWithUnspecifiedDateTimeKind_ShouldSetLastWriteTimeOfFileInFileSystem()
         {
             var date = DateTime.SpecifyKind(DateTime.Now.AddHours(-4), DateTimeKind.Unspecified);
             var fileSystem = new MockFileSystem();
@@ -975,8 +975,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 LastWriteTime = date
             };
 
-            Assert.That(fileInfo.LastWriteTime, Is.EqualTo(date));
-            Assert.That(fileInfo.LastWriteTime.Kind, Is.Not.EqualTo(DateTimeKind.Unspecified));
+            await That(fileInfo.LastWriteTime).IsEqualTo(date);
+            await That(fileInfo.LastWriteTime.Kind).IsNotEqualTo(DateTimeKind.Unspecified);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileLockTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileLockTests.cs
@@ -8,7 +8,7 @@
     class MockFileLockTests
     {
         [Test]
-        public void MockFile_Lock_FileShareNoneThrows()
+        public async Task MockFile_Lock_FileShareNoneThrows()
         {
             string filepath = XFS.Path(@"c:\something\does\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -16,10 +16,10 @@
                 { filepath, new MockFileData("I'm here") { AllowedFileShare = FileShare.None }}
             });
 
-            Assert.Throws(IOException(), () => filesystem.File.Open(filepath, FileMode.Open, FileAccess.Read, FileShare.Read));
+            await That(() => filesystem.File.Open(filepath, FileMode.Open, FileAccess.Read, FileShare.Read)).Throws<IOException>();
         }
         [Test]
-        public void MockFile_Lock_FileShareReadDoesNotThrowOnRead()
+        public async Task MockFile_Lock_FileShareReadDoesNotThrowOnRead()
         {
             string filepath = XFS.Path(@"c:\something\does\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -27,10 +27,10 @@
                 { filepath, new MockFileData("I'm here") { AllowedFileShare = FileShare.Read }}
             });
 
-            Assert.DoesNotThrow(() => filesystem.File.Open(filepath, FileMode.Open, FileAccess.Read, FileShare.Read));
+            await That(() => filesystem.File.Open(filepath, FileMode.Open, FileAccess.Read, FileShare.Read)).DoesNotThrow();
         }
         [Test]
-        public void MockFile_Lock_FileShareReadThrowsOnWrite()
+        public async Task MockFile_Lock_FileShareReadThrowsOnWrite()
         {
             string filepath = XFS.Path(@"c:\something\does\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -38,10 +38,10 @@
                 { filepath, new MockFileData("I'm here") { AllowedFileShare = FileShare.Read }}
             });
 
-            Assert.Throws(IOException(), () => filesystem.File.Open(filepath, FileMode.Open, FileAccess.Write, FileShare.Read));
+            await That(() => filesystem.File.Open(filepath, FileMode.Open, FileAccess.Write, FileShare.Read)).Throws<IOException>();
         }
         [Test]
-        public void MockFile_Lock_FileShareWriteThrowsOnRead()
+        public async Task MockFile_Lock_FileShareWriteThrowsOnRead()
         {
             string filepath = XFS.Path(@"c:\something\does\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -49,10 +49,10 @@
                 { filepath, new MockFileData("I'm here") { AllowedFileShare = FileShare.Write }}
             });
 
-            Assert.Throws(IOException(), () => filesystem.File.Open(filepath, FileMode.Open, FileAccess.Read, FileShare.Read));
+            await That(() => filesystem.File.Open(filepath, FileMode.Open, FileAccess.Read, FileShare.Read)).Throws<IOException>();
         }
         [Test]
-        public void MockFile_Lock_FileShareWriteDoesNotThrowOnWrite()
+        public async Task MockFile_Lock_FileShareWriteDoesNotThrowOnWrite()
         {
             string filepath = XFS.Path(@"c:\something\does\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -60,12 +60,12 @@
                 { filepath, new MockFileData("I'm here") { AllowedFileShare = FileShare.Write }}
             });
 
-            Assert.DoesNotThrow(() => filesystem.File.Open(filepath, FileMode.Open, FileAccess.Write, FileShare.Read));
+            await That(() => filesystem.File.Open(filepath, FileMode.Open, FileAccess.Write, FileShare.Read)).DoesNotThrow();
         }
 
 
         [Test]
-        public void MockFile_Lock_FileShareNoneThrowsOnOpenRead()
+        public async Task MockFile_Lock_FileShareNoneThrowsOnOpenRead()
         {
             string filepath = XFS.Path(@"c:\something\does\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -73,11 +73,11 @@
                 { filepath, new MockFileData("I'm here") { AllowedFileShare = FileShare.None }}
             });
 
-            var exception = Assert.Throws(IOException(), () => filesystem.File.OpenRead(filepath));
-            Assert.That(exception.Message, Is.EqualTo($"The process cannot access the file '{filepath}' because it is being used by another process."));
+            var exception = await That(() => filesystem.File.OpenRead(filepath)).Throws<IOException>();
+            await That(exception.Message).IsEqualTo($"The process cannot access the file '{filepath}' because it is being used by another process.");
         }
         [Test]
-        public void MockFile_Lock_FileShareNoneThrowsOnWriteAllLines()
+        public async Task MockFile_Lock_FileShareNoneThrowsOnWriteAllLines()
         {
             string filepath = XFS.Path(@"c:\something\does\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -85,11 +85,11 @@
                 { filepath, new MockFileData("I'm here") { AllowedFileShare = FileShare.None }}
             });
 
-            var exception = Assert.Throws(IOException(), () => filesystem.File.WriteAllLines(filepath, new string[] { "hello", "world" }));
-            Assert.That(exception.Message, Is.EqualTo($"The process cannot access the file '{filepath}' because it is being used by another process."));
+            var exception = await That(() => filesystem.File.WriteAllLines(filepath, new string[] { "hello", "world" })).Throws<IOException>();
+            await That(exception.Message).IsEqualTo($"The process cannot access the file '{filepath}' because it is being used by another process.");
         }
         [Test]
-        public void MockFile_Lock_FileShareNoneThrowsOnReadAllLines()
+        public async Task MockFile_Lock_FileShareNoneThrowsOnReadAllLines()
         {
             string filepath = XFS.Path(@"c:\something\does\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -97,11 +97,11 @@
                 { filepath, new MockFileData("I'm here") { AllowedFileShare = FileShare.None }}
             });
 
-            var exception = Assert.Throws(IOException(), () => filesystem.File.ReadAllLines(filepath));
-            Assert.That(exception.Message, Is.EqualTo($"The process cannot access the file '{filepath}' because it is being used by another process."));
+            var exception = await That(() => filesystem.File.ReadAllLines(filepath)).Throws<IOException>();
+            await That(exception.Message).IsEqualTo($"The process cannot access the file '{filepath}' because it is being used by another process.");
         }
         [Test]
-        public void MockFile_Lock_FileShareNoneThrowsOnReadAllText()
+        public async Task MockFile_Lock_FileShareNoneThrowsOnReadAllText()
         {
             string filepath = XFS.Path(@"c:\something\does\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -109,11 +109,11 @@
                 { filepath, new MockFileData("I'm here") { AllowedFileShare = FileShare.None }}
             });
 
-            var exception = Assert.Throws(IOException(), () => filesystem.File.ReadAllText(filepath));
-            Assert.That(exception.Message, Is.EqualTo($"The process cannot access the file '{filepath}' because it is being used by another process."));
+            var exception = await That(() => filesystem.File.ReadAllText(filepath)).Throws<IOException>();
+            await That(exception.Message).IsEqualTo($"The process cannot access the file '{filepath}' because it is being used by another process.");
         }
         [Test]
-        public void MockFile_Lock_FileShareNoneThrowsOnReadAllBytes()
+        public async Task MockFile_Lock_FileShareNoneThrowsOnReadAllBytes()
         {
             string filepath = XFS.Path(@"c:\something\does\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -121,11 +121,11 @@
                 { filepath, new MockFileData("I'm here") { AllowedFileShare = FileShare.None }}
             });
 
-            var exception = Assert.Throws(IOException(), () => filesystem.File.ReadAllBytes(filepath));
-            Assert.That(exception.Message, Is.EqualTo($"The process cannot access the file '{filepath}' because it is being used by another process."));
+            var exception = await That(() => filesystem.File.ReadAllBytes(filepath)).Throws<IOException>();
+            await That(exception.Message).IsEqualTo($"The process cannot access the file '{filepath}' because it is being used by another process.");
         }
         [Test]
-        public void MockFile_Lock_FileShareNoneThrowsOnAppendLines()
+        public async Task MockFile_Lock_FileShareNoneThrowsOnAppendLines()
         {
             string filepath = XFS.Path(@"c:\something\does\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -133,12 +133,12 @@
                 { filepath, new MockFileData("I'm here") { AllowedFileShare = FileShare.None }}
             });
 
-            var exception = Assert.Throws(IOException(), () => filesystem.File.AppendAllLines(filepath, new string[] { "hello", "world" }));
-            Assert.That(exception.Message, Is.EqualTo($"The process cannot access the file '{filepath}' because it is being used by another process."));
+            var exception = await That(() => filesystem.File.AppendAllLines(filepath, new string[] { "hello", "world" })).Throws<IOException>();
+            await That(exception.Message).IsEqualTo($"The process cannot access the file '{filepath}' because it is being used by another process.");
         }
 
         [Test]
-        public void MockFile_Lock_FileShareNoneThrowsFileMove()
+        public async Task MockFile_Lock_FileShareNoneThrowsFileMove()
         {
             string filepath = XFS.Path(@"c:\something\does\exist.txt");
             string target = XFS.Path(@"c:\something\does\notexist.txt");
@@ -147,11 +147,11 @@
                 { filepath, new MockFileData("I'm here") { AllowedFileShare = FileShare.None }}
             });
 
-            var exception = Assert.Throws(IOException(), () => filesystem.File.Move(filepath, target));
-            Assert.That(exception.Message, Is.EqualTo("The process cannot access the file because it is being used by another process."));
+            var exception = await That(() => filesystem.File.Move(filepath, target)).Throws<IOException>();
+            await That(exception.Message).IsEqualTo("The process cannot access the file because it is being used by another process.");
         }
         [Test]
-        public void MockFile_Lock_FileShareDeleteDoesNotThrowFileMove()
+        public async Task MockFile_Lock_FileShareDeleteDoesNotThrowFileMove()
         {
             string filepath = XFS.Path(@"c:\something\does\exist.txt");
             string target = XFS.Path(@"c:\something\does\notexist.txt");
@@ -160,10 +160,10 @@
                 { filepath, new MockFileData("I'm here") { AllowedFileShare = FileShare.Delete }}
             });
 
-            Assert.DoesNotThrow(() => filesystem.File.Move(filepath, target));
+            await That(() => filesystem.File.Move(filepath, target)).DoesNotThrow();
         }
         [Test]
-        public void MockFile_Lock_FileShareNoneThrowsDelete()
+        public async Task MockFile_Lock_FileShareNoneThrowsDelete()
         {
             string filepath = XFS.Path(@"c:\something\does\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -171,11 +171,11 @@
                 { filepath, new MockFileData("I'm here") { AllowedFileShare = FileShare.None }}
             });
 
-            var exception = Assert.Throws(IOException(), () => filesystem.File.Delete(filepath));
-            Assert.That(exception.Message, Is.EqualTo($"The process cannot access the file '{filepath}' because it is being used by another process."));
+            var exception = await That(() => filesystem.File.Delete(filepath)).Throws<IOException>();
+            await That(exception.Message).IsEqualTo($"The process cannot access the file '{filepath}' because it is being used by another process.");
         }
         [Test]
-        public void MockFile_Lock_FileShareDeleteDoesNotThrowDelete()
+        public async Task MockFile_Lock_FileShareDeleteDoesNotThrowDelete()
         {
             string filepath = XFS.Path(@"c:\something\does\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -183,7 +183,7 @@
                 { filepath, new MockFileData("I'm here") { AllowedFileShare = FileShare.Delete }}
             });
 
-            Assert.DoesNotThrow(() => filesystem.File.Delete(filepath));
+            await That(() => filesystem.File.Delete(filepath)).DoesNotThrow();
         }
 
         private static IResolveConstraint IOException() => Is.TypeOf<IOException>().And.Property("HResult").EqualTo(unchecked((int)0x80070020));

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileMoveTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileMoveTests.cs
@@ -8,7 +8,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockFileMoveTests
     {
         [Test]
-        public void MockFile_Move_ShouldMoveFileWithinMemoryFileSystem()
+        public async Task MockFile_Move_ShouldMoveFileWithinMemoryFileSystem()
         {
             string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
             string sourceFileContent = "this is some content";
@@ -22,13 +22,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileSystem.File.Move(sourceFilePath, destFilePath);
 
-            Assert.That(fileSystem.FileExists(destFilePath), Is.True);
-            Assert.That(fileSystem.GetFile(destFilePath).TextContents, Is.EqualTo(sourceFileContent));
-            Assert.That(fileSystem.FileExists(sourceFilePath), Is.False);
+            await That(fileSystem.FileExists(destFilePath)).IsTrue();
+            await That(fileSystem.GetFile(destFilePath).TextContents).IsEqualTo(sourceFileContent);
+            await That(fileSystem.FileExists(sourceFilePath)).IsFalse();
         }
 
         [Test]
-        public void MockFile_Move_WithReadOnlyAttribute_ShouldThrowUnauthorizedAccessExceptionAndNotMoveFile()
+        public async Task MockFile_Move_WithReadOnlyAttribute_ShouldThrowUnauthorizedAccessExceptionAndNotMoveFile()
         {
             var sourceFilePath = @"c:\foo.txt";
             var destFilePath = @"c:\bar.txt";
@@ -36,14 +36,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.File.WriteAllText(sourceFilePath, "this is some content");
             fileSystem.File.SetAttributes(sourceFilePath, FileAttributes.ReadOnly);
 
-            Assert.Throws<UnauthorizedAccessException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
+            await That(() => fileSystem.File.Move(sourceFilePath, destFilePath)).Throws<UnauthorizedAccessException>();
 
-            Assert.That(fileSystem.File.Exists(sourceFilePath), Is.EqualTo(true));
-            Assert.That(fileSystem.File.Exists(destFilePath), Is.EqualTo(false));
+            await That(fileSystem.File.Exists(sourceFilePath)).IsEqualTo(true);
+            await That(fileSystem.File.Exists(destFilePath)).IsEqualTo(false);
         }
 
         [Test]
-        public void MockFile_Move_SameSourceAndTargetIsANoOp()
+        public async Task MockFile_Move_SameSourceAndTargetIsANoOp()
         {
             string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
             string sourceFileContent = "this is some content";
@@ -57,12 +57,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileSystem.File.Move(sourceFilePath, destFilePath);
 
-            Assert.That(fileSystem.FileExists(destFilePath), Is.True);
-            Assert.That(fileSystem.GetFile(destFilePath).TextContents, Is.EqualTo(sourceFileContent));
+            await That(fileSystem.FileExists(destFilePath)).IsTrue();
+            await That(fileSystem.GetFile(destFilePath).TextContents).IsEqualTo(sourceFileContent);
         }
 
         [Test]
-        public void MockFile_Move_ShouldThrowIOExceptionWhenTargetAlreadyExists()
+        public async Task MockFile_Move_ShouldThrowIOExceptionWhenTargetAlreadyExists()
         {
             string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
             string sourceFileContent = "this is some content";
@@ -73,14 +73,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 {destFilePath, new MockFileData(sourceFileContent)}
             });
 
-            var exception = Assert.Throws<IOException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
+            var exception = await That(() => fileSystem.File.Move(sourceFilePath, destFilePath)).Throws<IOException>();
 
-            Assert.That(exception.Message, Is.EqualTo("A file can not be created if it already exists."));
+            await That(exception.Message).IsEqualTo("A file can not be created if it already exists.");
         }
 
 #if FEATURE_FILE_MOVE_WITH_OVERWRITE
         [Test]
-        public void MockFile_MoveWithOverwrite_ShouldSucceedWhenTargetAlreadyExists()
+        public async Task MockFile_MoveWithOverwrite_ShouldSucceedWhenTargetAlreadyExists()
         {
             string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
             string sourceFileContent = "this is some content";
@@ -93,35 +93,35 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileSystem.File.Move(sourceFilePath, destFilePath, overwrite: true);
 
-            Assert.That(fileSystem.File.ReadAllText(destFilePath), Is.EqualTo(sourceFileContent));
+            await That(fileSystem.File.ReadAllText(destFilePath)).IsEqualTo(sourceFileContent);
         }
 #endif
 
         [Test]
-        public void MockFile_Move_ShouldThrowArgumentNullExceptionWhenSourceIsNull_Message()
+        public async Task MockFile_Move_ShouldThrowArgumentNullExceptionWhenSourceIsNull_Message()
         {
             string destFilePath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
 
-            var exception = Assert.Throws<ArgumentNullException>(() => fileSystem.File.Move(null, destFilePath));
+            var exception = await That(() => fileSystem.File.Move(null, destFilePath)).Throws<ArgumentNullException>();
 
-            Assert.That(exception.Message, Does.StartWith("File name cannot be null."));
+            await That(exception.Message).StartsWith("File name cannot be null.");
         }
 
         [Test]
-        public void MockFile_Move_ShouldThrowArgumentNullExceptionWhenSourceIsNull_ParamName()
+        public async Task MockFile_Move_ShouldThrowArgumentNullExceptionWhenSourceIsNull_ParamName()
         {
             string destFilePath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
 
-            var exception = Assert.Throws<ArgumentNullException>(() => fileSystem.File.Move(null, destFilePath));
+            var exception = await That(() => fileSystem.File.Move(null, destFilePath)).Throws<ArgumentNullException>();
 
-            Assert.That(exception.ParamName, Is.EqualTo("sourceFileName"));
+            await That(exception.ParamName).IsEqualTo("sourceFileName");
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.StrictPathRules)]
-        public void MockFile_Move_ShouldThrowArgumentExceptionWhenSourceFileNameContainsInvalidChars_Message()
+        public async Task MockFile_Move_ShouldThrowArgumentExceptionWhenSourceFileNameContainsInvalidChars_Message()
         {
             var destFilePath = @"c:\something\demo.txt";
             var fileSystem = new MockFileSystem();
@@ -132,16 +132,16 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 var sourceFilePath = @"c:\something\demo.txt" + invalidChar;
 
                 var exception =
-                    Assert.Throws<ArgumentException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
+                    await That(() => fileSystem.File.Move(sourceFilePath, destFilePath)).Throws<ArgumentException>();
 
-                Assert.That(exception.Message, Is.EqualTo("Illegal characters in path."),
-                    string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
+                await That(exception.Message).IsEqualTo("Illegal characters in path.")
+                    .Because(string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
             }
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.StrictPathRules)]
-        public void MockFile_Move_ShouldThrowArgumentExceptionWhenSourcePathContainsInvalidChars_Message()
+        public async Task MockFile_Move_ShouldThrowArgumentExceptionWhenSourcePathContainsInvalidChars_Message()
         {
             var destFilePath = @"c:\something\demo.txt";
             var fileSystem = new MockFileSystem();
@@ -151,16 +151,16 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 var sourceFilePath = @"c:\some" + invalidChar + @"thing\demo.txt";
 
                 var exception =
-                    Assert.Throws<ArgumentException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
+                    await That(() => fileSystem.File.Move(sourceFilePath, destFilePath)).Throws<ArgumentException>();
 
-                Assert.That(exception.Message, Is.EqualTo("Illegal characters in path."),
-                    string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
+                await That(exception.Message).IsEqualTo("Illegal characters in path.")
+                    .Because(string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
             }
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.StrictPathRules)]
-        public void MockFile_Move_ShouldThrowArgumentExceptionWhenTargetPathContainsInvalidChars_Message()
+        public async Task MockFile_Move_ShouldThrowArgumentExceptionWhenTargetPathContainsInvalidChars_Message()
         {
             var sourceFilePath = @"c:\something\demo.txt";
             var fileSystem = new MockFileSystem();
@@ -170,16 +170,16 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 var destFilePath = @"c:\some" + invalidChar + @"thing\demo.txt";
 
                 var exception =
-                    Assert.Throws<ArgumentException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
+                    await That(() => fileSystem.File.Move(sourceFilePath, destFilePath)).Throws<ArgumentException>();
 
-                Assert.That(exception.Message, Is.EqualTo("Illegal characters in path."),
-                    string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
+                await That(exception.Message).IsEqualTo("Illegal characters in path.")
+                    .Because(string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
             }
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.StrictPathRules)]
-        public void MockFile_Move_ShouldThrowArgumentExceptionWhenTargetFileNameContainsInvalidChars_Message()
+        public async Task MockFile_Move_ShouldThrowArgumentExceptionWhenTargetFileNameContainsInvalidChars_Message()
         {
             var sourceFilePath = @"c:\something\demo.txt";
             var fileSystem = new MockFileSystem();
@@ -190,181 +190,181 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 var destFilePath = @"c:\something\demo.txt" + invalidChar;
 
                 var exception =
-                    Assert.Throws<ArgumentException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
+                    await That(() => fileSystem.File.Move(sourceFilePath, destFilePath)).Throws<ArgumentException>();
 
-                Assert.That(exception.Message, Is.EqualTo("Illegal characters in path."),
-                    string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
+                await That(exception.Message).IsEqualTo("Illegal characters in path.")
+                    .Because(string.Format("Testing char: [{0:c}] \\{1:X4}", invalidChar, (int)invalidChar));
             }
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.Drives)]
-        public void MockFile_Move_ShouldThrowNotSupportedExceptionWhenSourcePathContainsInvalidUseOfDriveSeparator()
+        public async Task MockFile_Move_ShouldThrowNotSupportedExceptionWhenSourcePathContainsInvalidUseOfDriveSeparator()
         {
             var badSourcePath = @"C::\something\demo.txt";
             var destinationPath = @"C:\elsewhere\demo.txt";
             var fileSystem = new MockFileSystem();
 
-            TestDelegate action = () => fileSystem.File.Move(badSourcePath, destinationPath);
+            Action action = () => fileSystem.File.Move(badSourcePath, destinationPath);
 
-            Assert.Throws<NotSupportedException>(action);
+            await That(action).Throws<NotSupportedException>();
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.Drives)]
-        public void MockFile_Move_ShouldThrowNotSupportedExceptionWhenSourcePathContainsInvalidDriveLetter()
+        public async Task MockFile_Move_ShouldThrowNotSupportedExceptionWhenSourcePathContainsInvalidDriveLetter()
         {
             var badSourcePath = @"0:\something\demo.txt";
             var destinationPath = @"C:\elsewhere\demo.txt";
             var fileSystem = new MockFileSystem();
 
-            TestDelegate action = () => fileSystem.File.Move(badSourcePath, destinationPath);
+            Action action = () => fileSystem.File.Move(badSourcePath, destinationPath);
 
-            Assert.Throws<NotSupportedException>(action);
+            await That(action).Throws<NotSupportedException>();
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.Drives)]
-        public void MockFile_Move_ShouldThrowNotSupportedExceptionWhenDestinationPathContainsInvalidUseOfDriveSeparator()
+        public async Task MockFile_Move_ShouldThrowNotSupportedExceptionWhenDestinationPathContainsInvalidUseOfDriveSeparator()
         {
             var sourcePath = @"C:\something\demo.txt";
             var badDestinationPath = @"C:\elsewhere:\demo.txt";
             var fileSystem = new MockFileSystem();
 
-            TestDelegate action = () => fileSystem.File.Move(sourcePath, badDestinationPath);
+            Action action = () => fileSystem.File.Move(sourcePath, badDestinationPath);
 
-            Assert.Throws<NotSupportedException>(action);
+            await That(action).Throws<NotSupportedException>();
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.Drives)]
-        public void MockFile_Move_ShouldThrowNotSupportedExceptionWhenDestinationPathContainsInvalidDriveLetter()
+        public async Task MockFile_Move_ShouldThrowNotSupportedExceptionWhenDestinationPathContainsInvalidDriveLetter()
         {
             var sourcePath = @"C:\something\demo.txt";
             var badDestinationPath = @"^:\elsewhere\demo.txt";
             var fileSystem = new MockFileSystem();
 
-            TestDelegate action = () => fileSystem.File.Move(sourcePath, badDestinationPath);
+            Action action = () => fileSystem.File.Move(sourcePath, badDestinationPath);
 
-            Assert.Throws<NotSupportedException>(action);
+            await That(action).Throws<NotSupportedException>();
         }
 
         [Test]
-        public void MockFile_Move_ShouldThrowArgumentExceptionWhenSourceIsEmpty_Message()
+        public async Task MockFile_Move_ShouldThrowArgumentExceptionWhenSourceIsEmpty_Message()
         {
             string destFilePath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
 
-            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Move(string.Empty, destFilePath));
+            var exception = await That(() => fileSystem.File.Move(string.Empty, destFilePath)).Throws<ArgumentException>();
 
-            Assert.That(exception.Message, Does.StartWith("Empty file name is not legal."));
+            await That(exception.Message).StartsWith("Empty file name is not legal.");
         }
 
         [Test]
-        public void MockFile_Move_ShouldThrowArgumentExceptionWhenSourceIsEmpty_ParamName()
+        public async Task MockFile_Move_ShouldThrowArgumentExceptionWhenSourceIsEmpty_ParamName()
         {
             string destFilePath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
 
-            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Move(string.Empty, destFilePath));
+            var exception = await That(() => fileSystem.File.Move(string.Empty, destFilePath)).Throws<ArgumentException>();
 
-            Assert.That(exception.ParamName, Is.EqualTo("sourceFileName"));
+            await That(exception.ParamName).IsEqualTo("sourceFileName");
         }
 
         [Test]
-        public void MockFile_Move_ShouldThrowArgumentExceptionWhenSourceIsStringOfBlanks()
+        public async Task MockFile_Move_ShouldThrowArgumentExceptionWhenSourceIsStringOfBlanks()
         {
             string sourceFilePath = "   ";
             string destFilePath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
 
-            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
+            var exception = await That(() => fileSystem.File.Move(sourceFilePath, destFilePath)).Throws<ArgumentException>();
 
-            Assert.That(exception.Message, Does.StartWith("The path is not of a legal form."));
+            await That(exception.Message).StartsWith("The path is not of a legal form.");
         }
 
         [Test]
-        public void MockFile_Move_ShouldThrowArgumentNullExceptionWhenTargetIsNull_Message()
+        public async Task MockFile_Move_ShouldThrowArgumentNullExceptionWhenTargetIsNull_Message()
         {
             string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
 
-            var exception = Assert.Throws<ArgumentNullException>(() => fileSystem.File.Move(sourceFilePath, null));
+            var exception = await That(() => fileSystem.File.Move(sourceFilePath, null)).Throws<ArgumentNullException>();
 
-            Assert.That(exception.Message, Does.StartWith("File name cannot be null."));
+            await That(exception.Message).StartsWith("File name cannot be null.");
         }
 
         [Test]
-        public void MockFile_Move_ShouldThrowArgumentNullExceptionWhenTargetIsNull_ParamName()
+        public async Task MockFile_Move_ShouldThrowArgumentNullExceptionWhenTargetIsNull_ParamName()
         {
             string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
 
-            var exception = Assert.Throws<ArgumentNullException>(() => fileSystem.File.Move(sourceFilePath, null));
+            var exception = await That(() => fileSystem.File.Move(sourceFilePath, null)).Throws<ArgumentNullException>();
 
-            Assert.That(exception.ParamName, Is.EqualTo("destFileName"));
+            await That(exception.ParamName).IsEqualTo("destFileName");
         }
 
         [Test]
-        public void MockFile_Move_ShouldThrowArgumentExceptionWhenTargetIsStringOfBlanks()
+        public async Task MockFile_Move_ShouldThrowArgumentExceptionWhenTargetIsStringOfBlanks()
         {
             string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
             string destFilePath = "   ";
             var fileSystem = new MockFileSystem();
 
-            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
+            var exception = await That(() => fileSystem.File.Move(sourceFilePath, destFilePath)).Throws<ArgumentException>();
 
-            Assert.That(exception.Message, Does.StartWith("The path is not of a legal form."));
+            await That(exception.Message).StartsWith("The path is not of a legal form.");
         }
 
         [Test]
-        public void MockFile_Move_ShouldThrowArgumentExceptionWhenTargetIsEmpty_Message()
+        public async Task MockFile_Move_ShouldThrowArgumentExceptionWhenTargetIsEmpty_Message()
         {
             string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
 
-            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Move(sourceFilePath, string.Empty));
+            var exception = await That(() => fileSystem.File.Move(sourceFilePath, string.Empty)).Throws<ArgumentException>();
 
-            Assert.That(exception.Message, Does.StartWith("Empty file name is not legal."));
+            await That(exception.Message).StartsWith("Empty file name is not legal.");
         }
 
         [Test]
-        public void MockFile_Move_ShouldThrowArgumentExceptionWhenTargetIsEmpty_ParamName()
+        public async Task MockFile_Move_ShouldThrowArgumentExceptionWhenTargetIsEmpty_ParamName()
         {
             string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
 
-            var exception = Assert.Throws<ArgumentException>(() => fileSystem.File.Move(sourceFilePath, string.Empty));
+            var exception = await That(() => fileSystem.File.Move(sourceFilePath, string.Empty)).Throws<ArgumentException>();
 
-            Assert.That(exception.ParamName, Is.EqualTo("destFileName"));
+            await That(exception.ParamName).IsEqualTo("destFileName");
         }
 
         [Test]
-        public void MockFile_Move_ShouldThrowFileNotFoundExceptionWhenSourceDoesNotExist_Message()
-        {
-            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
-            string destFilePath = XFS.Path(@"c:\something\demo1.txt");
-            var fileSystem = new MockFileSystem();
-
-            var exception = Assert.Throws<FileNotFoundException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
-
-            Assert.That(exception.Message, Is.EqualTo("Could not find file '" + XFS.Path("c:\\something\\demo.txt") + "'."));
-        }
-
-        [Test]
-        public void MockFile_Move_ShouldThrowFileNotFoundExceptionWhenSourceDoesNotExist_FileName()
+        public async Task MockFile_Move_ShouldThrowFileNotFoundExceptionWhenSourceDoesNotExist_Message()
         {
             string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
             string destFilePath = XFS.Path(@"c:\something\demo1.txt");
             var fileSystem = new MockFileSystem();
 
-            var exception = Assert.Throws<FileNotFoundException>(() => fileSystem.File.Move(sourceFilePath, destFilePath));
+            var exception = await That(() => fileSystem.File.Move(sourceFilePath, destFilePath)).Throws<FileNotFoundException>();
 
-            Assert.That(exception.FileName, Is.EqualTo(XFS.Path(@"c:\something\demo.txt")));
+            await That(exception.Message).IsEqualTo("Could not find file '" + XFS.Path("c:\\something\\demo.txt") + "'.");
         }
 
         [Test]
-        public void MockFile_Move_ShouldThrowDirectoryNotFoundExceptionWhenSourcePathDoesNotExist_Message()
+        public async Task MockFile_Move_ShouldThrowFileNotFoundExceptionWhenSourceDoesNotExist_FileName()
+        {
+            string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
+            string destFilePath = XFS.Path(@"c:\something\demo1.txt");
+            var fileSystem = new MockFileSystem();
+
+            var exception = await That(() => fileSystem.File.Move(sourceFilePath, destFilePath)).Throws<FileNotFoundException>();
+
+            await That(exception.FileName).IsEqualTo(XFS.Path(@"c:\something\demo.txt"));
+        }
+
+        [Test]
+        public async Task MockFile_Move_ShouldThrowDirectoryNotFoundExceptionWhenSourcePathDoesNotExist_Message()
         {
             string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
             string destFilePath = XFS.Path(@"c:\somethingelse\demo.txt");
@@ -373,34 +373,35 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 {sourceFilePath, new MockFileData(new byte[] {0})}
             });
 
-            Assert.That(() => fileSystem.File.Move(sourceFilePath, destFilePath),
-                Throws.InstanceOf<DirectoryNotFoundException>().With.Message.StartsWith(@"Could not find a part of the path"));
+            await That(() => fileSystem.File.Move(sourceFilePath, destFilePath))
+                .Throws<DirectoryNotFoundException>()
+                .WithMessage(@"Could not find a part of the path*").AsWildcard();
         }
 
         [Test]
-        public void MockFile_Move_ShouldThrowExceptionWhenSourceDoesNotExist()
+        public async Task MockFile_Move_ShouldThrowExceptionWhenSourceDoesNotExist()
         {
             string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
 
-            TestDelegate action = () => fileSystem.File.Move(sourceFilePath, XFS.Path(@"c:\something\demo2.txt"));
+            Action action = () => fileSystem.File.Move(sourceFilePath, XFS.Path(@"c:\something\demo2.txt"));
 
-            Assert.Throws<FileNotFoundException>(action);
+            await That(action).Throws<FileNotFoundException>();
         }
 
         [Test]
-        public void MockFile_Move_ShouldThrowExceptionWhenSourceDoesNotExist_EvenWhenCopyingToItself()
+        public async Task MockFile_Move_ShouldThrowExceptionWhenSourceDoesNotExist_EvenWhenCopyingToItself()
         {
             string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
 
-            TestDelegate action = () => fileSystem.File.Move(sourceFilePath, XFS.Path(@"c:\something\demo.txt"));
+            Action action = () => fileSystem.File.Move(sourceFilePath, XFS.Path(@"c:\something\demo.txt"));
 
-            Assert.Throws<FileNotFoundException>(action);
+            await That(action).Throws<FileNotFoundException>();
         }
 
         [Test]
-        public void MockFile_Move_ShouldRetainMetadata()
+        public async Task MockFile_Move_ShouldRetainMetadata()
         {
             string sourceFilePath = XFS.Path(@"c:\something\demo.txt");
             string sourceFileContent = "this is some content";
@@ -415,11 +416,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileSystem.File.Move(sourceFilePath, destFilePath);
 
-            Assert.That(fileSystem.File.GetCreationTimeUtc(destFilePath), Is.EqualTo(creationTime.UtcDateTime));
+            await That(fileSystem.File.GetCreationTimeUtc(destFilePath)).IsEqualTo(creationTime.UtcDateTime);
         }
 
         [Test]
-        public void MockFile_Move_ShouldThrowExceptionWhenSourceFileShare_Is_Not_Delete()
+        public async Task MockFile_Move_ShouldThrowExceptionWhenSourceFileShare_Is_Not_Delete()
         {
             string sourceFileReadDelete = XFS.Path(@"c:\something\IHaveReadDelete.txt");
             string sourceFileDelete = XFS.Path(@"c:\something\IHaveDelete.txt");
@@ -433,22 +434,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 { sourceFileNone, new MockFileData("") { AllowedFileShare = FileShare.None } },
             });
 
-            AssertMoveSuccess(sourceFileReadDelete);
-            AssertMoveSuccess(sourceFileDelete);
-            AssertMoveThrowsIOException(sourceFileRead);
-            AssertMoveThrowsIOException(sourceFileNone);
+            await AssertMoveSuccess(sourceFileReadDelete);
+            await AssertMoveSuccess(sourceFileDelete);
+            await AssertMoveThrowsIOException(sourceFileRead);
+            await AssertMoveThrowsIOException(sourceFileNone);
 
-            void AssertMoveThrowsIOException(string sourceFile)
+            async Task AssertMoveThrowsIOException(string sourceFile)
             {
                 var target = sourceFile + ".moved";
-                Assert.Throws<IOException>(() => fileSystem.File.Move(sourceFile, target));
+                await That(() => fileSystem.File.Move(sourceFile, target)).Throws<IOException>();
             }
 
-            void AssertMoveSuccess(string sourceFile)
+            async Task AssertMoveSuccess(string sourceFile)
             {
                 var target = sourceFile + ".moved";
                 fileSystem.File.Move(sourceFile, target);
-                Assert.That(fileSystem.File.Exists(target), Is.True);
+                await That(fileSystem.File.Exists(target)).IsTrue();
             }
         }
     }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileOpenTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileOpenTests.cs
@@ -11,7 +11,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockFileOpenTests
     {
         [Test]
-        public void MockFile_Open_ThrowsOnCreateNewWithExistingFile()
+        public async Task MockFile_Open_ThrowsOnCreateNewWithExistingFile()
         {
             string filepath = XFS.Path(@"c:\something\already\exists.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -19,43 +19,29 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 { filepath, new MockFileData("I'm here") }
             });
 
-            Assert.Throws<IOException>(() => filesystem.File.Open(filepath, FileMode.CreateNew));
+            await That(() => filesystem.File.Open(filepath, FileMode.CreateNew)).Throws<IOException>();
         }
 
         [Test]
-        public void MockFile_Open_ThrowsOnOpenWithMissingFile()
+        public async Task MockFile_Open_ThrowsOnOpenWithMissingFile()
         {
             string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
 
-            Assert.Throws<FileNotFoundException>(() => filesystem.File.Open(filepath, FileMode.Open));
+            await That(() => filesystem.File.Open(filepath, FileMode.Open)).Throws<FileNotFoundException>();
         }
 
         [Test]
-        public void MockFile_Open_ThrowsOnTruncateWithMissingFile()
+        public async Task MockFile_Open_ThrowsOnTruncateWithMissingFile()
         {
             string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
 
-            Assert.Throws<FileNotFoundException>(() => filesystem.File.Open(filepath, FileMode.Truncate));
+            await That(() => filesystem.File.Open(filepath, FileMode.Truncate)).Throws<FileNotFoundException>();
         }
 
         [Test]
-        public void MockFile_Open_CreatesNewFileFileOnCreate()
-        {
-            string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
-            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
-            filesystem.AddDirectory(XFS.Path(@"c:\something\doesnt"));
-
-            var stream = filesystem.File.Open(filepath, FileMode.Create);
-
-            Assert.That(filesystem.File.Exists(filepath), Is.True);
-            Assert.That(stream.Position, Is.EqualTo(0));
-            Assert.That(stream.Length, Is.EqualTo(0));
-        }
-
-        [Test]
-        public void MockFile_Open_AllowsReadWriteOnCreate()
+        public async Task MockFile_Open_CreatesNewFileFileOnCreate()
         {
             string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
@@ -63,12 +49,26 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var stream = filesystem.File.Open(filepath, FileMode.Create);
 
-            Assert.That(stream.CanRead, Is.True);
-            Assert.That(stream.CanWrite, Is.True);
+            await That(filesystem.File.Exists(filepath)).IsTrue();
+            await That(stream.Position).IsEqualTo(0);
+            await That(stream.Length).IsEqualTo(0);
         }
 
         [Test]
-        public void MockFile_Open_CreatesNewFileFileOnCreateNew()
+        public async Task MockFile_Open_AllowsReadWriteOnCreate()
+        {
+            string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
+            var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
+            filesystem.AddDirectory(XFS.Path(@"c:\something\doesnt"));
+
+            var stream = filesystem.File.Open(filepath, FileMode.Create);
+
+            await That(stream.CanRead).IsTrue();
+            await That(stream.CanWrite).IsTrue();
+        }
+
+        [Test]
+        public async Task MockFile_Open_CreatesNewFileFileOnCreateNew()
         {
             string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
@@ -76,13 +76,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var stream = filesystem.File.Open(filepath, FileMode.CreateNew);
 
-            Assert.That(filesystem.File.Exists(filepath), Is.True);
-            Assert.That(stream.Position, Is.EqualTo(0));
-            Assert.That(stream.Length, Is.EqualTo(0));
+            await That(filesystem.File.Exists(filepath)).IsTrue();
+            await That(stream.Position).IsEqualTo(0);
+            await That(stream.Length).IsEqualTo(0);
         }
 
         [Test]
-        public void MockFile_Open_OpensExistingFileOnAppend()
+        public async Task MockFile_Open_OpensExistingFileOnAppend()
         {
             string filepath = XFS.Path(@"c:\something\does\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -93,12 +93,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var stream = filesystem.File.Open(filepath, FileMode.Append);
             var file = filesystem.GetFile(filepath);
 
-            Assert.That(stream.Position, Is.EqualTo(file.Contents.Length));
-            Assert.That(stream.Length, Is.EqualTo(file.Contents.Length));
+            await That(stream.Position).IsEqualTo(file.Contents.Length);
+            await That(stream.Length).IsEqualTo(file.Contents.Length);
         }
 
         [Test]
-        public void MockFile_Open_OpensExistingFileOnTruncate()
+        public async Task MockFile_Open_OpensExistingFileOnTruncate()
         {
             string filepath = XFS.Path(@"c:\something\does\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -109,13 +109,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var stream = filesystem.File.Open(filepath, FileMode.Truncate);
             var file = filesystem.GetFile(filepath);
 
-            Assert.That(stream.Position, Is.EqualTo(0));
-            Assert.That(stream.Length, Is.EqualTo(0));
-            Assert.That(file.Contents.Length, Is.EqualTo(0));
+            await That(stream.Position).IsEqualTo(0);
+            await That(stream.Length).IsEqualTo(0);
+            await That(file.Contents.Length).IsEqualTo(0);
         }
 
         [Test]
-        public void MockFile_Open_OpensExistingFileOnOpen()
+        public async Task MockFile_Open_OpensExistingFileOnOpen()
         {
             string filepath = XFS.Path(@"c:\something\does\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -126,18 +126,18 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var stream = filesystem.File.Open(filepath, FileMode.Open);
             var file = filesystem.GetFile(filepath);
 
-            Assert.That(stream.Position, Is.EqualTo(0));
-            Assert.That(stream.Length, Is.EqualTo(file.Contents.Length));
+            await That(stream.Position).IsEqualTo(0);
+            await That(stream.Length).IsEqualTo(file.Contents.Length);
 
             byte[] data;
             using (var br = new BinaryReader(stream))
                 data = br.ReadBytes((int)stream.Length);
 
-            Assert.That(data, Is.EqualTo(file.Contents));
+            await That(data).IsEqualTo(file.Contents);
         }
 
         [Test]
-        public void MockFile_Open_OpensExistingFileOnOpenOrCreate()
+        public async Task MockFile_Open_OpensExistingFileOnOpenOrCreate()
         {
             string filepath = XFS.Path(@"c:\something\does\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -148,18 +148,18 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var stream = filesystem.File.Open(filepath, FileMode.OpenOrCreate);
             var file = filesystem.GetFile(filepath);
 
-            Assert.That(stream.Position, Is.EqualTo(0));
-            Assert.That(stream.Length, Is.EqualTo(file.Contents.Length));
+            await That(stream.Position).IsEqualTo(0);
+            await That(stream.Length).IsEqualTo(file.Contents.Length);
 
             byte[] data;
             using (var br = new BinaryReader(stream))
                 data = br.ReadBytes((int)stream.Length);
 
-            Assert.That(data, Is.EqualTo(file.Contents));
+            await That(data).IsEqualTo(file.Contents);
         }
 
         [Test]
-        public void MockFile_Open_CreatesNewFileOnOpenOrCreate()
+        public async Task MockFile_Open_CreatesNewFileOnOpenOrCreate()
         {
             string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
@@ -167,13 +167,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var stream = filesystem.File.Open(filepath, FileMode.OpenOrCreate);
 
-            Assert.That(filesystem.File.Exists(filepath), Is.True);
-            Assert.That(stream.Position, Is.EqualTo(0));
-            Assert.That(stream.Length, Is.EqualTo(0));
+            await That(filesystem.File.Exists(filepath)).IsTrue();
+            await That(stream.Position).IsEqualTo(0);
+            await That(stream.Length).IsEqualTo(0);
         }
 
         [Test]
-        public void MockFile_Open_OverwritesExistingFileOnCreate()
+        public async Task MockFile_Open_OverwritesExistingFileOnCreate()
         {
             string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -184,13 +184,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var stream = filesystem.File.Open(filepath, FileMode.Create);
             var file = filesystem.GetFile(filepath);
 
-            Assert.That(stream.Position, Is.EqualTo(0));
-            Assert.That(stream.Length, Is.EqualTo(0));
-            Assert.That(file.Contents.Length, Is.EqualTo(0));
+            await That(stream.Position).IsEqualTo(0);
+            await That(stream.Length).IsEqualTo(0);
+            await That(file.Contents.Length).IsEqualTo(0);
         }
 
         [Test]
-        public void MockFile_OpenText_ShouldRetainLastWriteTime()
+        public async Task MockFile_OpenText_ShouldRetainLastWriteTime()
         {
             // Arrange
             var fs = new MockFileSystem();
@@ -207,11 +207,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             }
 
             // Assert
-            Assert.That(fs.FileInfo.New(filepath).LastWriteTime, Is.EqualTo(lastWriteTime));
+            await That(fs.FileInfo.New(filepath).LastWriteTime).IsEqualTo(lastWriteTime);
         }
 
         [Test]
-        public void MockFile_OpenText_ShouldUpdateLastAccessTime()
+        public async Task MockFile_OpenText_ShouldUpdateLastAccessTime()
         {
             // Arrange
             var fs = new MockFileSystem();
@@ -228,11 +228,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             }
 
             // Assert
-            Assert.That(DateTime.Now - fs.FileInfo.New(filepath).LastAccessTime, Is.LessThanOrEqualTo(TimeSpan.FromSeconds(1)));
+            await That(DateTime.Now - fs.FileInfo.New(filepath).LastAccessTime).IsLessThanOrEqualTo(TimeSpan.FromSeconds(1));
         }
 
         [Test]
-        public void MockFile_Read_ShouldRetainCreationTimeAndUpdateLastAccessTime()
+        public async Task MockFile_Read_ShouldRetainCreationTimeAndUpdateLastAccessTime()
         {
             // Arrange
             var fs = new MockFileSystem();
@@ -252,8 +252,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 #pragma warning restore CA2022
             fi.Refresh();
             // Assert
-            Assert.That(fi.CreationTime, Is.EqualTo(creationTime));
-            Assert.That(DateTime.Now - fi.LastAccessTime, Is.LessThanOrEqualTo(TimeSpan.FromSeconds(1)));
+            await That(fi.CreationTime).IsEqualTo(creationTime);
+            await That(DateTime.Now - fi.LastAccessTime).IsLessThanOrEqualTo(TimeSpan.FromSeconds(1));
         }
 
         [Test]
@@ -280,12 +280,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 #pragma warning restore CA1835
             fi.Refresh();
             // Assert
-            Assert.That(fi.CreationTime, Is.EqualTo(creationTime));
-            Assert.That(DateTime.Now - fi.LastAccessTime, Is.LessThanOrEqualTo(TimeSpan.FromSeconds(1)));
+            await That(fi.CreationTime).IsEqualTo(creationTime);
+            await That(DateTime.Now - fi.LastAccessTime).IsLessThanOrEqualTo(TimeSpan.FromSeconds(1));
         }
 
         [Test]
-        public void MockFile_Write_ShouldRetainCreationTimeAndUpdateLastAccessTimeAndLastWriteTime()
+        public async Task MockFile_Write_ShouldRetainCreationTimeAndUpdateLastAccessTimeAndLastWriteTime()
         {
             // Arrange
             var fs = new MockFileSystem();
@@ -303,9 +303,9 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             stream.Write(buffer, 0, buffer.Length);
             fi.Refresh();
             // Assert
-            Assert.That(fi.CreationTime, Is.EqualTo(creationTime));
-            Assert.That(DateTime.Now - fi.LastAccessTime, Is.LessThanOrEqualTo(TimeSpan.FromSeconds(1)));
-            Assert.That(DateTime.Now - fi.LastWriteTime, Is.LessThanOrEqualTo(TimeSpan.FromSeconds(1)));
+            await That(fi.CreationTime).IsEqualTo(creationTime);
+            await That(DateTime.Now - fi.LastAccessTime).IsLessThanOrEqualTo(TimeSpan.FromSeconds(1));
+            await That(DateTime.Now - fi.LastWriteTime).IsLessThanOrEqualTo(TimeSpan.FromSeconds(1));
         }
 
         [Test]
@@ -327,13 +327,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             await stream.WriteAsync(buffer, 0, buffer.Length);
             fi.Refresh();
             // Assert
-            Assert.That(fi.CreationTime, Is.EqualTo(creationTime));
-            Assert.That(DateTime.Now - fi.LastAccessTime, Is.LessThanOrEqualTo(TimeSpan.FromSeconds(1)));
-            Assert.That(DateTime.Now - fi.LastWriteTime, Is.LessThanOrEqualTo(TimeSpan.FromSeconds(1)));
+            await That(fi.CreationTime).IsEqualTo(creationTime);
+            await That(DateTime.Now - fi.LastAccessTime).IsLessThanOrEqualTo(TimeSpan.FromSeconds(1));
+            await That(DateTime.Now - fi.LastWriteTime).IsLessThanOrEqualTo(TimeSpan.FromSeconds(1));
         }
 
         [Test]
-        public void MockFile_OpenText_ShouldRetainCreationTime()
+        public async Task MockFile_OpenText_ShouldRetainCreationTime()
         {
             // Arrange
             var fs = new MockFileSystem();
@@ -350,33 +350,33 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             }
 
             // Assert
-            Assert.That(fs.FileInfo.New(filepath).CreationTime, Is.EqualTo(creationTime));
+            await That(fs.FileInfo.New(filepath).CreationTime).IsEqualTo(creationTime);
         }
 
         [Test]
-        public void MockFile_Open_ShouldThrowDirectoryNotFoundExceptionIfFileModeCreateAndParentPathDoesNotExist()
+        public async Task MockFile_Open_ShouldThrowDirectoryNotFoundExceptionIfFileModeCreateAndParentPathDoesNotExist()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
             var file = XFS.Path("C:\\path\\NotFound.ext");
 
             // Act
-            TestDelegate action = () => fileSystem.File.Open(file, FileMode.Create);
+            Action action = () => fileSystem.File.Open(file, FileMode.Create);
 
             // Assert
-            var exception = Assert.Throws<DirectoryNotFoundException>(action);
-            Assert.That(exception.Message, Does.StartWith("Could not find a part of the path"));
+            var exception = await That(action).Throws<DirectoryNotFoundException>();
+            await That(exception.Message).StartsWith("Could not find a part of the path");
         }
 
         [Test]
-        public void MockFile_OpenWrite_ShouldWorkWithRelativePath()
+        public async Task MockFile_OpenWrite_ShouldWorkWithRelativePath()
         {
             var file = "file.txt";
             var fileSystem = new MockFileSystem();
 
             fileSystem.File.OpenWrite(file).Close();
 
-            Assert.That(fileSystem.File.Exists(file));
+            await That(fileSystem.File.Exists(file)).IsTrue();
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileReadAllBytesTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileReadAllBytesTests.cs
@@ -9,7 +9,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockFileReadAllBytesTests
     {
         [Test]
-        public void MockFile_ReadAllBytes_ShouldReturnOriginalByteData()
+        public async Task MockFile_ReadAllBytes_ShouldReturnOriginalByteData()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -21,12 +21,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = file.ReadAllBytes(XFS.Path(@"c:\something\other.gif"));
 
-            Assert.That(result,
-                Is.EqualTo(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }));
+            await That(result)
+                .IsEqualTo(new byte[] { 0x21, 0x58, 0x3f, 0xa9 });
         }
 
         [Test]
-        public void MockFile_ReadAllBytes_ShouldReturnDataSavedByWriteAllBytes()
+        public async Task MockFile_ReadAllBytes_ShouldReturnDataSavedByWriteAllBytes()
         {
             string path = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem();
@@ -35,22 +35,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileSystem.File.WriteAllBytes(path, fileContent);
 
-            Assert.That(fileSystem.File.ReadAllBytes(path), Is.EqualTo(fileContent));
+            await That(fileSystem.File.ReadAllBytes(path)).IsEqualTo(fileContent);
         }
 
         [Test]
-        public void MockFile_ReadAllBytes_ShouldThrowFileNotFoundExceptionIfFileDoesNotExist()
+        public async Task MockFile_ReadAllBytes_ShouldThrowFileNotFoundExceptionIfFileDoesNotExist()
         {
             var fileSystem = new MockFileSystem();
             var file = new MockFile(fileSystem);
 
-            TestDelegate action = () => file.ReadAllBytes(@"C:\a.txt");
+            Action action = () => file.ReadAllBytes(@"C:\a.txt");
 
-            Assert.Throws<FileNotFoundException>(action);
+            await That(action).Throws<FileNotFoundException>();
         }
 
         [Test]
-        public void MockFile_ReadAllBytes_ShouldTolerateAltDirectorySeparatorInPath()
+        public async Task MockFile_ReadAllBytes_ShouldTolerateAltDirectorySeparatorInPath()
         {
             var fileSystem = new MockFileSystem();
             var path = XFS.Path("C:" + fileSystem.Path.DirectorySeparatorChar + "test.dat");
@@ -59,11 +59,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileSystem.AddFile(path, new MockFileData(data));
 
-            Assert.That(fileSystem.File.ReadAllBytes(altPath), Is.EqualTo(data));
+            await That(fileSystem.File.ReadAllBytes(altPath)).IsEqualTo(data);
         }
 
         [Test]
-        public void MockFile_ReadAllBytes_ShouldReturnANewCopyOfTheFileContents()
+        public async Task MockFile_ReadAllBytes_ShouldReturnANewCopyOfTheFileContents()
         {
             var path = XFS.Path(@"c:\something\demo.bin");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -80,7 +80,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 firstRead[i] += 1;
             }
 
-            Assert.That(firstRead, Is.Not.EqualTo(secondRead));
+            await That(firstRead).IsNotEqualTo(secondRead);
         }
 
 #if FEATURE_ASYNC_FILE
@@ -97,8 +97,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = await file.ReadAllBytesAsync(XFS.Path(@"c:\something\other.gif"));
 
-            Assert.That(result,
-                Is.EqualTo(new byte[] { 0x21, 0x58, 0x3f, 0xa9 }));
+            await That(result)
+                .IsEqualTo(new byte[] { 0x21, 0x58, 0x3f, 0xa9 });
         }
 
         [Test]
@@ -111,29 +111,29 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileSystem.File.WriteAllBytes(path, fileContent);
 
-            Assert.That(await fileSystem.File.ReadAllBytesAsync(path), Is.EqualTo(fileContent));
+            await That(await fileSystem.File.ReadAllBytesAsync(path)).IsEqualTo(fileContent);
         }
 
         [Test]
-        public void MockFile_ReadAllBytesAsync_ShouldThrowFileNotFoundExceptionIfFileDoesNotExist()
+        public async Task MockFile_ReadAllBytesAsync_ShouldThrowFileNotFoundExceptionIfFileDoesNotExist()
         {
             var fileSystem = new MockFileSystem();
             var file = new MockFile(fileSystem);
 
-            AsyncTestDelegate action = async () => await file.ReadAllBytesAsync(@"C:\a.txt");
+            Func<Task> action = async () => await file.ReadAllBytesAsync(@"C:\a.txt");
 
-            Assert.ThrowsAsync<FileNotFoundException>(action);
+            await That(action).Throws<FileNotFoundException>();
         }
 
         [Test]
-        public void MockFile_ReadAllBytesAsync_ShouldThrowOperationCanceledExceptionIfCanceled()
+        public async Task MockFile_ReadAllBytesAsync_ShouldThrowOperationCanceledExceptionIfCanceled()
         {
             var fileSystem = new MockFileSystem();
 
-            AsyncTestDelegate action = async () =>
+            Func<Task> action = async () =>
                 await fileSystem.File.ReadAllBytesAsync(@"C:\a.txt", new CancellationToken(canceled: true));
 
-            Assert.ThrowsAsync<OperationCanceledException>(action);
+            await That(action).Throws<OperationCanceledException>();
         }
 
         [Test]
@@ -146,7 +146,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             fileSystem.AddFile(path, new MockFileData(data));
 
-            Assert.That(await fileSystem.File.ReadAllBytesAsync(altPath), Is.EqualTo(data));
+            await That(await fileSystem.File.ReadAllBytesAsync(altPath)).IsEqualTo(data);
         }
 #endif
     }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileReadAllLinesTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileReadAllLinesTests.cs
@@ -14,7 +14,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockFileReadAllLinesTests
     {
         [Test]
-        public void MockFile_ReadAllLines_ShouldReturnOriginalTextData()
+        public async Task MockFile_ReadAllLines_ShouldReturnOriginalTextData()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -29,12 +29,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.ReadAllLines(XFS.Path(@"c:\something\demo.txt"));
 
             // Assert
-            Assert.That(result,
-                Is.EqualTo(new[] { "Demo", "text", "content", "value" }));
+            await That(result)
+                .IsEqualTo(new[] { "Demo", "text", "content", "value" });
         }
 
         [Test]
-        public void MockFile_ReadAllLines_ShouldReturnOriginalDataWithCustomEncoding()
+        public async Task MockFile_ReadAllLines_ShouldReturnOriginalDataWithCustomEncoding()
         {
             // Arrange
             string text = "Hello\r\nthere\rBob\nBob!";
@@ -50,27 +50,27 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.ReadAllLines(XFS.Path(@"c:\something\demo.txt"), Encoding.BigEndianUnicode);
 
             // Assert
-            Assert.That(result,
-                Is.EqualTo(new[] { "Hello", "there", "Bob", "Bob!" }));
+            await That(result)
+                .IsEqualTo(new[] { "Hello", "there", "Bob", "Bob!" });
         }
 
         [Test]
-        public void MockFile_ReadAllLines_NotExistingFile_ThrowsCorrectFileNotFoundException()
+        public async Task MockFile_ReadAllLines_NotExistingFile_ThrowsCorrectFileNotFoundException()
         {
             var absentFileNameFullPath = XFS.Path(@"c:\you surely don't have such file.hope-so");
             var mockFileSystem = new MockFileSystem();
 
-            var act = new TestDelegate(() =>
+            var act = new Action(() =>
                 mockFileSystem.File.ReadAllLines(absentFileNameFullPath)
             );
 
-            var exception = Assert.Catch<FileNotFoundException>(act);
-            Assert.That(exception.FileName, Is.EqualTo(absentFileNameFullPath));
-            Assert.That(exception.Message, Is.EqualTo("Could not find file '" + absentFileNameFullPath + "'."));
+            var exception = await That(act).Throws<FileNotFoundException>();
+            await That(exception.FileName).IsEqualTo(absentFileNameFullPath);
+            await That(exception.Message).IsEqualTo("Could not find file '" + absentFileNameFullPath + "'.");
         }
 
         [Test]
-        public void MockFile_ReadAllLines_ShouldNotReturnBom()
+        public async Task MockFile_ReadAllLines_ShouldNotReturnBom()
         {
             // Arrange
             var testFilePath = XFS.Path(@"c:\a test file.txt");
@@ -82,8 +82,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.File.ReadAllLines(testFilePath, Encoding.UTF8);
 
             // Assert
-            Assert.That(result.Length, Is.EqualTo(1));
-            Assert.That(result[0], Is.EqualTo(testText));
+            await That(result.Length).IsEqualTo(1);
+            await That(result[0]).IsEqualTo(testText);
         }
 #if FEATURE_ASYNC_FILE
         [Test]
@@ -102,7 +102,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = await file.ReadAllLinesAsync(XFS.Path(@"c:\something\demo.txt"));
 
             // Assert
-            Assert.That(result, Is.EqualTo(new[] { "Demo", "text", "content", "value" }));
+            await That(result).IsEqualTo(new[] { "Demo", "text", "content", "value" });
         }
 
         [Test]
@@ -122,33 +122,33 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = await file.ReadAllLinesAsync(XFS.Path(@"c:\something\demo.txt"), Encoding.BigEndianUnicode);
 
             // Assert
-            Assert.That(result, Is.EqualTo(new[] { "Hello", "there", "Bob", "Bob!" }));
+            await That(result).IsEqualTo(new[] { "Hello", "there", "Bob", "Bob!" });
         }
 
         [Test]
-        public void MockFile_ReadAllLinesAsync_ShouldThrowOperationCanceledExceptionIfCanceled()
+        public async Task MockFile_ReadAllLinesAsync_ShouldThrowOperationCanceledExceptionIfCanceled()
         {
             var fileSystem = new MockFileSystem();
 
-            AsyncTestDelegate action = async () =>
+            Func<Task> action = async () =>
                 await fileSystem.File.ReadAllLinesAsync(@"C:\a.txt", new CancellationToken(canceled: true));
 
-            Assert.ThrowsAsync<OperationCanceledException>(action);
+            await That(action).Throws<OperationCanceledException>();
         }
 
         [Test]
-        public void MockFile_ReadAllLinesAsync_NotExistingFile_ThrowsCorrectFileNotFoundException()
+        public async Task MockFile_ReadAllLinesAsync_NotExistingFile_ThrowsCorrectFileNotFoundException()
         {
             var absentFileNameFullPath = XFS.Path(@"c:\you surely don't have such file.hope-so");
             var mockFileSystem = new MockFileSystem();
 
-            var act = new AsyncTestDelegate(async () =>
+            var act = new Func<Task>(async () =>
                 await mockFileSystem.File.ReadAllLinesAsync(absentFileNameFullPath)
             );
 
-            var exception = Assert.CatchAsync<FileNotFoundException>(act);
-            Assert.That(exception.FileName, Is.EqualTo(absentFileNameFullPath));
-            Assert.That(exception.Message, Is.EqualTo("Could not find file '" + absentFileNameFullPath + "'."));
+            var exception = await That(act).Throws<FileNotFoundException>();
+            await That(exception.FileName).IsEqualTo(absentFileNameFullPath);
+            await That(exception.Message).IsEqualTo("Could not find file '" + absentFileNameFullPath + "'.");
         }
 
 #if FEATURE_READ_LINES_ASYNC
@@ -166,12 +166,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Act
             var enumerable = file.ReadLinesAsync(XFS.Path(@"c:\something\demo.txt"));
-            StringCollection result = new();
+            List<string> result = new();
             await foreach (var line in enumerable)
                 result.Add(line);
 
             // Assert
-            Assert.That(result, Is.EqualTo(new[] { "Demo", "text", "content", "value" }));
+            await That(result).IsEqualTo(new[] { "Demo", "text", "content", "value" });
         }
 
         [Test]
@@ -189,43 +189,43 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Act
             var enumerable = file.ReadLinesAsync(XFS.Path(@"c:\something\demo.txt"), Encoding.BigEndianUnicode);
-            StringCollection result = new();
+            List<string> result = new();
             await foreach (var line in enumerable)
                 result.Add(line);
 
             // Assert
-            Assert.That(result, Is.EqualTo(new[] { "Hello", "there", "Bob", "Bob!" }));
+            await That(result).IsEqualTo(new[] { "Hello", "there", "Bob", "Bob!" });
         }
 
         [Test]
-        public void MockFile_ReadLinesAsync_ShouldThrowOperationCanceledExceptionIfCanceled()
+        public async Task MockFile_ReadLinesAsync_ShouldThrowOperationCanceledExceptionIfCanceled()
         {
             var fileSystem = new MockFileSystem();
 
-            AsyncTestDelegate action = async () =>
+            Func<Task> action = async () =>
             {
                 var enumerable = fileSystem.File.ReadLinesAsync(@"C:\a.txt", new CancellationToken(canceled: true));
                 await foreach (var line in enumerable);
             };
 
-            Assert.ThrowsAsync<OperationCanceledException>(action);
+            await That(action).Throws<OperationCanceledException>();
         }
 
         [Test]
-        public void MockFile_ReadLinesAsync_NotExistingFile_ThrowsCorrectFileNotFoundException()
+        public async Task MockFile_ReadLinesAsync_NotExistingFile_ThrowsCorrectFileNotFoundException()
         {
             var absentFileNameFullPath = XFS.Path(@"c:\you surely don't have such file.hope-so");
             var mockFileSystem = new MockFileSystem();
 
-            AsyncTestDelegate action = async () =>
+            Func<Task> action = async () =>
             {
                 var enumerable = mockFileSystem.File.ReadLinesAsync(absentFileNameFullPath);
                 await foreach (var line in enumerable) ;
             };
 
-            var exception = Assert.CatchAsync<FileNotFoundException>(action);
-            Assert.That(exception.FileName, Is.EqualTo(absentFileNameFullPath));
-            Assert.That(exception.Message, Is.EqualTo("Could not find file '" + absentFileNameFullPath + "'."));
+            var exception = await That(action).Throws<FileNotFoundException>();
+            await That(exception.FileName).IsEqualTo(absentFileNameFullPath);
+            await That(exception.Message).IsEqualTo("Could not find file '" + absentFileNameFullPath + "'.");
         }
 #endif
 #endif

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileReadLinesTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileReadLinesTests.cs
@@ -11,7 +11,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockFileReadLinesTests
     {
         [Test]
-        public void MockFile_ReadLines_ShouldReturnOriginalTextData()
+        public async Task MockFile_ReadLines_ShouldReturnOriginalTextData()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -26,11 +26,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.ReadLines(XFS.Path(@"c:\something\demo.txt"));
 
             // Assert
-            Assert.That(result, Is.EqualTo(new[] { "Demo", "text", "content", "value" }));
+            await That(result).IsEqualTo(new[] { "Demo", "text", "content", "value" });
         }
 
         [Test]
-        public void MockFile_ReadLines_ShouldReturnOriginalDataWithCustomEncoding()
+        public async Task MockFile_ReadLines_ShouldReturnOriginalDataWithCustomEncoding()
         {
             // Arrange
             string text = "Hello\r\nthere\rBob\nBob!";
@@ -46,7 +46,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.ReadLines(XFS.Path(@"c:\something\demo.txt"), Encoding.BigEndianUnicode);
 
             // Assert
-            Assert.That(result, Is.EqualTo(new[] { "Hello", "there", "Bob", "Bob!" }));
+            await That(result).IsEqualTo(new[] { "Hello", "there", "Bob", "Bob!" });
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSetAccessControlTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSetAccessControlTests.cs
@@ -13,22 +13,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     {
         [TestCase(" ")]
         [TestCase("   ")]
-        public void MockFile_SetAccessControl_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
+        public async Task MockFile_SetAccessControl_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
             var fileSecurity = new FileSecurity();
 
             // Act
-            TestDelegate action = () => fileSystem.File.SetAccessControl(path, fileSecurity);
+            Action action = () => fileSystem.File.SetAccessControl(path, fileSecurity);
 
             // Assert
-            var exception = Assert.Throws<ArgumentException>(action);
-            Assert.That(exception.ParamName, Is.EqualTo("path"));
+            var exception = await That(action).Throws<ArgumentException>();
+            await That(exception.ParamName).IsEqualTo("path");
         }
 
         [Test]
-        public void MockFile_SetAccessControl_ShouldThrowFileNotFoundExceptionIfFileDoesNotExistInMockData()
+        public async Task MockFile_SetAccessControl_ShouldThrowFileNotFoundExceptionIfFileDoesNotExistInMockData()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -36,15 +36,15 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileSecurity = new FileSecurity();
 
             // Act
-            TestDelegate action = () => fileSystem.File.SetAccessControl(expectedFileName, fileSecurity);
+            Action action = () => fileSystem.File.SetAccessControl(expectedFileName, fileSecurity);
 
             // Assert
-            var exception = Assert.Throws<FileNotFoundException>(action);
-            Assert.That(exception.FileName, Is.EqualTo(expectedFileName));
+            var exception = await That(action).Throws<FileNotFoundException>();
+            await That(exception.FileName).IsEqualTo(expectedFileName);
         }
 
         [Test]
-        public void MockFile_SetAccessControl_ShouldSetAccessControlOfFileData()
+        public async Task MockFile_SetAccessControl_ShouldSetAccessControlOfFileData()
         {
             // Arrange
             var filePath = XFS.Path(@"c:\a.txt");
@@ -62,7 +62,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             var accessControl = fileSystem.File.GetAccessControl(filePath);
-            Assert.That(accessControl, Is.EqualTo(expectedAccessControl));
+            await That(accessControl).IsEqualTo(expectedAccessControl);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSetAttributesTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSetAttributesTests.cs
@@ -8,7 +8,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockFileSetAttributesTests
     {
         [Test]
-        public void MockFile_SetAttributes_ShouldSetAttributesOnFile()
+        public async Task MockFile_SetAttributes_ShouldSetAttributesOnFile()
         {
             var path = XFS.Path(@"c:\something\demo.txt");
             var filedata = new MockFileData("test");
@@ -20,11 +20,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.File.SetAttributes(path, FileAttributes.Hidden);
 
             var attributes = fileSystem.File.GetAttributes(path);
-            Assert.That(attributes, Is.EqualTo(FileAttributes.Hidden));
+            await That(attributes).IsEqualTo(FileAttributes.Hidden);
         }
 
         [Test]
-        public void MockFile_SetAttributes_ShouldSetAttributesOnDirectory()
+        public async Task MockFile_SetAttributes_ShouldSetAttributesOnDirectory()
         {
             var fileSystem = new MockFileSystem();
             var path = XFS.Path(@"c:\something");
@@ -35,32 +35,32 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.File.SetAttributes(path, FileAttributes.Directory | FileAttributes.Hidden);
 
             var attributes = fileSystem.File.GetAttributes(path);
-            Assert.That(attributes, Is.EqualTo(FileAttributes.Directory | FileAttributes.Hidden));
+            await That(attributes).IsEqualTo(FileAttributes.Directory | FileAttributes.Hidden);
         }
 
         [Test]
         [TestCase("", FileAttributes.Normal)]
         [TestCase("   ", FileAttributes.Normal)]
-        public void MockFile_SetAttributes_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path, FileAttributes attributes)
+        public async Task MockFile_SetAttributes_ShouldThrowArgumentExceptionIfPathContainsOnlyWhitespaces(string path, FileAttributes attributes)
         {
             var fileSystem = new MockFileSystem();
 
-            TestDelegate action = () => fileSystem.File.SetAttributes(path, attributes);
+            Action action = () => fileSystem.File.SetAttributes(path, attributes);
 
-            Assert.Throws<ArgumentException>(action);
+            await That(action).Throws<ArgumentException>();
         }
 
         [Test]
-        public void MockFile_SetAttributes_ShouldThrowFileNotFoundExceptionIfMissingDirectory()
+        public async Task MockFile_SetAttributes_ShouldThrowFileNotFoundExceptionIfMissingDirectory()
         {
             var path = XFS.Path(@"C:\something");
             var attributes = FileAttributes.Normal;
             var fileSystem = new MockFileSystem();
 
-            TestDelegate action = () => fileSystem.File.SetAttributes(path, attributes);
+            Action action = () => fileSystem.File.SetAttributes(path, attributes);
 
-            var exception = Assert.Throws<FileNotFoundException>(action);
-            Assert.That(exception.FileName, Is.EqualTo(path));
+            var exception = await That(action).Throws<FileNotFoundException>();
+            await That(exception.FileName).IsEqualTo(path);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSetUnixFileModeTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSetUnixFileModeTests.cs
@@ -14,7 +14,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockFileSetUnixFileModeTests
     {
         [Test]
-        public void MockFile_SetUnixFileMode_ShouldSetSpecifiedAccessMode([Values] UnixFileMode unixFileMode)
+        public async Task MockFile_SetUnixFileMode_ShouldSetSpecifiedAccessMode([Values] UnixFileMode unixFileMode)
         {
             // Arrange
             var mockFileData = new MockFileData("Demo text content");
@@ -27,13 +27,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.File.SetUnixFileMode(XFS.Path(@"C:\something\some.txt"), unixFileMode);
 
             // Assert
-            Assert.That(mockFileData.UnixMode, Is.EqualTo(unixFileMode));
+            await That(mockFileData.UnixMode).IsEqualTo(unixFileMode);
         }
         
         [TestCase(UnixFileMode.UserRead | UnixFileMode.GroupRead | UnixFileMode.OtherRead)]
         [TestCase(UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute)]
         [TestCase(UnixFileMode.UserExecute | UnixFileMode.OtherWrite | UnixFileMode.GroupRead)]
-        public void MockFile_SetUnixFileMode_ShouldSetSpecifiedAccessModeFlags(UnixFileMode unixFileMode)
+        public async Task MockFile_SetUnixFileMode_ShouldSetSpecifiedAccessModeFlags(UnixFileMode unixFileMode)
         {
             // Arrange
             var mockFileData = new MockFileData("Demo text content");
@@ -46,7 +46,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.File.SetUnixFileMode(XFS.Path(@"C:\something\some.txt"), unixFileMode);
 
             // Assert
-            Assert.That(mockFileData.UnixMode, Is.EqualTo(unixFileMode));
+            await That(mockFileData.UnixMode).IsEqualTo(unixFileMode);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileStreamFactoryTests.cs
@@ -12,7 +12,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         [TestCase(FileMode.Create)]
         [TestCase(FileMode.Append)]
-        public void MockFileStreamFactory_CreateForExistingFile_ShouldReturnStream(FileMode fileMode)
+        public async Task MockFileStreamFactory_CreateForExistingFile_ShouldReturnStream(FileMode fileMode)
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -26,13 +26,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileStreamFactory.New(@"c:\existing.txt", fileMode, FileAccess.Write);
 
             // Assert
-            Assert.That(result, Is.Not.Null);
+            await That(result).IsNotNull();
         }
 
         [Test]
         [TestCase(FileMode.Create)]
         [TestCase(FileMode.Append)]
-        public void MockFileStreamFactory_CreateForNonExistingFile_ShouldReturnStream(FileMode fileMode)
+        public async Task MockFileStreamFactory_CreateForNonExistingFile_ShouldReturnStream(FileMode fileMode)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -42,12 +42,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileStreamFactory.New(XFS.Path(@"c:\not_existing.txt"), fileMode, FileAccess.Write);
 
             // Assert
-            Assert.That(result, Is.Not.Null);
+            await That(result).IsNotNull();
         }
 
         [Test]
         [TestCase(FileMode.Create)]
-        public void MockFileStreamFactory_CreateForAnExistingFile_ShouldReplaceFileContents(FileMode fileMode)
+        public async Task MockFileStreamFactory_CreateForAnExistingFile_ShouldReplaceFileContents(FileMode fileMode)
         {
             var fileSystem = new MockFileSystem();
             string FilePath = XFS.Path("C:\\File.txt");
@@ -65,14 +65,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             }
 
             var text = fileSystem.File.ReadAllText(FilePath);
-            Assert.That(text, Is.EqualTo("AAAAA"));
+            await That(text).IsEqualTo("AAAAA");
         }
 
         [Test]
         [TestCase(FileMode.Create)]
         [TestCase(FileMode.Open)]
         [TestCase(FileMode.CreateNew)]
-        public void MockFileStreamFactory_CreateInNonExistingDirectory_ShouldThrowDirectoryNotFoundException(FileMode fileMode)
+        public async Task MockFileStreamFactory_CreateInNonExistingDirectory_ShouldThrowDirectoryNotFoundException(FileMode fileMode)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -82,18 +82,18 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileStreamFactory = new MockFileStreamFactory(fileSystem);
 
             // Assert
-            Assert.Throws<DirectoryNotFoundException>(() => fileStreamFactory.New(XFS.Path(@"C:\Test\NonExistingDirectory\some_random_file.txt"), fileMode));
+            await That(() => fileStreamFactory.New(XFS.Path(@"C:\Test\NonExistingDirectory\some_random_file.txt"), fileMode)).Throws<DirectoryNotFoundException>();
         }
 
         [Test]
-        public void MockFileStreamFactory_AppendAccessWithReadWriteMode_ShouldThrowArgumentException()
+        public async Task MockFileStreamFactory_AppendAccessWithReadWriteMode_ShouldThrowArgumentException()
         {
             var fileSystem = new MockFileSystem();
             
-            Assert.Throws<ArgumentException>(() =>
+            await That(() =>
             {
                 fileSystem.FileStream.New(XFS.Path(@"c:\path.txt"), FileMode.Append, FileAccess.ReadWrite);
-            });
+            }).Throws<ArgumentException>();
         }
 
         [Test]
@@ -102,20 +102,20 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [TestCase(FileMode.Create)]
         [TestCase(FileMode.CreateNew)]
         [TestCase(FileMode.Append)]
-        public void MockFileStreamFactory_InvalidModeForReadAccess_ShouldThrowArgumentException(FileMode fileMode)
+        public async Task MockFileStreamFactory_InvalidModeForReadAccess_ShouldThrowArgumentException(FileMode fileMode)
         {
             var fileSystem = new MockFileSystem();
 
-            Assert.Throws<ArgumentException>(() =>
+            await That(() =>
             {
                 fileSystem.FileStream.New(XFS.Path(@"c:\path.txt"), fileMode, FileAccess.Read);
-            });
+            }).Throws<ArgumentException>();
         }
 
         [Test]
         [TestCase(FileMode.Open)]
         [TestCase(FileMode.Truncate)]
-        public void MockFileStreamFactory_OpenNonExistingFile_ShouldThrowFileNotFoundException(FileMode fileMode)
+        public async Task MockFileStreamFactory_OpenNonExistingFile_ShouldThrowFileNotFoundException(FileMode fileMode)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -125,12 +125,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileStreamFactory = new MockFileStreamFactory(fileSystem);
 
             // Assert
-            Assert.Throws<FileNotFoundException>(() => fileStreamFactory.New(XFS.Path(@"C:\Test\some_random_file.txt"), fileMode));
+            await That(() => fileStreamFactory.New(XFS.Path(@"C:\Test\some_random_file.txt"), fileMode)).Throws<FileNotFoundException>();
         }
 
         [Test]
         [TestCase(FileMode.CreateNew)]
-        public void MockFileStreamFactory_CreateExistingFile_Should_Throw_IOException(FileMode fileMode)
+        public async Task MockFileStreamFactory_CreateExistingFile_Should_Throw_IOException(FileMode fileMode)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -141,7 +141,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileStreamFactory = new MockFileStreamFactory(fileSystem);
 
             // Assert
-            Assert.Throws<IOException>(() => fileStreamFactory.New(path, fileMode));
+            await That(() => fileStreamFactory.New(path, fileMode)).Throws<IOException>();
 
         }
 
@@ -149,7 +149,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [TestCase(FileMode.Create)]
         [TestCase(FileMode.CreateNew)]
         [TestCase(FileMode.OpenOrCreate)]
-        public void MockFileStreamFactory_CreateWithRelativePath_CreatesFileInCurrentDirectory(FileMode fileMode)
+        public async Task MockFileStreamFactory_CreateWithRelativePath_CreatesFileInCurrentDirectory(FileMode fileMode)
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -159,11 +159,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileStreamFactory.New("some_random_file.txt", fileMode);
 
             // Assert
-            Assert.That(fileSystem.File.Exists(XFS.Path("./some_random_file.txt")), Is.True);
+            await That(fileSystem.File.Exists(XFS.Path("./some_random_file.txt"))).IsTrue();
         }
 
         [Test]
-        public void MockFileStream_CanRead_ReturnsFalseForAWriteOnlyStream()
+        public async Task MockFileStream_CanRead_ReturnsFalseForAWriteOnlyStream()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -172,7 +172,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileStream = fileSystem.FileStream.New("file.txt", FileMode.CreateNew, FileAccess.Write);
 
             // Assert
-            Assert.That(fileStream.CanRead, Is.False);
+            await That(fileStream.CanRead).IsFalse();
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSymlinkTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSymlinkTests.cs
@@ -11,7 +11,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 #if FEATURE_CREATE_SYMBOLIC_LINK
 
         [Test]
-        public void MockFile_CreateSymbolicLink_ShouldReturnFileSystemInfo()
+        public async Task MockFile_CreateSymbolicLink_ShouldReturnFileSystemInfo()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -24,12 +24,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             IFileSystemInfo fileSystemInfo = fileSystem.File.CreateSymbolicLink(path, pathToTarget);
 
             // Assert
-            Assert.That(fileSystemInfo.FullName, Is.EqualTo(path));
-            Assert.That(fileSystemInfo.LinkTarget, Is.EqualTo(pathToTarget));
+            await That(fileSystemInfo.FullName).IsEqualTo(path);
+            await That(fileSystemInfo.LinkTarget).IsEqualTo(pathToTarget);
         }
 
         [Test]
-        public void MockFile_CreateSymbolicLink_ShouldSucceedFromFileInfo()
+        public async Task MockFile_CreateSymbolicLink_ShouldSucceedFromFileInfo()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -43,12 +43,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             IFileInfo directoryInfo = fileSystem.FileInfo.New(path);
 
             // Assert
-            Assert.That(directoryInfo.FullName, Is.EqualTo(path));
-            Assert.That(directoryInfo.LinkTarget, Is.EqualTo(pathToTarget));
+            await That(directoryInfo.FullName).IsEqualTo(path);
+            await That(directoryInfo.LinkTarget).IsEqualTo(pathToTarget);
         }
 
         [Test]
-        public void MockFile_CreateSymbolicLink_ShouldFailWithNullPath()
+        public async Task MockFile_CreateSymbolicLink_ShouldFailWithNullPath()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -57,14 +57,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddFile(pathToTarget, data);
 
             // Act
-            var ex = Assert.Throws<ArgumentNullException>(() => fileSystem.File.CreateSymbolicLink(null, pathToTarget));
+            var ex = await That(() => fileSystem.File.CreateSymbolicLink(null, pathToTarget)).Throws<ArgumentNullException>();
 
             // Assert
-            Assert.That(ex.ParamName, Is.EqualTo("path"));
+            await That(ex.ParamName).IsEqualTo("path");
         }
 
         [Test]
-        public void MockFile_CreateSymbolicLink_ShouldFailWithNullTarget()
+        public async Task MockFile_CreateSymbolicLink_ShouldFailWithNullTarget()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -73,14 +73,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddFile(path, data);
 
             // Act
-            var ex = Assert.Throws<ArgumentNullException>(() => fileSystem.File.CreateSymbolicLink(path, null));
+            var ex = await That(() => fileSystem.File.CreateSymbolicLink(path, null)).Throws<ArgumentNullException>();
 
             // Assert
-            Assert.That(ex.ParamName, Is.EqualTo("pathToTarget"));
+            await That(ex.ParamName).IsEqualTo("pathToTarget");
         }
 
         [Test]
-        public void MockFile_CreateSymbolicLink_ShouldFailWithEmptyPath()
+        public async Task MockFile_CreateSymbolicLink_ShouldFailWithEmptyPath()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -89,14 +89,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddFile(pathToTarget, data);
 
             // Act
-            var ex = Assert.Throws<ArgumentException>(() => fileSystem.File.CreateSymbolicLink("", pathToTarget));
+            var ex = await That(() => fileSystem.File.CreateSymbolicLink("", pathToTarget)).Throws<ArgumentException>();
 
             // Assert
-            Assert.That(ex.ParamName, Is.EqualTo("path"));
+            await That(ex.ParamName).IsEqualTo("path");
         }
 
         [Test]
-        public void MockFile_CreateSymbolicLink_ShouldFailWithEmptyTarget()
+        public async Task MockFile_CreateSymbolicLink_ShouldFailWithEmptyTarget()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -105,14 +105,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddFile(path, data);
 
             // Act
-            var ex = Assert.Throws<ArgumentException>(() => fileSystem.File.CreateSymbolicLink(path, ""));
+            var ex = await That(() => fileSystem.File.CreateSymbolicLink(path, "")).Throws<ArgumentException>();
 
             // Assert
-            Assert.That(ex.ParamName, Is.EqualTo("pathToTarget"));
+            await That(ex.ParamName).IsEqualTo("pathToTarget");
         }
 
         [Test]
-        public void MockFile_CreateSymbolicLink_ShouldFailWithIllegalPath()
+        public async Task MockFile_CreateSymbolicLink_ShouldFailWithIllegalPath()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -121,14 +121,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddFile(pathToTarget, data);
 
             // Act
-            var ex = Assert.Throws<ArgumentException>(() => fileSystem.File.CreateSymbolicLink(" ", pathToTarget));
+            var ex = await That(() => fileSystem.File.CreateSymbolicLink(" ", pathToTarget)).Throws<ArgumentException>();
 
             // Assert
-            Assert.That(ex.ParamName, Is.EqualTo("path"));
+            await That(ex.ParamName).IsEqualTo("path");
         }
 
         [Test]
-        public void MockFile_CreateSymbolicLink_ShouldFailWithIllegalTarget()
+        public async Task MockFile_CreateSymbolicLink_ShouldFailWithIllegalTarget()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -137,15 +137,15 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddFile(path, data);
 
             // Act
-            var ex = Assert.Throws<ArgumentException>(() => fileSystem.File.CreateSymbolicLink(path, " "));
+            var ex = await That(() => fileSystem.File.CreateSymbolicLink(path, " ")).Throws<ArgumentException>();
 
             // Assert
-            Assert.That(ex.ParamName, Is.EqualTo("pathToTarget"));
+            await That(ex.ParamName).IsEqualTo("pathToTarget");
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.StrictPathRules)]
-        public void MockFile_CreateSymbolicLink_ShouldFailWithIllegalCharactersInPath()
+        public async Task MockFile_CreateSymbolicLink_ShouldFailWithIllegalCharactersInPath()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -154,30 +154,30 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddFile(pathToTarget, data);
 
             // Act
-            TestDelegate ex = () => fileSystem.File.CreateSymbolicLink(@"C:\bar.txt_?_", pathToTarget);
+            Action ex = () => fileSystem.File.CreateSymbolicLink(@"C:\bar.txt_?_", pathToTarget);
 
             // Assert
-            Assert.Throws<ArgumentException>(ex);
+            await That(ex).Throws<ArgumentException>();
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.StrictPathRules)]
 
-        public void MockFile_CreateSymbolicLink_ShouldFailWithIllegalCharactersInTarget()
+        public async Task MockFile_CreateSymbolicLink_ShouldFailWithIllegalCharactersInTarget()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
             string path = XFS.Path(@"C:\Folder\foo.txt");
 
             // Act
-            TestDelegate ex = () => fileSystem.File.CreateSymbolicLink(path, @"C:\bar.txt_?_");
+            Action ex = () => fileSystem.File.CreateSymbolicLink(path, @"C:\bar.txt_?_");
 
             // Assert
-            Assert.Throws<ArgumentException>(ex);
+            await That(ex).Throws<ArgumentException>();
         }
 
         [Test]
-        public void MockFile_CreateSymbolicLink_ShouldFailIfPathExists()
+        public async Task MockFile_CreateSymbolicLink_ShouldFailIfPathExists()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -188,14 +188,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddFile(path, data);
 
             // Act
-            var ex = Assert.Throws<IOException>(() => fileSystem.File.CreateSymbolicLink(path, pathToTarget));
+            var ex = await That(() => fileSystem.File.CreateSymbolicLink(path, pathToTarget)).Throws<IOException>();
 
             // Assert
-            Assert.That(ex.Message.Contains("path"));
+            await That(ex.Message).Contains("path");
         }
 
         [Test]
-        public void MockFile_CreateSymbolicLink_ShouldFailIfTargetDoesNotExist()
+        public async Task MockFile_CreateSymbolicLink_ShouldFailIfTargetDoesNotExist()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -205,14 +205,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(dir);
 
             // Act
-            var ex = Assert.Throws<FileNotFoundException>(() => fileSystem.File.CreateSymbolicLink(path, pathToTarget));
+            var ex = await That(() => fileSystem.File.CreateSymbolicLink(path, pathToTarget)).Throws<FileNotFoundException>();
 
             // Assert
-            Assert.That(ex.Message.Contains(pathToTarget));
+            await That(ex.Message).Contains(pathToTarget);
         }
 
         [Test]
-        public void MockFile_CreateSymbolicLink_ShouldFailIfPathDirectoryDoesNotExist()
+        public async Task MockFile_CreateSymbolicLink_ShouldFailIfPathDirectoryDoesNotExist()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -222,14 +222,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddFile(pathToTarget, data);
 
             // Act
-            var ex = Assert.Throws<DirectoryNotFoundException>(() => fileSystem.File.CreateSymbolicLink(path, pathToTarget));
+            var ex = await That(() => fileSystem.File.CreateSymbolicLink(path, pathToTarget)).Throws<DirectoryNotFoundException>();
 
             // Assert
-            Assert.That(ex.Message.Contains(path));
+            await That(ex.Message).Contains(path);
         }
 
         [Test]
-        public void MockFile_CreateSymbolicLink_ShouldSetReparsePointAttribute()
+        public async Task MockFile_CreateSymbolicLink_ShouldSetReparsePointAttribute()
         {
             var path = "foo.txt";
             var pathToTarget = "bar.txt";
@@ -239,11 +239,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.File.CreateSymbolicLink(path, pathToTarget);
 
             var attributes = fileSystem.FileInfo.New(path).Attributes;
-            Assert.That(attributes.HasFlag(FileAttributes.ReparsePoint), Is.True);
+            await That(attributes.HasFlag(FileAttributes.ReparsePoint)).IsTrue();
         }
 
         [Test]
-        public void MockFile_ResolveLinkTarget_ShouldReturnPathOfTargetLink()
+        public async Task MockFile_ResolveLinkTarget_ShouldReturnPathOfTargetLink()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.File.WriteAllText("bar", "some content");
@@ -251,11 +251,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.File.ResolveLinkTarget("foo", false);
 
-            Assert.That(result.Name, Is.EqualTo("bar"));
+            await That(result.Name).IsEqualTo("bar");
         }
 
         [Test]
-        public void MockFile_ResolveLinkTarget_WithFinalTarget_ShouldReturnPathOfTargetLink()
+        public async Task MockFile_ResolveLinkTarget_WithFinalTarget_ShouldReturnPathOfTargetLink()
         {
             // The maximum number of symbolic links that are followed:
             // https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.resolvelinktarget?view=net-6.0#remarks
@@ -272,11 +272,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.File.ResolveLinkTarget(previousPath, true);
 
-            Assert.That(result.Name, Is.EqualTo("bar"));
+            await That(result.Name).IsEqualTo("bar");
         }
 
         [Test]
-        public void MockFile_ResolveLinkTarget_WithFinalTargetWithTooManyLinks_ShouldThrowIOException()
+        public async Task MockFile_ResolveLinkTarget_WithFinalTargetWithTooManyLinks_ShouldThrowIOException()
         {
             // The maximum number of symbolic links that are followed:
             // https://learn.microsoft.com/en-us/dotnet/api/system.io.directory.resolvelinktarget?view=net-6.0#remarks
@@ -292,11 +292,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 previousPath = newPath;
             }
 
-            Assert.Throws<IOException>(() => fileSystem.File.ResolveLinkTarget(previousPath, true));
+            await That(() => fileSystem.File.ResolveLinkTarget(previousPath, true)).Throws<IOException>();
         }
 
         [Test]
-        public void MockFile_ResolveLinkTarget_WithoutFinalTarget_ShouldReturnFirstLink()
+        public async Task MockFile_ResolveLinkTarget_WithoutFinalTarget_ShouldReturnFirstLink()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.File.WriteAllText("bar", "some content");
@@ -305,20 +305,20 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.File.ResolveLinkTarget("foo1", false);
 
-            Assert.That(result.Name, Is.EqualTo("foo"));
+            await That(result.Name).IsEqualTo("foo");
         }
 
         [Test]
-        public void MockFile_ResolveLinkTarget_WithoutTargetLink_ShouldThrowIOException()
+        public async Task MockFile_ResolveLinkTarget_WithoutTargetLink_ShouldThrowIOException()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.File.WriteAllText("bar", "some content");
             fileSystem.File.CreateSymbolicLink("foo", "bar");
 
-            Assert.Throws<IOException>(() =>
+            await That(() =>
             {
                 fileSystem.File.ResolveLinkTarget("bar", false);
-            });
+            }).Throws<IOException>();
         }
 #endif
     }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemOptionTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemOptionTests.cs
@@ -9,7 +9,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [Test]
         [TestCase(true)]
         [TestCase(false)]
-        public void CreateDefaultTempDir_ShouldBeConsidered(bool createTempDir)
+        public async Task CreateDefaultTempDir_ShouldBeConsidered(bool createTempDir)
         {
             var fileSystem = new MockFileSystem(new MockFileSystemOptions
             {
@@ -18,13 +18,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.Directory.Exists(fileSystem.Path.GetTempPath());
 
-            Assert.That(result, Is.EqualTo(createTempDir));
+            await That(result).IsEqualTo(createTempDir);
         }
 
         [Test]
         [TestCase(@"C:\path")]
         [TestCase(@"C:\foo\bar")]
-        public void CurrentDirectory_ShouldBeConsidered(string currentDirectory)
+        public async Task CurrentDirectory_ShouldBeConsidered(string currentDirectory)
         {
             currentDirectory = XFS.Path(currentDirectory);
             var fileSystem = new MockFileSystem(new MockFileSystemOptions
@@ -34,7 +34,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.Directory.GetCurrentDirectory();
 
-            Assert.That(result, Is.EqualTo(currentDirectory));
+            await That(result).IsEqualTo(currentDirectory);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemSerializationTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemSerializationTests.cs
@@ -8,7 +8,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     class MockFileSystemSerializationTests
     {
         [Test]
-        public void SerializationBytes()
+        public async Task SerializationBytes()
         {
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
@@ -34,8 +34,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             memoryStream.Dispose();
 
             // Assert
-            Assert.That(fileSystem.GetFile(path).Contents, Is.EqualTo(expected));
-            Assert.That(fileSystem.File.ReadAllBytes(path), Is.EqualTo(content));
+            await That(fileSystem.GetFile(path).Contents).IsEqualTo(expected);
+            await That(fileSystem.File.ReadAllBytes(path)).IsEqualTo(expected);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemTests.cs
@@ -13,7 +13,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockFileSystemTests
     {
         [Test]
-        public void MockFileSystem_GetFile_ShouldReturnNullWhenFileIsNotRegistered()
+        public async Task MockFileSystem_GetFile_ShouldReturnNullWhenFileIsNotRegistered()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -23,11 +23,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.GetFile(@"c:\something\else.txt");
 
-            Assert.That(result, Is.Null);
+            await That(result).IsNull();
         }
 
         [Test]
-        public void MockFileSystem_GetFile_ShouldReturnFileRegisteredInConstructor()
+        public async Task MockFileSystem_GetFile_ShouldReturnFileRegisteredInConstructor()
         {
             var file1 = new MockFileData("Demo\r\ntext\ncontent\rvalue");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -38,12 +38,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.GetFile(@"c:\something\demo.txt");
 
-            Assert.That(result, Is.EqualTo(file1));
+            await That(result).IsEqualTo(file1);
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.CaseInsensitivity)]
-        public void MockFileSystem_GetFile_ShouldReturnFileRegisteredInConstructorWhenPathsDifferByCase()
+        public async Task MockFileSystem_GetFile_ShouldReturnFileRegisteredInConstructorWhenPathsDifferByCase()
         {
             var file1 = new MockFileData("Demo\r\ntext\ncontent\rvalue");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -54,12 +54,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.GetFile(@"c:\SomeThing\DEMO.txt");
 
-            Assert.That(result, Is.EqualTo(file1));
+            await That(result).IsEqualTo(file1);
         }
 
         [Test]
         [UnixOnly(UnixSpecifics.CaseSensitivity)]
-        public void MockFileSystem_GetFile_ShouldNotReturnFileRegisteredInConstructorWhenPathsDifferByCase()
+        public async Task MockFileSystem_GetFile_ShouldNotReturnFileRegisteredInConstructorWhenPathsDifferByCase()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -69,11 +69,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.GetFile("/SomeThing/DEMO.txt");
 
-            Assert.That(result, Is.Null);
+            await That(result).IsNull();
         }
 
         [Test]
-        public void MockFileSystem_AddFile_ShouldHandleUnnormalizedSlashes()
+        public async Task MockFileSystem_AddFile_ShouldHandleUnnormalizedSlashes()
         {
             var path = XFS.Path(@"c:\d1\d2\file.txt");
             var alternatePath = XFS.Path("c:/d1/d2/file.txt");
@@ -84,12 +84,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fileCount = fs.Directory.GetFiles(alternateParentPath).Length;
             var fileExists = fs.File.Exists(alternatePath);
 
-            Assert.That(fileCount, Is.EqualTo(1));
-            Assert.That(fileExists, Is.True);
+            await That(fileCount).IsEqualTo(1);
+            await That(fileExists).IsTrue();
         }
 
         [Test]
-        public void MockFileSystem_AddFile_ShouldHandleNullFileDataAsEmpty()
+        public async Task MockFileSystem_AddFile_ShouldHandleNullFileDataAsEmpty()
         {
             var path = XFS.Path(@"c:\something\nullish.txt");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -99,11 +99,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.File.ReadAllText(path);
 
-            Assert.That(result, Is.Empty, "Null MockFileData should be allowed for and result in an empty file.");
+            await That(result).IsEmpty().Because("Null MockFileData should be allowed for and result in an empty file.");
         }
 
         [Test]
-        public void MockFileSystem_AddFile_ShouldReplaceExistingFile()
+        public async Task MockFileSystem_AddFile_ShouldReplaceExistingFile()
         {
             var path = XFS.Path(@"c:\some\file.txt");
             const string existingContent = "Existing content";
@@ -111,61 +111,61 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             {
                 { path, new MockFileData(existingContent) }
             });
-            Assert.That(fileSystem.GetFile(path).TextContents, Is.EqualTo(existingContent));
+            await That(fileSystem.GetFile(path).TextContents).IsEqualTo(existingContent);
 
             const string newContent = "New content";
             fileSystem.AddFile(path, new MockFileData(newContent));
 
-            Assert.That(fileSystem.GetFile(path).TextContents, Is.EqualTo(newContent));
+            await That(fileSystem.GetFile(path).TextContents).IsEqualTo(newContent);
         }
 
         [Test]
-        public void MockFileSystem_AddEmptyFile_ShouldBeEmpty()
+        public async Task MockFileSystem_AddEmptyFile_ShouldBeEmpty()
         {
             var path = XFS.Path(@"c:\some\file.txt");
             var fileSystem = new MockFileSystem();
 
             fileSystem.AddEmptyFile(path);
 
-            Assert.That(fileSystem.GetFile(path).TextContents, Is.EqualTo(""));
+            await That(fileSystem.GetFile(path).TextContents).IsEqualTo("");
         }
 
         [Test]
-        public void MockFileSystem_AddEmptyFile_ShouldExist()
+        public async Task MockFileSystem_AddEmptyFile_ShouldExist()
         {
             var fileSystem = new MockFileSystem();
             var path = fileSystem.FileInfo.New(XFS.Path(@"c:\some\file.txt"));
 
             fileSystem.AddEmptyFile(path);
 
-            Assert.That(path.Exists, Is.True);
+            await That(path.Exists).IsTrue();
         }
 
         [Test]
-        public void MockFileSystem_AddFile_ShouldExist()
+        public async Task MockFileSystem_AddFile_ShouldExist()
         {
             var fileSystem = new MockFileSystem();
             var path = fileSystem.FileInfo.New(XFS.Path(@"c:\some\file.txt"));
 
             fileSystem.AddFile(path, new MockFileData("stuff"));
 
-            Assert.That(path.Exists, Is.True);
+            await That(path.Exists).IsTrue();
         }
 
         [Test]
-        public void MockFileSystem_AddDirectory_ShouldExist()
+        public async Task MockFileSystem_AddDirectory_ShouldExist()
         {
             var fileSystem = new MockFileSystem();
             var path = fileSystem.DirectoryInfo.New(XFS.Path(@"c:\thedir"));
 
             fileSystem.AddDirectory(path);
 
-            Assert.That(path.Exists, Is.True);
+            await That(path.Exists).IsTrue();
         }
         
 #if !NET9_0_OR_GREATER
         [Test]
-        public void MockFileSystem_ByDefault_IsSerializable()
+        public async Task MockFileSystem_ByDefault_IsSerializable()
         {
             var file1 = new MockFileData("Demo\r\ntext\ncontent\rvalue");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -181,36 +181,36 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             serializer.Serialize(memoryStream, fileSystem);
 #pragma warning restore SYSLIB0011
 
-            Assert.That(memoryStream.Length > 0, "Length didn't increase after serialization task.");
+            await That(memoryStream).HasLength().GreaterThan(0).Because("Length didn't increase after serialization task.");
         }
 #endif
 
         [Test]
-        public void MockFileSystem_AddDirectory_ShouldCreateDirectory()
+        public async Task MockFileSystem_AddDirectory_ShouldCreateDirectory()
         {
             string baseDirectory = XFS.Path(@"C:\Test");
             var fileSystem = new MockFileSystem();
 
             fileSystem.AddDirectory(baseDirectory);
 
-            Assert.That(fileSystem.Directory.Exists(baseDirectory), Is.True);
+            await That(fileSystem.Directory.Exists(baseDirectory)).IsTrue();
         }
 
         [Test]
-        public void MockFileSystem_AddDirectory_ShouldThrowExceptionIfDirectoryIsReadOnly()
+        public async Task MockFileSystem_AddDirectory_ShouldThrowExceptionIfDirectoryIsReadOnly()
         {
             string baseDirectory = XFS.Path(@"C:\Test");
             var fileSystem = new MockFileSystem();
             fileSystem.AddFile(baseDirectory, new MockFileData(string.Empty));
             fileSystem.File.SetAttributes(baseDirectory, FileAttributes.ReadOnly);
 
-            TestDelegate action = () => fileSystem.AddDirectory(baseDirectory);
+            Action action = () => fileSystem.AddDirectory(baseDirectory);
 
-            Assert.Throws<UnauthorizedAccessException>(action);
+            await That(action).Throws<UnauthorizedAccessException>();
         }
 
         [Test]
-        public void MockFileSystem_AddDrive_ShouldExist()
+        public async Task MockFileSystem_AddDrive_ShouldExist()
         {
             string name = @"D:\";
             var fileSystem = new MockFileSystem();
@@ -218,22 +218,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var actualResults = fileSystem.DriveInfo.GetDrives().Select(d => d.Name);
 
-            Assert.That(actualResults, Does.Contain(name));
+            await That(actualResults).Contains(name);
         }
 
         [Test]
-        public void MockFileSystem_DriveInfo_ShouldNotThrowAnyException()
+        public async Task MockFileSystem_DriveInfo_ShouldNotThrowAnyException()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.AddDirectory(XFS.Path(@"C:\Test"));
 
             var actualResults = fileSystem.DriveInfo.GetDrives();
 
-            Assert.That(actualResults, Is.Not.Null);
+            await That(actualResults).IsNotNull();
         }
 
         [Test]
-        public void MockFileSystem_AddFile_ShouldMatchCapitalization_PerfectMatch()
+        public async Task MockFileSystem_AddFile_ShouldMatchCapitalization_PerfectMatch()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.AddDirectory(XFS.Path(@"C:\test"));
@@ -244,15 +244,15 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(XFS.Path(@"C:\test\SUBDirectory"));
             fileSystem.AddDirectory(XFS.Path(@"C:\LOUD\SUBDirectory"));
 
-            Assert.That(fileSystem.AllFiles.ToList(), Does.Contain(XFS.Path(@"C:\test\file.txt")));
-            Assert.That(fileSystem.AllFiles.ToList(), Does.Contain(XFS.Path(@"C:\LOUD\file.txt")));
-            Assert.That(fileSystem.AllDirectories.ToList(), Does.Contain(XFS.Path(@"C:\test\SUBDirectory")));
-            Assert.That(fileSystem.AllDirectories.ToList(), Does.Contain(XFS.Path(@"C:\LOUD\SUBDirectory")));
+            await That(fileSystem.AllFiles.ToList()).Contains(XFS.Path(@"C:\test\file.txt"));
+            await That(fileSystem.AllFiles.ToList()).Contains(XFS.Path(@"C:\LOUD\file.txt"));
+            await That(fileSystem.AllDirectories.ToList()).Contains(XFS.Path(@"C:\test\SUBDirectory"));
+            await That(fileSystem.AllDirectories.ToList()).Contains(XFS.Path(@"C:\LOUD\SUBDirectory"));
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.CaseInsensitivity)]
-        public void MockFileSystem_AddFile_ShouldMatchCapitalization_PartialMatch()
+        public async Task MockFileSystem_AddFile_ShouldMatchCapitalization_PartialMatch()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.AddDirectory(XFS.Path(@"C:\test\subtest"));
@@ -263,15 +263,15 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(XFS.Path(@"C:\test\SUBTEST\SUBDirectory"));
             fileSystem.AddDirectory(XFS.Path(@"C:\LOUD\subloud\SUBDirectory"));
 
-            Assert.That(fileSystem.AllFiles.ToList(), Does.Contain(XFS.Path(@"C:\test\subtest\file.txt")));
-            Assert.That(fileSystem.AllFiles.ToList(), Does.Contain(XFS.Path(@"C:\LOUD\SUBLOUD\file.txt")));
-            Assert.That(fileSystem.AllDirectories.ToList(), Does.Contain(XFS.Path(@"C:\test\subtest\SUBDirectory")));
-            Assert.That(fileSystem.AllDirectories.ToList(), Does.Contain(XFS.Path(@"C:\LOUD\SUBLOUD\SUBDirectory")));
+            await That(fileSystem.AllFiles.ToList()).Contains(XFS.Path(@"C:\test\subtest\file.txt"));
+            await That(fileSystem.AllFiles.ToList()).Contains(XFS.Path(@"C:\LOUD\SUBLOUD\file.txt"));
+            await That(fileSystem.AllDirectories.ToList()).Contains(XFS.Path(@"C:\test\subtest\SUBDirectory"));
+            await That(fileSystem.AllDirectories.ToList()).Contains(XFS.Path(@"C:\LOUD\SUBLOUD\SUBDirectory"));
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.CaseInsensitivity)]
-        public void MockFileSystem_AddFile_ShouldMatchCapitalization_PartialMatch_FurtherLeft()
+        public async Task MockFileSystem_AddFile_ShouldMatchCapitalization_PartialMatch_FurtherLeft()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.AddDirectory(XFS.Path(@"C:\test\subtest"));
@@ -282,14 +282,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(XFS.Path(@"C:\test\SUBTEST\new\SUBDirectory"));
             fileSystem.AddDirectory(XFS.Path(@"C:\LOUD\subloud\new\SUBDirectory"));
 
-            Assert.That(fileSystem.AllFiles.ToList(), Does.Contain(XFS.Path(@"C:\test\subtest\new\file.txt")));
-            Assert.That(fileSystem.AllFiles.ToList(), Does.Contain(XFS.Path(@"C:\LOUD\SUBLOUD\new\file.txt")));
-            Assert.That(fileSystem.AllDirectories.ToList(), Does.Contain(XFS.Path(@"C:\test\subtest\new\SUBDirectory")));
-            Assert.That(fileSystem.AllDirectories.ToList(), Does.Contain(XFS.Path(@"C:\LOUD\SUBLOUD\new\SUBDirectory")));
+            await That(fileSystem.AllFiles.ToList()).Contains(XFS.Path(@"C:\test\subtest\new\file.txt"));
+            await That(fileSystem.AllFiles.ToList()).Contains(XFS.Path(@"C:\LOUD\SUBLOUD\new\file.txt"));
+            await That(fileSystem.AllDirectories.ToList()).Contains(XFS.Path(@"C:\test\subtest\new\SUBDirectory"));
+            await That(fileSystem.AllDirectories.ToList()).Contains(XFS.Path(@"C:\LOUD\SUBLOUD\new\SUBDirectory"));
         }
 
         [Test]
-        public void MockFileSystem_AddFile_InitializesMockFileDataFileVersionInfoIfNull()
+        public async Task MockFileSystem_AddFile_InitializesMockFileDataFileVersionInfoIfNull()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -299,34 +299,34 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             IFileVersionInfo fileVersionInfo = fileSystem.FileVersionInfo.GetVersionInfo(XFS.Path(@"C:\file.txt"));
-            Assert.That(fileVersionInfo, Is.Not.Null);
-            Assert.That(fileVersionInfo.FileName, Is.EqualTo(XFS.Path(@"C:\file.txt")));
+            await That(fileVersionInfo).IsNotNull();
+            await That(fileVersionInfo.FileName).IsEqualTo(XFS.Path(@"C:\file.txt"));
         }
 
         [Test]
-        public void MockFileSystem_AddFileFromEmbeddedResource_ShouldAddTheFile()
+        public async Task MockFileSystem_AddFileFromEmbeddedResource_ShouldAddTheFile()
         {
             var fileSystem = new MockFileSystem();
 
             fileSystem.AddFileFromEmbeddedResource(XFS.Path(@"C:\TestFile.txt"), Assembly.GetExecutingAssembly(), "System.IO.Abstractions.TestingHelpers.Tests.TestFiles.TestFile.txt");
             var result = fileSystem.GetFile(XFS.Path(@"C:\TestFile.txt"));
 
-            Assert.That(result.Contents, Is.EqualTo(new UTF8Encoding().GetBytes("This is a test file.")));
+            await That(result.Contents).IsEqualTo(new UTF8Encoding().GetBytes("This is a test file."));
         }
 
         [Test]
-        public void MockFileSystem_AddFilesFromEmbeddedResource_ShouldAddAllTheFiles()
+        public async Task MockFileSystem_AddFilesFromEmbeddedResource_ShouldAddAllTheFiles()
         {
             var fileSystem = new MockFileSystem();
 
             fileSystem.AddFilesFromEmbeddedNamespace(XFS.Path(@"C:\"), Assembly.GetExecutingAssembly(), "System.IO.Abstractions.TestingHelpers.Tests.TestFiles");
 
-            Assert.That(fileSystem.AllFiles.ToList(), Does.Contain(XFS.Path(@"C:\TestFile.txt")));
-            Assert.That(fileSystem.AllFiles.ToList(), Does.Contain(XFS.Path(@"C:\SecondTestFile.txt")));
+            await That(fileSystem.AllFiles.ToList()).Contains(XFS.Path(@"C:\TestFile.txt"));
+            await That(fileSystem.AllFiles.ToList()).Contains(XFS.Path(@"C:\SecondTestFile.txt"));
         }
 
         [Test]
-        public void MockFileSystem_MoveDirectory_MovesDirectoryWithoutRenamingFiles()
+        public async Task MockFileSystem_MoveDirectory_MovesDirectoryWithoutRenamingFiles()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.AddFile(XFS.Path(@"C:\dir1\dir1\dir1.txt"), string.Empty);
@@ -334,11 +334,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.MoveDirectory(XFS.Path(@"C:\dir1"), XFS.Path(@"C:\dir2"));
 
             var expected = new[] { XFS.Path(@"C:\dir2\dir1\dir1.txt") };
-            Assert.That(fileSystem.AllFiles, Is.EqualTo(expected));
+            await That(fileSystem.AllFiles).IsEqualTo(expected);
         }
 
         [Test]
-        public void MockFileSystem_MoveDirectoryAndFile_ShouldMoveCorrectly()
+        public async Task MockFileSystem_MoveDirectoryAndFile_ShouldMoveCorrectly()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.AddFile(XFS.Path(@"C:\source\project.txt"), string.Empty);
@@ -348,22 +348,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.File.Move(XFS.Path(@"C:\target\project.txt"), XFS.Path(@"C:\target\proj.txt"));
 
             var expected = new[] { XFS.Path(@"C:\target\proj.txt"), XFS.Path(@"C:\target\subdir\other.txt") };
-            Assert.That(fileSystem.AllFiles, Is.EqualTo(expected));
+            await That(fileSystem.AllFiles).IsEqualTo(expected);
         }
 
         [Test]
-        public void MockFileSystem_RemoveFile_RemovesFiles()
+        public async Task MockFileSystem_RemoveFile_RemovesFiles()
         {
             var fileSystem = new MockFileSystem();
             fileSystem.AddFile(@"C:\file.txt", new MockFileData("Content"));
 
             fileSystem.RemoveFile(@"C:\file.txt");
 
-            Assert.That(fileSystem.FileExists(@"C:\file.txt"), Is.False);
+            await That(fileSystem.FileExists(@"C:\file.txt")).IsFalse();
         }
 
         [Test]
-        public void MockFileSystem_RemoveFile_ThrowsUnauthorizedAccessExceptionIfFileIsReadOnly()
+        public async Task MockFileSystem_RemoveFile_ThrowsUnauthorizedAccessExceptionIfFileIsReadOnly()
         {
             var path = XFS.Path(@"C:\file.txt");
             var readOnlyFile = new MockFileData("")
@@ -375,13 +375,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 { path, readOnlyFile },
             });
 
-            TestDelegate action = () => fileSystem.RemoveFile(path);
+            Action action = () => fileSystem.RemoveFile(path);
 
-            Assert.Throws<UnauthorizedAccessException>(action);
+            await That(action).Throws<UnauthorizedAccessException>();
         }
 
         [Test]
-        public void MockFileSystem_AllNodes_ShouldReturnAllNodes()
+        public async Task MockFileSystem_AllNodes_ShouldReturnAllNodes()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -401,24 +401,24 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fileSystem.AllNodes;
 
-            Assert.That(result, Is.EqualTo(expectedNodes));
+            await That(result).IsEqualTo(expectedNodes);
         }
 
         [Test]
         [TestCase(@"C:\path")]
         [TestCase(@"C:\path\")]
-        public void MockFileSystem_AddDirectory_TrailingSlashAllowedButNotRequired(string path)
+        public async Task MockFileSystem_AddDirectory_TrailingSlashAllowedButNotRequired(string path)
         {
             var fileSystem = new MockFileSystem();
             var path2 = XFS.Path(path);
 
             fileSystem.AddDirectory(path2);
 
-            Assert.That(fileSystem.FileExists(path2), Is.True);
+            await That(fileSystem.FileExists(path2)).IsTrue();
         }
 
         [Test]
-        public void MockFileSystem_GetFiles_ThrowsArgumentExceptionForInvalidCharacters()
+        public async Task MockFileSystem_GetFiles_ThrowsArgumentExceptionForInvalidCharacters()
         {
             // Arrange
             const string path = @"c:\";
@@ -426,36 +426,36 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddDirectory(XFS.Path(path));
 
             // Act
-            TestDelegate getFilesWithInvalidCharacterInPath = () => fileSystem.Directory.GetFiles($"{path}{'\0'}.txt");
+            Action getFilesWithInvalidCharacterInPath = () => fileSystem.Directory.GetFiles($"{path}{'\0'}.txt");
 
             // Assert
-            Assert.Throws<ArgumentException>(getFilesWithInvalidCharacterInPath);
+            await That(getFilesWithInvalidCharacterInPath).Throws<ArgumentException>();
         }
 
         [Test]
         [TestCase(null)]
         [TestCase(@"C:\somepath")]
-        public void MockFileSystem_DefaultState_CurrentDirectoryExists(string currentDirectory)
+        public async Task MockFileSystem_DefaultState_CurrentDirectoryExists(string currentDirectory)
         {
             var fs = new MockFileSystem(null, XFS.Path(currentDirectory));
 
             var actualCurrentDirectory = fs.DirectoryInfo.New(".");
 
-            Assert.That(actualCurrentDirectory.Exists, Is.True);
+            await That(actualCurrentDirectory.Exists).IsTrue();
         }
 
         [Test]
-        public void MockFileSystem_Constructor_ThrowsForNonRootedCurrentDirectory()
+        public async Task MockFileSystem_Constructor_ThrowsForNonRootedCurrentDirectory()
         {
-            var ae = Assert.Throws<ArgumentException>(() =>
+            await That(() =>
                 new MockFileSystem(null, "non-rooted")
-            );
-            Assert.That(ae.ParamName, Is.EqualTo("currentDirectory"));
+            ).Throws<ArgumentException>()
+            .WithParamName("currentDirectory");
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.Drives)]
-        public void MockFileSystem_Constructor_ShouldSupportDifferentRootDrives()
+        public async Task MockFileSystem_Constructor_ShouldSupportDifferentRootDrives()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -468,15 +468,15 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var zExists = fileSystem.Directory.Exists(@"z:\");
             var dExists = fileSystem.Directory.Exists(@"d:\");
 
-            Assert.That(fileSystem, Is.Not.Null);
-            Assert.That(cExists, Is.True);
-            Assert.That(zExists, Is.True);
-            Assert.That(dExists, Is.True);
+            await That(fileSystem).IsNotNull();
+            await That(cExists).IsTrue();
+            await That(zExists).IsTrue();
+            await That(dExists).IsTrue();
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.Drives)]
-        public void MockFileSystem_Constructor_ShouldAddDifferentDrivesIfNotExist()
+        public async Task MockFileSystem_Constructor_ShouldAddDifferentDrivesIfNotExist()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -487,14 +487,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var fooExists = fileSystem.Directory.Exists(@"d:\foo\");
             var barExists = fileSystem.Directory.Exists(@"d:\foo\bar\");
 
-            Assert.That(drivesInfo.Any(d => string.Equals(d.Name, @"D:\", StringComparison.InvariantCultureIgnoreCase)), Is.True);
-            Assert.That(fooExists, Is.True);
-            Assert.That(barExists, Is.True);
+            await That(drivesInfo.Any(d => string.Equals(d.Name, @"D:\", StringComparison.InvariantCultureIgnoreCase))).IsTrue();
+            await That(fooExists).IsTrue();
+            await That(barExists).IsTrue();
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.Drives)]
-        public void MockFileSystem_Constructor_ShouldNotDuplicateDrives()
+        public async Task MockFileSystem_Constructor_ShouldNotDuplicateDrives()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
             {
@@ -504,32 +504,32 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var drivesInfo = fileSystem.DriveInfo.GetDrives();
 
-            Assert.That(drivesInfo.Where(d => string.Equals(d.Name, @"D:\", StringComparison.InvariantCultureIgnoreCase)), Has.Exactly(1).Items);
+            await That(drivesInfo.Where(d => string.Equals(d.Name, @"D:\", StringComparison.InvariantCultureIgnoreCase))).HasCount().EqualTo(1);
         }
 
         [Test]
-        public void MockFileSystem_DefaultState_DefaultTempDirectoryExists()
+        public async Task MockFileSystem_DefaultState_DefaultTempDirectoryExists()
         {
             var tempDirectory = XFS.Path(@"C:\temp");
 
             var mockFileSystem = new MockFileSystem();
             var mockFileSystemOverload = new MockFileSystem(null, string.Empty);
 
-            Assert.That(mockFileSystem.Directory.Exists(tempDirectory), Is.True);
-            Assert.That(mockFileSystemOverload.Directory.Exists(tempDirectory), Is.True);
+            await That(mockFileSystem.Directory.Exists(tempDirectory)).IsTrue();
+            await That(mockFileSystemOverload.Directory.Exists(tempDirectory)).IsTrue();
         }
 
         [Test]
-        public void MockFileSystem_FileSystemWatcher_Can_Be_Overridden()
+        public async Task MockFileSystem_FileSystemWatcher_Can_Be_Overridden()
         {
             var path = XFS.Path(@"C:\root");
             var fileSystem = new TestFileSystem(new TestFileSystemWatcherFactory());
             var watcher = fileSystem.FileSystemWatcher.New(path);
-            Assert.That(watcher.Path, Is.EqualTo(path));
+            await That(watcher.Path).IsEqualTo(path);
         }
 
         [Test]
-        public void MockFileSystem_DeleteDirectoryRecursive_WithReadOnlyFile_ShouldThrowUnauthorizedException()
+        public async Task MockFileSystem_DeleteDirectoryRecursive_WithReadOnlyFile_ShouldThrowUnauthorizedException()
         {
             string baseDirectory = XFS.Path(@"C:\Test");
             string textFile = XFS.Path(@"C:\Test\file.txt");
@@ -539,11 +539,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddFile(textFile, new MockFileData("Content"));
             fileSystem.File.SetAttributes(textFile, FileAttributes.ReadOnly);
 
-            TestDelegate action = () => fileSystem.Directory.Delete(baseDirectory, true);
+            Action action = () => fileSystem.Directory.Delete(baseDirectory, true);
 
-            Assert.Throws<UnauthorizedAccessException>(action);
-            Assert.That(fileSystem.File.Exists(textFile), Is.True);
-            Assert.That(fileSystem.Directory.Exists(baseDirectory), Is.True);
+            await That(action).Throws<UnauthorizedAccessException>();
+            await That(fileSystem.File.Exists(textFile)).IsTrue();
+            await That(fileSystem.Directory.Exists(baseDirectory)).IsTrue();
         }
 
         private class TestFileSystem : MockFileSystem

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemWatcherFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileSystemWatcherFactoryTests.cs
@@ -7,45 +7,45 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockFileSystemWatcherFactoryTests
     {
         [Test]
-        public void MockFileSystemWatcherFactory_CreateNew_ShouldThrowNotImplementedException()
+        public async Task MockFileSystemWatcherFactory_CreateNew_ShouldThrowNotImplementedException()
         {
             var factory = new MockFileSystemWatcherFactory(new MockFileSystem());
-            Assert.Throws<NotImplementedException>(() => factory.New());
+            await That(() => factory.New()).Throws<NotImplementedException>();
         }
 
         [Test]
-        public void MockFileSystemWatcherFactory_CreateNewWithPath_ShouldThrowNotImplementedException()
+        public async Task MockFileSystemWatcherFactory_CreateNewWithPath_ShouldThrowNotImplementedException()
         {
             var path = XFS.Path(@"y:\test");
             var factory = new MockFileSystemWatcherFactory(new MockFileSystem());
-            Assert.Throws<NotImplementedException>(() => factory.New(path));
+            await That(() => factory.New(path)).Throws<NotImplementedException>();
         }
 
         [Test]
-        public void MockFileSystemWatcherFactory_CreateNewWithPathAndFilter_ShouldThrowNotImplementedException()
+        public async Task MockFileSystemWatcherFactory_CreateNewWithPathAndFilter_ShouldThrowNotImplementedException()
         {
             var path = XFS.Path(@"y:\test");
             var filter = "*.txt";
             var factory = new MockFileSystemWatcherFactory(new MockFileSystem());
-            Assert.Throws<NotImplementedException>(() => factory.New(path, filter));
+            await That(() => factory.New(path, filter)).Throws<NotImplementedException>();
         }
 
         [Test]
-        public void MockFileSystemWatcherFactory_FromPath_ShouldThrowNotImplementedException()
+        public async Task MockFileSystemWatcherFactory_FromPath_ShouldThrowNotImplementedException()
         {
             var path = XFS.Path(@"y:\test");
             var factory = new MockFileSystemWatcherFactory(new MockFileSystem());
-            Assert.Throws<NotImplementedException>(() => factory.New(path));
+            await That(() => factory.New(path)).Throws<NotImplementedException>();
         }
 
         [Test]
-        public void MockFileSystemWatcherFactory_Wrap_WithNull_ShouldReturnNull()
+        public async Task MockFileSystemWatcherFactory_Wrap_WithNull_ShouldReturnNull()
         {
             var fileSystem = new MockFileSystem();
 
             var result = fileSystem.FileSystemWatcher.Wrap(null);
 
-            Assert.That(result, Is.Null);
+            await That(result).IsNull();
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
@@ -13,20 +13,20 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockFileTests
     {
         [Test]
-        public void MockFile_Constructor_ShouldThrowArgumentNullExceptionIfMockFileDataAccessorIsNull()
+        public async Task MockFile_Constructor_ShouldThrowArgumentNullExceptionIfMockFileDataAccessorIsNull()
         {
             // Arrange
             // nothing to do
 
             // Act
-            TestDelegate action = () => new MockFile(null);
+            Action action = () => new MockFile(null);
 
             // Assert
-            Assert.Throws<ArgumentNullException>(action);
+            await That(action).Throws<ArgumentNullException>();
         }
 
         [Test]
-        public void MockFile_GetSetCreationTime_ShouldPersist()
+        public async Task MockFile_GetSetCreationTime_ShouldPersist()
         {
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
@@ -42,11 +42,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.GetCreationTime(path);
 
             // Assert
-            Assert.That(result, Is.EqualTo(creationTime));
+            await That(result).IsEqualTo(creationTime);
         }
 
         [Test]
-        public void MockFile_SetCreationTimeUtc_ShouldAffectCreationTime()
+        public async Task MockFile_SetCreationTimeUtc_ShouldAffectCreationTime()
         {
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
@@ -62,11 +62,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.GetCreationTime(path);
 
             // Assert
-            Assert.That(result, Is.EqualTo(creationTime));
+            await That(result).IsEqualTo(creationTime);
         }
 
         [Test]
-        public void MockFile_SetCreationTime_ShouldAffectCreationTimeUtc()
+        public async Task MockFile_SetCreationTime_ShouldAffectCreationTimeUtc()
         {
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
@@ -82,11 +82,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.GetCreationTimeUtc(path);
 
             // Assert
-            Assert.That(result, Is.EqualTo(creationTime.ToUniversalTime()));
+            await That(result).IsEqualTo(creationTime.ToUniversalTime());
         }
 
         [Test]
-        public void MockFile_GetSetLastAccessTime_ShouldPersist()
+        public async Task MockFile_GetSetLastAccessTime_ShouldPersist()
         {
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
@@ -102,11 +102,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.GetLastAccessTime(path);
 
             // Assert
-            Assert.That(result, Is.EqualTo(lastAccessTime));
+            await That(result).IsEqualTo(lastAccessTime);
         }
 
         [Test]
-        public void MockFile_SetLastAccessTimeUtc_ShouldAffectLastAccessTime()
+        public async Task MockFile_SetLastAccessTimeUtc_ShouldAffectLastAccessTime()
         {
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
@@ -122,11 +122,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.GetLastAccessTime(path);
 
             // Assert
-            Assert.That(result, Is.EqualTo(lastAccessTime));
+            await That(result).IsEqualTo(lastAccessTime);
         }
 
         [Test]
-        public void MockFile_SetLastAccessTime_ShouldAffectLastAccessTimeUtc()
+        public async Task MockFile_SetLastAccessTime_ShouldAffectLastAccessTimeUtc()
         {
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
@@ -142,11 +142,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.GetLastAccessTimeUtc(path);
 
             // Assert
-            Assert.That(result, Is.EqualTo(lastAccessTime.ToUniversalTime()));
+            await That(result).IsEqualTo(lastAccessTime.ToUniversalTime());
         }
 
         [Test]
-        public void MockFile_GetSetLastWriteTime_ShouldPersist()
+        public async Task MockFile_GetSetLastWriteTime_ShouldPersist()
         {
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
@@ -162,10 +162,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.GetLastWriteTime(path);
 
             // Assert
-            Assert.That(result, Is.EqualTo(lastWriteTime));
+            await That(result).IsEqualTo(lastWriteTime);
         }
 
-        static void ExecuteDefaultValueTest(Func<MockFile, string, DateTime> getDateValue)
+        static async Task ExecuteDefaultValueTest(Func<MockFile, string, DateTime> getDateValue)
         {
             var expected = new DateTime(1601, 01, 01, 00, 00, 00, DateTimeKind.Utc);
             string path = XFS.Path(@"c:\something\demo.txt");
@@ -174,62 +174,62 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var actual = getDateValue(file, path);
 
-            Assert.That(actual.ToUniversalTime(), Is.EqualTo(expected));
+            await That(actual.ToUniversalTime()).IsEqualTo(expected);
         }
 
         [Test]
-        public void MockFile_GetLastWriteTimeOfNonExistentFile_ShouldReturnDefaultValue()
+        public async Task MockFile_GetLastWriteTimeOfNonExistentFile_ShouldReturnDefaultValue()
         {
-            ExecuteDefaultValueTest((f, p) => f.GetLastWriteTime(p));
+            await ExecuteDefaultValueTest((f, p) => f.GetLastWriteTime(p));
         }
 
         [Test]
-        public void MockFile_GetLastWriteTimeUtcOfNonExistentFile_ShouldReturnDefaultValue()
+        public async Task MockFile_GetLastWriteTimeUtcOfNonExistentFile_ShouldReturnDefaultValue()
         {
-            ExecuteDefaultValueTest((f, p) => f.GetLastWriteTimeUtc(p));
+            await ExecuteDefaultValueTest((f, p) => f.GetLastWriteTimeUtc(p));
         }
 
         [Test]
-        public void MockFile_GetLastAccessTimeUtcOfNonExistentFile_ShouldReturnDefaultValue()
+        public async Task MockFile_GetLastAccessTimeUtcOfNonExistentFile_ShouldReturnDefaultValue()
         {
-            ExecuteDefaultValueTest((f, p) => f.GetLastAccessTimeUtc(p));
+            await ExecuteDefaultValueTest((f, p) => f.GetLastAccessTimeUtc(p));
         }
 
         [Test]
-        public void MockFile_GetLastAccessTimeOfNonExistentFile_ShouldReturnDefaultValue()
+        public async Task MockFile_GetLastAccessTimeOfNonExistentFile_ShouldReturnDefaultValue()
         {
-            ExecuteDefaultValueTest((f, p) => f.GetLastAccessTime(p));
+            await ExecuteDefaultValueTest((f, p) => f.GetLastAccessTime(p));
         }
 
         [Test]
-        public void MockFile_GetAttributeOfNonExistentFileButParentDirectoryExists_ShouldThrowOneFileNotFoundException()
+        public async Task MockFile_GetAttributeOfNonExistentFileButParentDirectoryExists_ShouldThrowOneFileNotFoundException()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
             fileSystem.AddDirectory(XFS.Path(@"c:\something"));
 
             // Act
-            TestDelegate action = () => fileSystem.File.GetAttributes(XFS.Path(@"c:\something\demo.txt"));
+            Action action = () => fileSystem.File.GetAttributes(XFS.Path(@"c:\something\demo.txt"));
 
             // Assert
-            Assert.Throws<FileNotFoundException>(action);
+            await That(action).Throws<FileNotFoundException>();
         }
 
         [Test]
-        public void MockFile_GetAttributeOfNonExistentFile_ShouldThrowOneDirectoryNotFoundException()
+        public async Task MockFile_GetAttributeOfNonExistentFile_ShouldThrowOneDirectoryNotFoundException()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => fileSystem.File.GetAttributes(XFS.Path(@"c:\something\demo.txt"));
+            Action action = () => fileSystem.File.GetAttributes(XFS.Path(@"c:\something\demo.txt"));
 
             // Assert
-            Assert.Throws<DirectoryNotFoundException>(action);
+            await That(action).Throws<DirectoryNotFoundException>();
         }
 
         [Test]
-        public void MockFile_GetAttributeOfExistingFile_ShouldReturnCorrectValue()
+        public async Task MockFile_GetAttributeOfExistingFile_ShouldReturnCorrectValue()
         {
             var filedata = new MockFileData("test")
             {
@@ -241,12 +241,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             });
 
             var attributes = fileSystem.File.GetAttributes(XFS.Path(@"c:\something\demo.txt"));
-            Assert.That(attributes, Is.EqualTo(FileAttributes.Hidden));
+            await That(attributes).IsEqualTo(FileAttributes.Hidden);
         }
 
         [Test]
         [WindowsOnly(WindowsSpecifics.UNCPaths)]
-        public void MockFile_GetAttributeOfExistingUncDirectory_ShouldReturnCorrectValue()
+        public async Task MockFile_GetAttributeOfExistingUncDirectory_ShouldReturnCorrectValue()
         {
             var filedata = new MockFileData("test");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -255,52 +255,52 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             });
 
             var attributes = fileSystem.File.GetAttributes(XFS.Path(@"\\share\folder"));
-            Assert.That(attributes, Is.EqualTo(FileAttributes.Directory));
+            await That(attributes).IsEqualTo(FileAttributes.Directory);
         }
 
         [Test]
-        public void MockFile_GetAttributeWithEmptyParameter_ShouldThrowOneArgumentException()
+        public async Task MockFile_GetAttributeWithEmptyParameter_ShouldThrowOneArgumentException()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => fileSystem.File.GetAttributes(string.Empty);
+            Action action = () => fileSystem.File.GetAttributes(string.Empty);
 
             // Assert
-            var exception = Assert.Throws<ArgumentException>(action);
-            Assert.That(exception.Message, Does.StartWith("The path is not of a legal form."));
+            var exception = await That(action).Throws<ArgumentException>();
+            await That(exception.Message).StartsWith("The path is not of a legal form.");
         }
 
         [Test]
-        public void MockFile_GetAttributeWithIllegalParameter_ShouldThrowOneArgumentException()
+        public async Task MockFile_GetAttributeWithIllegalParameter_ShouldThrowOneArgumentException()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => fileSystem.File.GetAttributes(string.Empty);
+            Action action = () => fileSystem.File.GetAttributes(string.Empty);
 
             // Assert
             // Note: The actual type of the exception differs from the documentation.
             //       According to the documentation it should be of type NotSupportedException.
-            Assert.Throws<ArgumentException>(action);
+            await That(action).Throws<ArgumentException>();
         }
 
         [Test]
-        public void MockFile_GetCreationTimeOfNonExistentFile_ShouldReturnDefaultValue()
+        public async Task MockFile_GetCreationTimeOfNonExistentFile_ShouldReturnDefaultValue()
         {
-            ExecuteDefaultValueTest((f, p) => f.GetCreationTime(p));
+            await ExecuteDefaultValueTest((f, p) => f.GetCreationTime(p));
         }
 
         [Test]
-        public void MockFile_GetCreationTimeUtcOfNonExistentFile_ShouldReturnDefaultValue()
+        public async Task MockFile_GetCreationTimeUtcOfNonExistentFile_ShouldReturnDefaultValue()
         {
-            ExecuteDefaultValueTest((f, p) => f.GetCreationTimeUtc(p));
+            await ExecuteDefaultValueTest((f, p) => f.GetCreationTimeUtc(p));
         }
 
         [Test]
-        public void MockFile_SetLastWriteTimeUtc_ShouldAffectLastWriteTime()
+        public async Task MockFile_SetLastWriteTimeUtc_ShouldAffectLastWriteTime()
         {
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
@@ -316,11 +316,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.GetLastWriteTime(path);
 
             // Assert
-            Assert.That(result, Is.EqualTo(lastWriteTime));
+            await That(result).IsEqualTo(lastWriteTime);
         }
 
         [Test]
-        public void MockFile_SetLastWriteTime_ShouldAffectLastWriteTimeUtc()
+        public async Task MockFile_SetLastWriteTime_ShouldAffectLastWriteTimeUtc()
         {
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
@@ -336,11 +336,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.GetLastWriteTimeUtc(path);
 
             // Assert
-            Assert.That(result, Is.EqualTo(lastWriteTime.ToUniversalTime()));
+            await That(result).IsEqualTo(lastWriteTime.ToUniversalTime());
         }
 
         [Test]
-        public void MockFile_ReadAllText_ShouldReturnOriginalTextData()
+        public async Task MockFile_ReadAllText_ShouldReturnOriginalTextData()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -355,11 +355,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.ReadAllText(XFS.Path(@"c:\something\demo.txt"));
 
             // Assert
-            Assert.That(result, Is.EqualTo("Demo text content"));
+            await That(result).IsEqualTo("Demo text content");
         }
 
         [Test]
-        public void MockFile_ReadAllText_ShouldReturnOriginalDataWithCustomEncoding()
+        public async Task MockFile_ReadAllText_ShouldReturnOriginalDataWithCustomEncoding()
         {
             // Arrange
             string text = "Hello there!";
@@ -375,7 +375,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = file.ReadAllText(XFS.Path(@"c:\something\demo.txt"), Encoding.BigEndianUnicode);
 
             // Assert
-            Assert.That(result, Is.EqualTo(text));
+            await That(result).IsEqualTo(text);
         }
 
         public static IEnumerable<Encoding> GetEncodingsForReadAllText()
@@ -391,7 +391,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [TestCaseSource(typeof(MockFileTests), nameof(GetEncodingsForReadAllText))]
-        public void MockFile_ReadAllText_ShouldReturnTheOriginalContentWhenTheFileContainsDifferentEncodings(Encoding encoding)
+        public async Task MockFile_ReadAllText_ShouldReturnTheOriginalContentWhenTheFileContainsDifferentEncodings(Encoding encoding)
         {
             // Arrange
             string text = "Hello there!";
@@ -406,11 +406,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualText = fileSystem.File.ReadAllText(path);
 
             // Assert
-            Assert.That(actualText, Is.EqualTo(text));
+            await That(actualText).IsEqualTo(text);
         }
 
         [Test]
-        public void MockFile_OpenWrite_ShouldCreateNewFiles()
+        public async Task MockFile_OpenWrite_ShouldCreateNewFiles()
         {
             string filePath = XFS.Path(@"c:\something\demo.txt");
             string fileContent = "this is some content";
@@ -422,21 +422,21 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             stream.Write(bytes, 0, bytes.Length);
             stream.Dispose();
 
-            Assert.That(fileSystem.FileExists(filePath), Is.True);
-            Assert.That(fileSystem.GetFile(filePath).TextContents, Is.EqualTo(fileContent));
+            await That(fileSystem.FileExists(filePath)).IsTrue();
+            await That(fileSystem.GetFile(filePath).TextContents).IsEqualTo(fileContent);
         }
 
         [Test]
-        public void MockFile_OpenWrite_ShouldNotCreateFolders()
+        public async Task MockFile_OpenWrite_ShouldNotCreateFolders()
         {
             string filePath = XFS.Path(@"c:\something\demo.txt"); // c:\something does not exist: OpenWrite should fail
             var fileSystem = new MockFileSystem();
 
-            Assert.Throws<DirectoryNotFoundException>(() => fileSystem.File.OpenWrite(filePath));
+            await That(() => fileSystem.File.OpenWrite(filePath)).Throws<DirectoryNotFoundException>();
         }
 
         [Test]
-        public void MockFile_OpenWrite_ShouldOverwriteExistingFiles()
+        public async Task MockFile_OpenWrite_ShouldOverwriteExistingFiles()
         {
             string filePath = XFS.Path(@"c:\something\demo.txt");
             string startFileContent = "this is some content";
@@ -451,12 +451,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             stream.Write(bytes, 0, bytes.Length);
             stream.Dispose();
 
-            Assert.That(fileSystem.FileExists(filePath), Is.True);
-            Assert.That(fileSystem.GetFile(filePath).TextContents, Is.EqualTo(endFileContent));
+            await That(fileSystem.FileExists(filePath)).IsTrue();
+            await That(fileSystem.GetFile(filePath).TextContents).IsEqualTo(endFileContent);
         }
 
         [Test]
-        public void MockFile_Delete_ShouldRemoveFileFromFileSystem()
+        public async Task MockFile_Delete_ShouldRemoveFileFromFileSystem()
         {
             string fullPath = XFS.Path(@"c:\something\demo.txt");
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -468,22 +468,22 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             file.Delete(fullPath);
 
-            Assert.That(fileSystem.FileExists(fullPath), Is.False);
+            await That(fileSystem.FileExists(fullPath)).IsFalse();
         }
 
         [Test]
-        public void MockFile_Delete_Should_RemoveFiles()
+        public async Task MockFile_Delete_Should_RemoveFiles()
         {
             string filePath = XFS.Path(@"c:\something\demo.txt");
             string fileContent = "this is some content";
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData> { { filePath, new MockFileData(fileContent) } });
-            Assert.That(fileSystem.AllFiles.Count(), Is.EqualTo(1));
+            await That(fileSystem.AllFiles.Count()).IsEqualTo(1);
             fileSystem.File.Delete(filePath);
-            Assert.That(fileSystem.AllFiles.Count(), Is.EqualTo(0));
+            await That(fileSystem.AllFiles.Count()).IsEqualTo(0);
         }
 
         [Test]
-        public void MockFile_Delete_No_File_Does_Nothing()
+        public async Task MockFile_Delete_No_File_Does_Nothing()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>()
             {
@@ -496,7 +496,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [Test]
-        public void MockFile_Delete_ShouldThrowUnauthorizedAccessException_WhenPathIsADirectory()
+        public async Task MockFile_Delete_ShouldThrowUnauthorizedAccessException_WhenPathIsADirectory()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -505,14 +505,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             });
 
             // Act
-            TestDelegate action = () => fileSystem.File.Delete(XFS.Path(@"c:\bar"));
+            Action action = () => fileSystem.File.Delete(XFS.Path(@"c:\bar"));
 
             // Assert
-            Assert.Throws<UnauthorizedAccessException>(action);
+            await That(action).Throws<UnauthorizedAccessException>();
         }
 
         [Test]
-        public void MockFile_AppendText_AppendTextToAnExistingFile()
+        public async Task MockFile_AppendText_AppendTextToAnExistingFile()
         {
             string filepath = XFS.Path(@"c:\something\does\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -527,11 +527,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             stream.Dispose();
 
             var file = filesystem.GetFile(filepath);
-            Assert.That(file.TextContents, Is.EqualTo("I'm here. Me too!"));
+            await That(file.TextContents).IsEqualTo("I'm here. Me too!");
         }
 
         [Test]
-        public void MockFile_AppendText_CreatesNewFileForAppendToNonExistingFile()
+        public async Task MockFile_AppendText_CreatesNewFileForAppendToNonExistingFile()
         {
             string filepath = XFS.Path(@"c:\something\doesnt\exist.txt");
             var filesystem = new MockFileSystem(new Dictionary<string, MockFileData>());
@@ -544,13 +544,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             stream.Dispose();
 
             var file = filesystem.GetFile(filepath);
-            Assert.That(file.TextContents, Is.EqualTo("New too!"));
-            Assert.That(filesystem.FileExists(filepath));
+            await That(file.TextContents).IsEqualTo("New too!");
+            await That(filesystem.FileExists(filepath)).IsTrue();
         }
         
 #if !NET9_0_OR_GREATER
         [Test]
-        public void Serializable_works()
+        public async Task Serializable_works()
         {
             //Arrange
             MockFileData data = new MockFileData("Text Contents");
@@ -570,7 +570,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         
 #if !NET9_0_OR_GREATER
         [Test]
-        public void Serializable_can_deserialize()
+        public async Task Serializable_can_deserialize()
         {
             //Arrange
             string textContentStr = "Text Contents";
@@ -589,12 +589,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 #pragma warning restore SYSLIB0011
 
             //Assert
-            Assert.That(deserialized.TextContents, Is.EqualTo(textContentStr));
+            await That(deserialized.TextContents).IsEqualTo(textContentStr);
         }
 #endif
 
         [Test]
-        public void MockFile_Encrypt_ShouldSetEncryptedAttribute()
+        public async Task MockFile_Encrypt_ShouldSetEncryptedAttribute()
         {
             // Arrange
             var fileData = new MockFileData("Demo text content");
@@ -611,11 +611,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var attributes = fileSystem.File.GetAttributes(filePath);
 
             // Assert
-            Assert.That(attributes & FileAttributes.Encrypted, Is.EqualTo(FileAttributes.Encrypted));
+            await That(attributes & FileAttributes.Encrypted).IsEqualTo(FileAttributes.Encrypted);
         }
 
         [Test]
-        public void MockFile_Decrypt_ShouldRemoveEncryptedAttribute()
+        public async Task MockFile_Decrypt_ShouldRemoveEncryptedAttribute()
         {
             // Arrange
             const string Content = "Demo text content";
@@ -636,11 +636,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var attributes = fileSystem.File.GetAttributes(filePath);
 
             // Assert
-            Assert.That(attributes & FileAttributes.Encrypted, Is.Not.EqualTo(FileAttributes.Encrypted));
+            await That(attributes & FileAttributes.Encrypted).IsNotEqualTo(FileAttributes.Encrypted);
         }
 
         [Test]
-        public void MockFile_Replace_ShouldReplaceFileContents()
+        public async Task MockFile_Replace_ShouldReplaceFileContents()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -652,11 +652,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Act
             fileSystem.File.Replace(path1, path2, null);
 
-            Assert.That(fileSystem.File.ReadAllText(path2), Is.EqualTo("1"));
+            await That(fileSystem.File.ReadAllText(path2)).IsEqualTo("1");
         }
 
         [Test]
-        public void MockFile_Replace_ShouldCreateBackup()
+        public async Task MockFile_Replace_ShouldCreateBackup()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -669,11 +669,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // Act
             fileSystem.File.Replace(path1, path2, path3);
 
-            Assert.That(fileSystem.File.ReadAllText(path3), Is.EqualTo("2"));
+            await That(fileSystem.File.ReadAllText(path3)).IsEqualTo("2");
         } 
 
         [Test]
-        public void MockFile_Replace_ShouldThrowIfDirectoryOfBackupPathDoesNotExist()
+        public async Task MockFile_Replace_ShouldThrowIfDirectoryOfBackupPathDoesNotExist()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -684,11 +684,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             fileSystem.AddFile(path2, new MockFileData("2"));
 
             // Act
-            Assert.Throws<DirectoryNotFoundException>(() => fileSystem.File.Replace(path1, path2, path3));
+            await That(() => fileSystem.File.Replace(path1, path2, path3)).Throws<DirectoryNotFoundException>();
         }
 
         [Test]
-        public void MockFile_Replace_ShouldThrowIfSourceFileDoesNotExist()
+        public async Task MockFile_Replace_ShouldThrowIfSourceFileDoesNotExist()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -696,11 +696,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var path2 = XFS.Path(@"c:\temp\file2.txt");
             fileSystem.AddFile(path2, new MockFileData("2"));
 
-            Assert.Throws<FileNotFoundException>(() => fileSystem.File.Replace(path1, path2, null));
+            await That(() => fileSystem.File.Replace(path1, path2, null)).Throws<FileNotFoundException>();
         }
 
         [Test]
-        public void MockFile_Replace_ShouldThrowIfDestinationFileDoesNotExist()
+        public async Task MockFile_Replace_ShouldThrowIfDestinationFileDoesNotExist()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -708,11 +708,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var path2 = XFS.Path(@"c:\temp\file2.txt");
             fileSystem.AddFile(path1, new MockFileData("1"));
 
-            Assert.Throws<FileNotFoundException>(() => fileSystem.File.Replace(path1, path2, null));
+            await That(() => fileSystem.File.Replace(path1, path2, null)).Throws<FileNotFoundException>();
         }
 
         [Test]
-        public void MockFile_OpenRead_ShouldReturnReadOnlyStream()
+        public async Task MockFile_OpenRead_ShouldReturnReadOnlyStream()
         {
             // Tests issue #230
             // Arrange
@@ -727,8 +727,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var stream = fileSystem.File.OpenRead(filePath);
 
             // Assert
-            Assert.That(stream.CanWrite, Is.False);
-            Assert.Throws<NotSupportedException>(() => stream.WriteByte(0));
+            await That(stream.CanWrite).IsFalse();
+            await That(() => stream.WriteByte(0)).Throws<NotSupportedException>();
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
@@ -492,7 +492,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             string filePath = XFS.Path(@"c:\something\not_exist.txt");
 
-            fileSystem.File.Delete(filePath);
+            await That(() => fileSystem.File.Delete(filePath)).DoesNotThrow();
         }
 
         [Test]
@@ -550,7 +550,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         
 #if !NET9_0_OR_GREATER
         [Test]
-        public async Task Serializable_works()
+        public void Serializable_works()
         {
             //Arrange
             MockFileData data = new MockFileData("Text Contents");

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileVersionInfoFactoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileVersionInfoFactoryTests.cs
@@ -7,7 +7,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockFileVersionInfoFactoryTests
     {
         [Test]
-        public void MockFileVersionInfoFactory_GetVersionInfo_ShouldReturnTheFileVersionInfoOfTheMockFileData()
+        public async Task MockFileVersionInfoFactory_GetVersionInfo_ShouldReturnTheFileVersionInfoOfTheMockFileData()
         {
             // Arrange
             var fileVersionInfo = new MockFileVersionInfo(@"c:\a.txt");
@@ -20,11 +20,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = fileSystem.FileVersionInfo.GetVersionInfo(@"c:\a.txt");
 
             // Assert
-            Assert.That(result, Is.EqualTo(fileVersionInfo));
+            await That(result).IsEqualTo(fileVersionInfo);
         }
 
         [Test]
-        public void MockFileVersionInfoFactory_GetVersionInfo_ShouldThrowFileNotFoundExceptionIfFileDoesNotExist()
+        public async Task MockFileVersionInfoFactory_GetVersionInfo_ShouldThrowFileNotFoundExceptionIfFileDoesNotExist()
         {
             // Arrange
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -34,10 +34,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             });
 
             // Act
-            TestDelegate code = () => fileSystem.FileVersionInfo.GetVersionInfo(@"c:\foo.txt");
+            Action code = () => fileSystem.FileVersionInfo.GetVersionInfo(@"c:\foo.txt");
 
             // Assert
-            Assert.Throws<FileNotFoundException>(code);
+            await That(code).Throws<FileNotFoundException>();
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileVersionInfoTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileVersionInfoTests.cs
@@ -6,7 +6,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class MockFileVersionInfoTests
     {
         [Test]
-        public void MockFileVersionInfo_ToString_ShouldReturnTheDefaultFormat()
+        public async Task MockFileVersionInfo_ToString_ShouldReturnTheDefaultFormat()
         {
             // Arrange
             var mockFileVersionInfo = new MockFileVersionInfo(
@@ -46,41 +46,41 @@ Language:         English
 ";
 
             // Act & Assert
-            Assert.That(mockFileVersionInfo.ToString(), Is.EqualTo(expected));
+            await That(mockFileVersionInfo.ToString()).IsEqualTo(expected);
         }
 
         [Test]
-        public void MockFileVersionInfo_Constructor_ShouldSetFileAndProductVersionNumbersIfFileAndProductVersionAreNotNull()
+        public async Task MockFileVersionInfo_Constructor_ShouldSetFileAndProductVersionNumbersIfFileAndProductVersionAreNotNull()
         {
             // Arrange
             var mockFileVersionInfo = new MockFileVersionInfo(@"c:\file.txt", fileVersion: "1.2.3.4", productVersion: "5.6.7.8");
 
             // Assert
-            Assert.That(mockFileVersionInfo.FileMajorPart, Is.EqualTo(1));
-            Assert.That(mockFileVersionInfo.FileMinorPart, Is.EqualTo(2));
-            Assert.That(mockFileVersionInfo.FileBuildPart, Is.EqualTo(3));
-            Assert.That(mockFileVersionInfo.FilePrivatePart, Is.EqualTo(4));
-            Assert.That(mockFileVersionInfo.ProductMajorPart, Is.EqualTo(5));
-            Assert.That(mockFileVersionInfo.ProductMinorPart, Is.EqualTo(6));
-            Assert.That(mockFileVersionInfo.ProductBuildPart, Is.EqualTo(7));
-            Assert.That(mockFileVersionInfo.ProductPrivatePart, Is.EqualTo(8));
+            await That(mockFileVersionInfo.FileMajorPart).IsEqualTo(1);
+            await That(mockFileVersionInfo.FileMinorPart).IsEqualTo(2);
+            await That(mockFileVersionInfo.FileBuildPart).IsEqualTo(3);
+            await That(mockFileVersionInfo.FilePrivatePart).IsEqualTo(4);
+            await That(mockFileVersionInfo.ProductMajorPart).IsEqualTo(5);
+            await That(mockFileVersionInfo.ProductMinorPart).IsEqualTo(6);
+            await That(mockFileVersionInfo.ProductBuildPart).IsEqualTo(7);
+            await That(mockFileVersionInfo.ProductPrivatePart).IsEqualTo(8);
         }
 
         [Test]
-        public void MockFileVersionInfo_Constructor_ShouldNotSetFileAndProductVersionNumbersIfFileAndProductVersionAreNull()
+        public async Task MockFileVersionInfo_Constructor_ShouldNotSetFileAndProductVersionNumbersIfFileAndProductVersionAreNull()
         {
             // Act
             var mockFileVersionInfo = new MockFileVersionInfo(@"c:\a.txt");
 
             // Assert
-            Assert.That(mockFileVersionInfo.FileMajorPart, Is.EqualTo(0));
-            Assert.That(mockFileVersionInfo.FileMinorPart, Is.EqualTo(0));
-            Assert.That(mockFileVersionInfo.FileBuildPart, Is.EqualTo(0));
-            Assert.That(mockFileVersionInfo.FilePrivatePart, Is.EqualTo(0));
-            Assert.That(mockFileVersionInfo.ProductMajorPart, Is.EqualTo(0));
-            Assert.That(mockFileVersionInfo.ProductMinorPart, Is.EqualTo(0));
-            Assert.That(mockFileVersionInfo.ProductBuildPart, Is.EqualTo(0));
-            Assert.That(mockFileVersionInfo.ProductPrivatePart, Is.EqualTo(0));
+            await That(mockFileVersionInfo.FileMajorPart).IsEqualTo(0);
+            await That(mockFileVersionInfo.FileMinorPart).IsEqualTo(0);
+            await That(mockFileVersionInfo.FileBuildPart).IsEqualTo(0);
+            await That(mockFileVersionInfo.FilePrivatePart).IsEqualTo(0);
+            await That(mockFileVersionInfo.ProductMajorPart).IsEqualTo(0);
+            await That(mockFileVersionInfo.ProductMinorPart).IsEqualTo(0);
+            await That(mockFileVersionInfo.ProductBuildPart).IsEqualTo(0);
+            await That(mockFileVersionInfo.ProductPrivatePart).IsEqualTo(0);
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllLinesTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllLinesTests.cs
@@ -66,10 +66,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 var fileSystem = new MockFileSystem();
                 var fileContentEnumerable = new List<string>();
                 var fileContentArray = fileContentEnumerable.ToArray();
-                TestDelegate writeEnumerable = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable);
-                TestDelegate writeEnumerableUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable, Encoding.UTF32);
-                TestDelegate writeArray = () => fileSystem.File.WriteAllLines(path, fileContentArray);
-                TestDelegate writeArrayUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentArray, Encoding.UTF32);
+                Action writeEnumerable = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable);
+                Action writeEnumerableUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable, Encoding.UTF32);
+                Action writeArray = () => fileSystem.File.WriteAllLines(path, fileContentArray);
+                Action writeArrayUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentArray, Encoding.UTF32);
 
                 // IEnumerable
                 yield return new TestCaseData(writeEnumerable)
@@ -91,8 +91,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                     var fileSystem = new MockFileSystem();
                     var fileContentEnumerable = new List<string>();
                     var fileContentArray = fileContentEnumerable.ToArray();
-                    TestDelegate writeEnumerableNull = () => fileSystem.File.WriteAllLines(Path, fileContentEnumerable, null);
-                    TestDelegate writeArrayNull = () => fileSystem.File.WriteAllLines(Path, fileContentArray, null);
+                    Action writeEnumerableNull = () => fileSystem.File.WriteAllLines(Path, fileContentEnumerable, null);
+                    Action writeArrayNull = () => fileSystem.File.WriteAllLines(Path, fileContentArray, null);
 
                     // IEnumerable
                     yield return new TestCaseData(writeEnumerableNull)
@@ -113,10 +113,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                     fileSystem.Directory.CreateDirectory(path);
                     var fileContentEnumerable = new List<string>();
                     var fileContentArray = fileContentEnumerable.ToArray();
-                    TestDelegate writeEnumerable = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable);
-                    TestDelegate writeEnumerableUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable, Encoding.UTF32);
-                    TestDelegate writeArray = () => fileSystem.File.WriteAllLines(path, fileContentArray);
-                    TestDelegate writeArrayUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentArray, Encoding.UTF32);
+                    Action writeEnumerable = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable);
+                    Action writeEnumerableUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable, Encoding.UTF32);
+                    Action writeArray = () => fileSystem.File.WriteAllLines(path, fileContentArray);
+                    Action writeArrayUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentArray, Encoding.UTF32);
 
                     // IEnumerable
                     yield return new TestCaseData(writeEnumerable, path)
@@ -143,10 +143,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                     fileSystem.AddFile(path, mockFileData);
                     var fileContentEnumerable = new List<string>();
                     var fileContentArray = fileContentEnumerable.ToArray();
-                    TestDelegate writeEnumerable = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable);
-                    TestDelegate writeEnumerableUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable, Encoding.UTF32);
-                    TestDelegate writeArray = () => fileSystem.File.WriteAllLines(path, fileContentArray);
-                    TestDelegate writeArrayUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentArray, Encoding.UTF32);
+                    Action writeEnumerable = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable);
+                    Action writeEnumerableUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable, Encoding.UTF32);
+                    Action writeArray = () => fileSystem.File.WriteAllLines(path, fileContentArray);
+                    Action writeArrayUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentArray, Encoding.UTF32);
 
                     // IEnumerable
                     yield return new TestCaseData(writeEnumerable, path)
@@ -176,10 +176,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                     string[] fileContentArray = null;
 
                     // ReSharper disable ExpressionIsAlwaysNull
-                    TestDelegate writeEnumerable = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable);
-                    TestDelegate writeEnumerableUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable, Encoding.UTF32);
-                    TestDelegate writeArray = () => fileSystem.File.WriteAllLines(path, fileContentArray);
-                    TestDelegate writeArrayUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentArray, Encoding.UTF32);
+                    Action writeEnumerable = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable);
+                    Action writeEnumerableUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentEnumerable, Encoding.UTF32);
+                    Action writeArray = () => fileSystem.File.WriteAllLines(path, fileContentArray);
+                    Action writeArrayUtf32 = () => fileSystem.File.WriteAllLines(path, fileContentArray, Encoding.UTF32);
                     // ReSharper restore ExpressionIsAlwaysNull
 
                     // IEnumerable
@@ -249,10 +249,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                 var fileSystem = new MockFileSystem();
                 var fileContentEnumerable = new List<string>();
                 var fileContentArray = fileContentEnumerable.ToArray();
-                AsyncTestDelegate writeEnumberable = () => fileSystem.File.WriteAllLinesAsync(path, fileContentEnumerable);
-                AsyncTestDelegate writeEnumberableUtf32 = () => fileSystem.File.WriteAllLinesAsync(path, fileContentEnumerable, Encoding.UTF32);
-                AsyncTestDelegate writeArray = () => fileSystem.File.WriteAllLinesAsync(path, fileContentArray);
-                AsyncTestDelegate writeArrayUtf32 = () => fileSystem.File.WriteAllLinesAsync(path, fileContentArray, Encoding.UTF32);
+                Func<Task> writeEnumberable = () => fileSystem.File.WriteAllLinesAsync(path, fileContentEnumerable);
+                Func<Task> writeEnumberableUtf32 = () => fileSystem.File.WriteAllLinesAsync(path, fileContentEnumerable, Encoding.UTF32);
+                Func<Task> writeArray = () => fileSystem.File.WriteAllLinesAsync(path, fileContentArray);
+                Func<Task> writeArrayUtf32 = () => fileSystem.File.WriteAllLinesAsync(path, fileContentArray, Encoding.UTF32);
 
                 // IEnumerable
                 yield return new TestCaseData(writeEnumberable)
@@ -274,8 +274,8 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                     var fileSystem = new MockFileSystem();
                     var fileContentEnumerable = new List<string>();
                     var fileContentArray = fileContentEnumerable.ToArray();
-                    AsyncTestDelegate writeEnumberableNull = () => fileSystem.File.WriteAllLinesAsync(Path, fileContentEnumerable, null);
-                    AsyncTestDelegate writeArrayNull = () => fileSystem.File.WriteAllLinesAsync(Path, fileContentArray, null);
+                    Func<Task> writeEnumberableNull = () => fileSystem.File.WriteAllLinesAsync(Path, fileContentEnumerable, null);
+                    Func<Task> writeArrayNull = () => fileSystem.File.WriteAllLinesAsync(Path, fileContentArray, null);
 
                     // IEnumerable
                     yield return new TestCaseData(writeEnumberableNull)
@@ -296,10 +296,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                     fileSystem.Directory.CreateDirectory(path);
                     var fileContentEnumerable = new List<string>();
                     var fileContentArray = fileContentEnumerable.ToArray();
-                    AsyncTestDelegate writeEnumberable = () => fileSystem.File.WriteAllLinesAsync(path, fileContentEnumerable);
-                    AsyncTestDelegate writeEnumberableUtf32 = () => fileSystem.File.WriteAllLinesAsync(path, fileContentEnumerable, Encoding.UTF32);
-                    AsyncTestDelegate writeArray = () => fileSystem.File.WriteAllLinesAsync(path, fileContentArray);
-                    AsyncTestDelegate writeArrayUtf32 = () => fileSystem.File.WriteAllLinesAsync(path, fileContentArray, Encoding.UTF32);
+                    Func<Task> writeEnumberable = () => fileSystem.File.WriteAllLinesAsync(path, fileContentEnumerable);
+                    Func<Task> writeEnumberableUtf32 = () => fileSystem.File.WriteAllLinesAsync(path, fileContentEnumerable, Encoding.UTF32);
+                    Func<Task> writeArray = () => fileSystem.File.WriteAllLinesAsync(path, fileContentArray);
+                    Func<Task> writeArrayUtf32 = () => fileSystem.File.WriteAllLinesAsync(path, fileContentArray, Encoding.UTF32);
 
                     // IEnumerable
                     yield return new TestCaseData(writeEnumberable, path)
@@ -326,10 +326,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                     fileSystem.AddFile(path, mockFileData);
                     var fileContentEnumerable = new List<string>();
                     var fileContentArray = fileContentEnumerable.ToArray();
-                    AsyncTestDelegate writeEnumberable = () => fileSystem.File.WriteAllLinesAsync(path, fileContentEnumerable);
-                    AsyncTestDelegate writeEnumberableUtf32 = () => fileSystem.File.WriteAllLinesAsync(path, fileContentEnumerable, Encoding.UTF32);
-                    AsyncTestDelegate writeArray = () => fileSystem.File.WriteAllLinesAsync(path, fileContentArray);
-                    AsyncTestDelegate writeArrayUtf32 = () => fileSystem.File.WriteAllLinesAsync(path, fileContentArray, Encoding.UTF32);
+                    Func<Task> writeEnumberable = () => fileSystem.File.WriteAllLinesAsync(path, fileContentEnumerable);
+                    Func<Task> writeEnumberableUtf32 = () => fileSystem.File.WriteAllLinesAsync(path, fileContentEnumerable, Encoding.UTF32);
+                    Func<Task> writeArray = () => fileSystem.File.WriteAllLinesAsync(path, fileContentArray);
+                    Func<Task> writeArrayUtf32 = () => fileSystem.File.WriteAllLinesAsync(path, fileContentArray, Encoding.UTF32);
 
                     // IEnumerable
                     yield return new TestCaseData(writeEnumberable, path)
@@ -359,10 +359,10 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
                     string[] fileContentArray = null;
 
                     // ReSharper disable ExpressionIsAlwaysNull
-                    AsyncTestDelegate writeEnumberable = () => fileSystem.File.WriteAllLinesAsync(path, fileContentEnumerable);
-                    AsyncTestDelegate writeEnumberableUtf32 = () => fileSystem.File.WriteAllLinesAsync(path, fileContentEnumerable, Encoding.UTF32);
-                    AsyncTestDelegate writeArray = () => fileSystem.File.WriteAllLinesAsync(path, fileContentArray);
-                    AsyncTestDelegate writeArrayUtf32 = () => fileSystem.File.WriteAllLinesAsync(path, fileContentArray, Encoding.UTF32);
+                    Func<Task> writeEnumberable = () => fileSystem.File.WriteAllLinesAsync(path, fileContentEnumerable);
+                    Func<Task> writeEnumberableUtf32 = () => fileSystem.File.WriteAllLinesAsync(path, fileContentEnumerable, Encoding.UTF32);
+                    Func<Task> writeArray = () => fileSystem.File.WriteAllLinesAsync(path, fileContentArray);
+                    Func<Task> writeArrayUtf32 = () => fileSystem.File.WriteAllLinesAsync(path, fileContentArray, Encoding.UTF32);
                     // ReSharper restore ExpressionIsAlwaysNull
 
                     // IEnumerable
@@ -380,29 +380,29 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             }
 
             [Test]
-            public void MockFile_WriteAllLinesAsync_ShouldThrowOperationCanceledExceptionIfCancelled()
+            public async Task MockFile_WriteAllLinesAsync_ShouldThrowOperationCanceledExceptionIfCancelled()
             {
                 // Arrange
                 const string path = "test.txt";
                 var fileSystem = new MockFileSystem();
 
                 // Act
-                Assert.ThrowsAsync<OperationCanceledException>(async () =>
+                async Task Act() =>
                     await fileSystem.File.WriteAllLinesAsync(
                         path,
                         new[] { "line 1", "line 2" },
-                        new CancellationToken(canceled: true))
-                );
+                        new CancellationToken(canceled: true));
+                await That(Act).Throws<OperationCanceledException>();
 
                 // Assert
-                Assert.That(fileSystem.File.Exists(path), Is.False);
+                await That(fileSystem.File.Exists(path)).IsFalse();
             }
 #endif
 
         }
 
         [TestCaseSource(typeof(TestDataForWriteAllLines), nameof(TestDataForWriteAllLines.ForDifferentEncoding))]
-        public void MockFile_WriteAllLinesGeneric_ShouldWriteTheCorrectContent(IMockFileDataAccessor fileSystem, Action action, string expectedContent)
+        public async Task MockFile_WriteAllLinesGeneric_ShouldWriteTheCorrectContent(IMockFileDataAccessor fileSystem, Action action, string expectedContent)
         {
             // Arrange
             // is done in the test case source
@@ -412,11 +412,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             var actualContent = fileSystem.GetFile(TestDataForWriteAllLines.Path).TextContents;
-            Assert.That(actualContent, Is.EqualTo(expectedContent));
+            await That(actualContent).IsEqualTo(expectedContent);
         }
 
         [TestCaseSource(typeof(TestDataForWriteAllLines), nameof(TestDataForWriteAllLines.ForNullPath))]
-        public void MockFile_WriteAllLinesGeneric_ShouldThrowAnArgumentNullExceptionIfPathIsNull(TestDelegate action)
+        public async Task MockFile_WriteAllLinesGeneric_ShouldThrowAnArgumentNullExceptionIfPathIsNull(Action action)
         {
             // Arrange
             // is done in the test case source
@@ -425,13 +425,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // is done in the test case source
 
             // Assert
-            var exception = Assert.Throws<ArgumentNullException>(action);
-            Assert.That(exception.Message, Does.StartWith("Value cannot be null."));
-            Assert.That(exception.ParamName, Does.StartWith("path"));
+            var exception = await That(action).Throws<ArgumentNullException>();
+            await That(exception.Message).StartsWith("Value cannot be null.");
+            await That(exception.ParamName).StartsWith("path");
         }
 
         [TestCaseSource(typeof(TestDataForWriteAllLines), "ForNullEncoding")]
-        public void MockFile_WriteAllLinesGeneric_ShouldThrowAnArgumentNullExceptionIfEncodingIsNull(TestDelegate action)
+        public async Task MockFile_WriteAllLinesGeneric_ShouldThrowAnArgumentNullExceptionIfEncodingIsNull(Action action)
         {
             // Arrange
             // is done in the test case source
@@ -440,14 +440,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // is done in the test case source
 
             // Assert
-            var exception = Assert.Throws<ArgumentNullException>(action);
-            Assert.That(exception.Message, Does.StartWith("Value cannot be null."));
-            Assert.That(exception.ParamName, Does.StartWith("encoding"));
+            var exception = await That(action).Throws<ArgumentNullException>();
+            await That(exception.Message).StartsWith("Value cannot be null.");
+            await That(exception.ParamName).StartsWith("encoding");
         }
 
         [TestCaseSource(typeof(TestDataForWriteAllLines), nameof(TestDataForWriteAllLines.ForIllegalPath))]
         [WindowsOnly(WindowsSpecifics.StrictPathRules)]
-        public void MockFile_WriteAllLinesGeneric_ShouldThrowAnArgumentExceptionIfPathContainsIllegalCharacters(TestDelegate action)
+        public async Task MockFile_WriteAllLinesGeneric_ShouldThrowAnArgumentExceptionIfPathContainsIllegalCharacters(Action action)
         {
             // Arrange
             // is done in the test case source
@@ -456,12 +456,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // is done in the test case source
 
             // Assert
-            var exception = Assert.Throws<ArgumentException>(action);
-            Assert.That(exception.Message, Is.EqualTo("Illegal characters in path."));
+            var exception = await That(action).Throws<ArgumentException>();
+            await That(exception.Message).IsEqualTo("Illegal characters in path.");
         }
 
         [TestCaseSource(typeof(TestDataForWriteAllLines), nameof(TestDataForWriteAllLines.ForPathIsDirectory))]
-        public void MockFile_WriteAllLinesGeneric_ShouldThrowAnUnauthorizedAccessExceptionIfPathIsOneDirectory(TestDelegate action, string path)
+        public async Task MockFile_WriteAllLinesGeneric_ShouldThrowAnUnauthorizedAccessExceptionIfPathIsOneDirectory(Action action, string path)
         {
             // Arrange
             // is done in the test case source
@@ -470,13 +470,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // is done in the test case source
 
             // Assert
-            var exception = Assert.Throws<UnauthorizedAccessException>(action);
+            var exception = await That(action).Throws<UnauthorizedAccessException>();
             var expectedMessage = string.Format(CultureInfo.InvariantCulture, "Access to the path '{0}' is denied.", path);
-            Assert.That(exception.Message, Is.EqualTo(expectedMessage));
+            await That(exception.Message).IsEqualTo(expectedMessage);
         }
 
         [TestCaseSource(typeof(TestDataForWriteAllLines), nameof(TestDataForWriteAllLines.ForFileIsReadOnly))]
-        public void MockFile_WriteAllLinesGeneric_ShouldThrowOneUnauthorizedAccessExceptionIfFileIsReadOnly(TestDelegate action, string path)
+        public async Task MockFile_WriteAllLinesGeneric_ShouldThrowOneUnauthorizedAccessExceptionIfFileIsReadOnly(Action action, string path)
         {
             // Arrange
             // is done in the test case source
@@ -485,13 +485,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // is done in the test case source
 
             // Assert
-            var exception = Assert.Throws<UnauthorizedAccessException>(action);
+            var exception = await That(action).Throws<UnauthorizedAccessException>();
             var expectedMessage = string.Format(CultureInfo.InvariantCulture, "Access to the path '{0}' is denied.", path);
-            Assert.That(exception.Message, Is.EqualTo(expectedMessage));
+            await That(exception.Message).IsEqualTo(expectedMessage);
         }
 
         [TestCaseSource(typeof(TestDataForWriteAllLines), nameof(TestDataForWriteAllLines.ForContentsIsNull))]
-        public void MockFile_WriteAllLinesGeneric_ShouldThrowAnArgumentNullExceptionIfContentsIsNull(TestDelegate action)
+        public async Task MockFile_WriteAllLinesGeneric_ShouldThrowAnArgumentNullExceptionIfContentsIsNull(Action action)
         {
             // Arrange
             // is done in the test case source
@@ -500,14 +500,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // is done in the test case sourceForContentsIsNull
 
             // Assert
-            var exception = Assert.Throws<ArgumentNullException>(action);
-            Assert.That(exception.Message, Does.StartWith("Value cannot be null."));
-            Assert.That(exception.ParamName, Is.EqualTo("contents"));
+            var exception = await That(action).Throws<ArgumentNullException>();
+            await That(exception.Message).StartsWith("Value cannot be null.");
+            await That(exception.ParamName).IsEqualTo("contents");
         }
 
 #if FEATURE_ASYNC_FILE
         [TestCaseSource(typeof(TestDataForWriteAllLines), nameof(TestDataForWriteAllLines.ForDifferentEncodingAsync))]
-        public void MockFile_WriteAllLinesAsyncGeneric_ShouldWriteTheCorrectContent(IMockFileDataAccessor fileSystem, Action action, string expectedContent)
+        public async Task MockFile_WriteAllLinesAsyncGeneric_ShouldWriteTheCorrectContent(IMockFileDataAccessor fileSystem, Action action, string expectedContent)
         {
             // Arrange
             // is done in the test case source
@@ -517,11 +517,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             // Assert
             var actualContent = fileSystem.GetFile(TestDataForWriteAllLines.Path).TextContents;
-            Assert.That(actualContent, Is.EqualTo(expectedContent));
+            await That(actualContent).IsEqualTo(expectedContent);
         }
 
         [TestCaseSource(typeof(TestDataForWriteAllLines), nameof(TestDataForWriteAllLines.ForNullPathAsync))]
-        public void MockFile_WriteAllLinesAsyncGeneric_ShouldThrowAnArgumentNullExceptionIfPathIsNull(AsyncTestDelegate action)
+        public async Task MockFile_WriteAllLinesAsyncGeneric_ShouldThrowAnArgumentNullExceptionIfPathIsNull(Func<Task> action)
         {
             // Arrange
             // is done in the test case source
@@ -530,13 +530,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // is done in the test case source
 
             // Assert
-            var exception = Assert.ThrowsAsync<ArgumentNullException>(action);
-            Assert.That(exception.Message, Does.StartWith("Value cannot be null."));
-            Assert.That(exception.ParamName, Does.StartWith("path"));
+            var exception = await That(action).Throws<ArgumentNullException>();
+            await That(exception.Message).StartsWith("Value cannot be null.");
+            await That(exception.ParamName).StartsWith("path");
         }
 
         [TestCaseSource(typeof(TestDataForWriteAllLines), "ForNullEncodingAsync")]
-        public void MockFile_WriteAllLinesAsyncGeneric_ShouldThrowAnArgumentNullExceptionIfEncodingIsNull(AsyncTestDelegate action)
+        public async Task MockFile_WriteAllLinesAsyncGeneric_ShouldThrowAnArgumentNullExceptionIfEncodingIsNull(Func<Task> action)
         {
             // Arrange
             // is done in the test case source
@@ -545,14 +545,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // is done in the test case source
 
             // Assert
-            var exception = Assert.ThrowsAsync<ArgumentNullException>(action);
-            Assert.That(exception.Message, Does.StartWith("Value cannot be null."));
-            Assert.That(exception.ParamName, Does.StartWith("encoding"));
+            var exception = await That(action).Throws<ArgumentNullException>();
+            await That(exception.Message).StartsWith("Value cannot be null.");
+            await That(exception.ParamName).StartsWith("encoding");
         }
 
         [TestCaseSource(typeof(TestDataForWriteAllLines), nameof(TestDataForWriteAllLines.ForIllegalPathAsync))]
         [WindowsOnly(WindowsSpecifics.StrictPathRules)]
-        public void MockFile_WriteAllLinesAsyncGeneric_ShouldThrowAnArgumentExceptionIfPathContainsIllegalCharacters(AsyncTestDelegate action)
+        public async Task MockFile_WriteAllLinesAsyncGeneric_ShouldThrowAnArgumentExceptionIfPathContainsIllegalCharacters(Func<Task> action)
         {
             // Arrange
             // is done in the test case source
@@ -561,12 +561,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // is done in the test case source
 
             // Assert
-            var exception = Assert.ThrowsAsync<ArgumentException>(action);
-            Assert.That(exception.Message, Is.EqualTo("Illegal characters in path."));
+            var exception = await That(action).Throws<ArgumentException>();
+            await That(exception.Message).IsEqualTo("Illegal characters in path.");
         }
 
         [TestCaseSource(typeof(TestDataForWriteAllLines), nameof(TestDataForWriteAllLines.ForPathIsDirectoryAsync))]
-        public void MockFile_WriteAllLinesAsyncGeneric_ShouldThrowAnUnauthorizedAccessExceptionIfPathIsOneDirectory(AsyncTestDelegate action, string path)
+        public async Task MockFile_WriteAllLinesAsyncGeneric_ShouldThrowAnUnauthorizedAccessExceptionIfPathIsOneDirectory(Func<Task> action, string path)
         {
             // Arrange
             // is done in the test case source
@@ -575,13 +575,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // is done in the test case source
 
             // Assert
-            var exception = Assert.ThrowsAsync<UnauthorizedAccessException>(action);
+            var exception = await That(action).Throws<UnauthorizedAccessException>();
             var expectedMessage = string.Format(CultureInfo.InvariantCulture, "Access to the path '{0}' is denied.", path);
-            Assert.That(exception.Message, Is.EqualTo(expectedMessage));
+            await That(exception.Message).IsEqualTo(expectedMessage);
         }
 
         [TestCaseSource(typeof(TestDataForWriteAllLines), nameof(TestDataForWriteAllLines.ForFileIsReadOnlyAsync))]
-        public void MockFile_WriteAllLinesAsyncGeneric_ShouldThrowOneUnauthorizedAccessExceptionIfFileIsReadOnly(AsyncTestDelegate action, string path)
+        public async Task MockFile_WriteAllLinesAsyncGeneric_ShouldThrowOneUnauthorizedAccessExceptionIfFileIsReadOnly(Func<Task> action, string path)
         {
             // Arrange
             // is done in the test case source
@@ -590,13 +590,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // is done in the test case source
 
             // Assert
-            var exception = Assert.ThrowsAsync<UnauthorizedAccessException>(action);
+            var exception = await That(action).Throws<UnauthorizedAccessException>();
             var expectedMessage = string.Format(CultureInfo.InvariantCulture, "Access to the path '{0}' is denied.", path);
-            Assert.That(exception.Message, Is.EqualTo(expectedMessage));
+            await That(exception.Message).IsEqualTo(expectedMessage);
         }
 
         [TestCaseSource(typeof(TestDataForWriteAllLines), nameof(TestDataForWriteAllLines.ForContentsIsNullAsync))]
-        public void MockFile_WriteAllLinesAsyncGeneric_ShouldThrowAnArgumentNullExceptionIfContentsIsNull(AsyncTestDelegate action)
+        public async Task MockFile_WriteAllLinesAsyncGeneric_ShouldThrowAnArgumentNullExceptionIfContentsIsNull(Func<Task> action)
         {
             // Arrange
             // is done in the test case source
@@ -605,9 +605,9 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             // is done in the test case sourceForContentsIsNull
 
             // Assert
-            var exception = Assert.ThrowsAsync<ArgumentNullException>(action);
-            Assert.That(exception.Message, Does.StartWith("Value cannot be null."));
-            Assert.That(exception.ParamName, Is.EqualTo("contents"));
+            var exception = await That(action).Throws<ArgumentNullException>();
+            await That(exception.Message).StartsWith("Value cannot be null.");
+            await That(exception.ParamName).IsEqualTo("contents");
         }
 #endif
     }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllTextTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileWriteAllTextTests.cs
@@ -14,7 +14,7 @@
     public class MockFileWriteAllTextTests
     {
         [Test]
-        public void MockFile_WriteAllText_ShouldWriteTextFileToMemoryFileSystem()
+        public async Task MockFile_WriteAllText_ShouldWriteTextFileToMemoryFileSystem()
         {
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
@@ -26,11 +26,11 @@
             fileSystem.File.WriteAllText(path, fileContent);
 
             // Assert
-            Assert.That(fileSystem.GetFile(path).TextContents, Is.EqualTo(fileContent));
+            await That(fileSystem.GetFile(path).TextContents).IsEqualTo(fileContent);
         }
 
         [Test]
-        public void MockFile_WriteAllText_ShouldOverwriteAnExistingFile()
+        public async Task MockFile_WriteAllText_ShouldOverwriteAnExistingFile()
         {
             // http://msdn.microsoft.com/en-us/library/ms143375.aspx
 
@@ -44,11 +44,11 @@
             fileSystem.File.WriteAllText(path, "bar");
 
             // Assert
-            Assert.That(fileSystem.GetFile(path).TextContents, Is.EqualTo("bar"));
+            await That(fileSystem.GetFile(path).TextContents).IsEqualTo("bar");
         }
 
         [Test]
-        public void MockFile_WriteAllText_ShouldThrowAnUnauthorizedAccessExceptionIfFileIsHidden()
+        public async Task MockFile_WriteAllText_ShouldThrowAnUnauthorizedAccessExceptionIfFileIsHidden()
         {
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
@@ -59,27 +59,28 @@
             fileSystem.File.SetAttributes(path, FileAttributes.Hidden);
 
             // Act
-            TestDelegate action = () => fileSystem.File.WriteAllText(path, "hello world");
+            Action action = () => fileSystem.File.WriteAllText(path, "hello world");
 
             // Assert
-            Assert.Throws<UnauthorizedAccessException>(action, "Access to the path '{0}' is denied.", path);
+            await That(action).Throws<UnauthorizedAccessException>()
+                .Because($"Access to the path '{path}' is denied.");
         }
 
         [Test]
-        public void MockFile_WriteAllText_ShouldThrowAnArgumentExceptionIfThePathIsEmpty()
+        public async Task MockFile_WriteAllText_ShouldThrowAnArgumentExceptionIfThePathIsEmpty()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            TestDelegate action = () => fileSystem.File.WriteAllText(string.Empty, "hello world");
+            Action action = () => fileSystem.File.WriteAllText(string.Empty, "hello world");
 
             // Assert
-            Assert.Throws<ArgumentException>(action);
+            await That(action).Throws<ArgumentException>();
         }
 
         [Test]
-        public void MockFile_WriteAllText_ShouldNotThrowAnArgumentNullExceptionIfTheContentIsNull()
+        public async Task MockFile_WriteAllText_ShouldNotThrowAnArgumentNullExceptionIfTheContentIsNull()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -93,11 +94,11 @@
             // Assert
             // no exception should be thrown, also the documentation says so
             var data = fileSystem.GetFile(filePath);
-            Assert.That(data.Contents, Is.Empty);
+            await That(data.Contents).IsEmpty();
         }
 
         [Test]
-        public void MockFile_WriteAllText_ShouldThrowAnUnauthorizedAccessExceptionIfTheFileIsReadOnly()
+        public async Task MockFile_WriteAllText_ShouldThrowAnUnauthorizedAccessExceptionIfTheFileIsReadOnly()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -107,14 +108,14 @@
             fileSystem.AddFile(filePath, mockFileData);
 
             // Act
-            TestDelegate action = () => fileSystem.File.WriteAllText(filePath, null);
+            Action action = () => fileSystem.File.WriteAllText(filePath, null);
 
             // Assert
-            Assert.Throws<UnauthorizedAccessException>(action);
+            await That(action).Throws<UnauthorizedAccessException>();
         }
 
         [Test]
-        public void MockFile_WriteAllText_ShouldThrowAnUnauthorizedAccessExceptionIfThePathIsOneDirectory()
+        public async Task MockFile_WriteAllText_ShouldThrowAnUnauthorizedAccessExceptionIfThePathIsOneDirectory()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -122,24 +123,24 @@
             fileSystem.AddDirectory(directoryPath);
 
             // Act
-            TestDelegate action = () => fileSystem.File.WriteAllText(directoryPath, null);
+            Action action = () => fileSystem.File.WriteAllText(directoryPath, null);
 
             // Assert
-            Assert.Throws<UnauthorizedAccessException>(action);
+            await That(action).Throws<UnauthorizedAccessException>();
         }
 
         [Test]
-        public void MockFile_WriteAllText_ShouldThrowDirectoryNotFoundExceptionIfPathDoesNotExists()
+        public async Task MockFile_WriteAllText_ShouldThrowDirectoryNotFoundExceptionIfPathDoesNotExists()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
             string path = XFS.Path(@"c:\something\file.txt");
 
             // Act
-            TestDelegate action = () => fileSystem.File.WriteAllText(path, string.Empty);
+            Action action = () => fileSystem.File.WriteAllText(path, string.Empty);
 
             // Assert
-            Assert.Throws<DirectoryNotFoundException>(action);
+            await That(action).Throws<DirectoryNotFoundException>();
         }
 
         public static IEnumerable<KeyValuePair<Encoding, byte[]>> GetEncodingsWithExpectedBytes()
@@ -183,7 +184,7 @@
         }
 
         [TestCaseSource(typeof(MockFileWriteAllTextTests), nameof(GetEncodingsWithExpectedBytes))]
-        public void MockFile_WriteAllText_Encoding_ShouldWriteTextFileToMemoryFileSystem(KeyValuePair<Encoding, byte[]> encodingsWithContents)
+        public async Task MockFile_WriteAllText_Encoding_ShouldWriteTextFileToMemoryFileSystem(KeyValuePair<Encoding, byte[]> encodingsWithContents)
         {
             // Arrange
             const string FileContent = "Hello there! Dzięki.";
@@ -198,11 +199,11 @@
 
             // Assert
             var actualBytes = fileSystem.GetFile(path).Contents;
-            Assert.That(actualBytes, Is.EqualTo(expectedBytes));
+            await That(actualBytes).IsEqualTo(expectedBytes);
         }
 
         [Test]
-        public void MockFile_WriteAllTextMultipleLines_ShouldWriteTextFileToMemoryFileSystem()
+        public async Task MockFile_WriteAllTextMultipleLines_ShouldWriteTextFileToMemoryFileSystem()
         {
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
@@ -217,7 +218,7 @@
             fileSystem.File.WriteAllLines(path, fileContent);
 
             // Assert
-            Assert.That(fileSystem.GetFile(path).TextContents, Is.EqualTo(expected));
+            await That(fileSystem.GetFile(path).TextContents).IsEqualTo(expected);
         }
 
 #if FEATURE_ASYNC_FILE
@@ -234,26 +235,26 @@
             await fileSystem.File.WriteAllTextAsync(path, fileContent);
 
             // Assert
-            Assert.That(fileSystem.GetFile(path).TextContents, Is.EqualTo(fileContent));
+            await That(fileSystem.GetFile(path).TextContents).IsEqualTo(fileContent);
         }
 
         [Test]
-        public void MockFile_WriteAllTextAsync_ShouldThrowOperationCanceledExceptionIfCancelled()
+        public async Task MockFile_WriteAllTextAsync_ShouldThrowOperationCanceledExceptionIfCancelled()
         {
             // Arrange
             const string path = "test.txt";
             var fileSystem = new MockFileSystem();
 
             // Act
-            Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            async Task Act() =>
                 await fileSystem.File.WriteAllTextAsync(
                     path,
                     "line",
-                    new CancellationToken(canceled: true))
-            );
+                    new CancellationToken(canceled: true));
+            await That(Act).Throws<OperationCanceledException>();
 
             // Assert
-            Assert.That(fileSystem.File.Exists(path), Is.False);
+            await That(fileSystem.File.Exists(path)).IsFalse();
         }
 
         [Test]
@@ -271,11 +272,11 @@
             await fileSystem.File.WriteAllTextAsync(path, "bar");
 
             // Assert
-            Assert.That(fileSystem.GetFile(path).TextContents, Is.EqualTo("bar"));
+            await That(fileSystem.GetFile(path).TextContents).IsEqualTo("bar");
         }
 
         [Test]
-        public void MockFile_WriteAllTextAsync_ShouldThrowAnUnauthorizedAccessExceptionIfFileIsHidden()
+        public async Task MockFile_WriteAllTextAsync_ShouldThrowAnUnauthorizedAccessExceptionIfFileIsHidden()
         {
             // Arrange
             string path = XFS.Path(@"c:\something\demo.txt");
@@ -286,23 +287,24 @@
             fileSystem.File.SetAttributes(path, FileAttributes.Hidden);
 
             // Act
-            AsyncTestDelegate action = () => fileSystem.File.WriteAllTextAsync(path, "hello world");
+            Func<Task> action = () => fileSystem.File.WriteAllTextAsync(path, "hello world");
 
             // Assert
-            Assert.ThrowsAsync<UnauthorizedAccessException>(action, "Access to the path '{0}' is denied.", path);
+            await That(action).Throws<UnauthorizedAccessException>()
+                .Because($"Access to the path '{path}' is denied.");
         }
 
         [Test]
-        public void MockFile_WriteAllTextAsync_ShouldThrowAnArgumentExceptionIfThePathIsEmpty()
+        public async Task MockFile_WriteAllTextAsync_ShouldThrowAnArgumentExceptionIfThePathIsEmpty()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
 
             // Act
-            AsyncTestDelegate action = () => fileSystem.File.WriteAllTextAsync(string.Empty, "hello world");
+            Func<Task> action = () => fileSystem.File.WriteAllTextAsync(string.Empty, "hello world");
 
             // Assert
-            Assert.ThrowsAsync<ArgumentException>(action);
+            await That(action).Throws<ArgumentException>();
         }
 
         [Test]
@@ -320,11 +322,11 @@
             // Assert
             // no exception should be thrown, also the documentation says so
             var data = fileSystem.GetFile(filePath);
-            Assert.That(data.Contents, Is.Empty);
+            await That(data.Contents).IsEmpty();
         }
 
         [Test]
-        public void MockFile_WriteAllTextAsync_ShouldThrowAnUnauthorizedAccessExceptionIfTheFileIsReadOnly()
+        public async Task MockFile_WriteAllTextAsync_ShouldThrowAnUnauthorizedAccessExceptionIfTheFileIsReadOnly()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -334,14 +336,14 @@
             fileSystem.AddFile(filePath, mockFileData);
 
             // Act
-            AsyncTestDelegate action = () => fileSystem.File.WriteAllTextAsync(filePath, "");
+            Func<Task> action = () => fileSystem.File.WriteAllTextAsync(filePath, "");
 
             // Assert
-            Assert.ThrowsAsync<UnauthorizedAccessException>(action);
+            await That(action).Throws<UnauthorizedAccessException>();
         }
 
         [Test]
-        public void MockFile_WriteAllTextAsync_ShouldThrowAnUnauthorizedAccessExceptionIfThePathIsOneDirectory()
+        public async Task MockFile_WriteAllTextAsync_ShouldThrowAnUnauthorizedAccessExceptionIfThePathIsOneDirectory()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
@@ -349,24 +351,24 @@
             fileSystem.AddDirectory(directoryPath);
 
             // Act
-            AsyncTestDelegate action = () => fileSystem.File.WriteAllTextAsync(directoryPath, "");
+            Func<Task> action = () => fileSystem.File.WriteAllTextAsync(directoryPath, "");
 
             // Assert
-            Assert.ThrowsAsync<UnauthorizedAccessException>(action);
+            await That(action).Throws<UnauthorizedAccessException>();
         }
 
         [Test]
-        public void MockFile_WriteAllTextAsync_ShouldThrowDirectoryNotFoundExceptionIfPathDoesNotExists()
+        public async Task MockFile_WriteAllTextAsync_ShouldThrowDirectoryNotFoundExceptionIfPathDoesNotExists()
         {
             // Arrange
             var fileSystem = new MockFileSystem();
             string path = XFS.Path(@"c:\something\file.txt");
 
             // Act
-            AsyncTestDelegate action = () => fileSystem.File.WriteAllTextAsync(path, string.Empty);
+            Func<Task> action = () => fileSystem.File.WriteAllTextAsync(path, string.Empty);
 
             // Assert
-            Assert.ThrowsAsync<DirectoryNotFoundException>(action);
+            await That(action).Throws<DirectoryNotFoundException>();
         }
 
         [TestCaseSource(typeof(MockFileWriteAllTextTests), nameof(GetEncodingsWithExpectedBytes))]
@@ -385,7 +387,7 @@
 
             // Assert
             var actualBytes = fileSystem.GetFile(path).Contents;
-            Assert.That(actualBytes, Is.EqualTo(expectedBytes));
+            await That(actualBytes).IsEqualTo(expectedBytes);
         }
 
         [Test]
@@ -404,7 +406,7 @@
             await fileSystem.File.WriteAllLinesAsync(path, fileContent);
 
             // Assert
-            Assert.That(fileSystem.GetFile(path).TextContents, Is.EqualTo(expected));
+            await That(fileSystem.GetFile(path).TextContents).IsEqualTo(expected);
         }
 #endif
     }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockPathTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockPathTests.cs
@@ -10,7 +10,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         static readonly string TestPath = XFS.Path("C:\\test\\test.bmp");
 
         [Test]
-        public void ChangeExtension_ExtensionNoPeriod_PeriodAdded()
+        public async Task ChangeExtension_ExtensionNoPeriod_PeriodAdded()
         {
             //Arrange
             var mockPath = new MockPath(new MockFileSystem());
@@ -19,11 +19,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.ChangeExtension(TestPath, "doc");
 
             //Assert
-            Assert.That(result, Is.EqualTo(XFS.Path("C:\\test\\test.doc")));
+            await That(result).IsEqualTo(XFS.Path("C:\\test\\test.doc"));
         }
 
         [Test]
-        public void Combine_SentTwoPaths_Combines()
+        public async Task Combine_SentTwoPaths_Combines()
         {
             //Arrange
             var mockPath = new MockPath(new MockFileSystem());
@@ -32,11 +32,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.Combine(XFS.Path("C:\\test"), "test.bmp");
 
             //Assert
-            Assert.That(result, Is.EqualTo(XFS.Path("C:\\test\\test.bmp")));
+            await That(result).IsEqualTo(XFS.Path("C:\\test\\test.bmp"));
         }
 
         [Test]
-        public void Combine_SentThreePaths_Combines()
+        public async Task Combine_SentThreePaths_Combines()
         {
             //Arrange
             var mockPath = new MockPath(new MockFileSystem());
@@ -45,11 +45,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.Combine(XFS.Path("C:\\test"), "subdir1", "test.bmp");
 
             //Assert
-            Assert.That(result, Is.EqualTo(XFS.Path("C:\\test\\subdir1\\test.bmp")));
+            await That(result).IsEqualTo(XFS.Path("C:\\test\\subdir1\\test.bmp"));
         }
 
         [Test]
-        public void Combine_SentFourPaths_Combines()
+        public async Task Combine_SentFourPaths_Combines()
         {
             //Arrange
             var mockPath = new MockPath(new MockFileSystem());
@@ -58,11 +58,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.Combine(XFS.Path("C:\\test"), "subdir1", "subdir2", "test.bmp");
 
             //Assert
-            Assert.That(result, Is.EqualTo(XFS.Path("C:\\test\\subdir1\\subdir2\\test.bmp")));
+            await That(result).IsEqualTo(XFS.Path("C:\\test\\subdir1\\subdir2\\test.bmp"));
         }
 
         [Test]
-        public void Combine_SentFivePaths_Combines()
+        public async Task Combine_SentFivePaths_Combines()
         {
             //Arrange
             var mockPath = new MockPath(new MockFileSystem());
@@ -71,11 +71,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.Combine(XFS.Path("C:\\test"), "subdir1", "subdir2", "subdir3", "test.bmp");
 
             //Assert
-            Assert.That(result, Is.EqualTo(XFS.Path("C:\\test\\subdir1\\subdir2\\subdir3\\test.bmp")));
+            await That(result).IsEqualTo(XFS.Path("C:\\test\\subdir1\\subdir2\\subdir3\\test.bmp"));
         }
 
         [Test]
-        public void GetDirectoryName_SentPath_ReturnsDirectory()
+        public async Task GetDirectoryName_SentPath_ReturnsDirectory()
         {
             //Arrange
             var mockPath = new MockPath(new MockFileSystem());
@@ -84,11 +84,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetDirectoryName(TestPath);
 
             //Assert
-            Assert.That(result, Is.EqualTo(XFS.Path("C:\\test")));
+            await That(result).IsEqualTo(XFS.Path("C:\\test"));
         }
 
         [Test]
-        public void GetExtension_SendInPath_ReturnsExtension()
+        public async Task GetExtension_SendInPath_ReturnsExtension()
         {
             //Arrange
             var mockPath = new MockPath(new MockFileSystem());
@@ -97,11 +97,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetExtension(TestPath);
 
             //Assert
-            Assert.That(result, Is.EqualTo(".bmp"));
+            await That(result).IsEqualTo(".bmp");
         }
 
         [Test]
-        public void GetFileName_SendInPath_ReturnsFilename()
+        public async Task GetFileName_SendInPath_ReturnsFilename()
         {
             //Arrange
             var mockPath = new MockPath(new MockFileSystem());
@@ -110,11 +110,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetFileName(TestPath);
 
             //Assert
-            Assert.That(result, Is.EqualTo("test.bmp"));
+            await That(result).IsEqualTo("test.bmp");
         }
 
         [Test]
-        public void GetFileNameWithoutExtension_SendInPath_ReturnsFileNameNoExt()
+        public async Task GetFileNameWithoutExtension_SendInPath_ReturnsFileNameNoExt()
         {
             //Arrange
             var mockPath = new MockPath(new MockFileSystem());
@@ -123,11 +123,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetFileNameWithoutExtension(TestPath);
 
             //Assert
-            Assert.That(result, Is.EqualTo("test"));
+            await That(result).IsEqualTo("test");
         }
 
         [Test]
-        public void GetFullPath_SendInPath_ReturnsFullPath()
+        public async Task GetFullPath_SendInPath_ReturnsFullPath()
         {
             //Arrange
             var mockPath = new MockPath(new MockFileSystem());
@@ -136,7 +136,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetFullPath(TestPath);
 
             //Assert
-            Assert.That(result, Is.EqualTo(TestPath));
+            await That(result).IsEqualTo(TestPath);
         }
 
         public static IEnumerable<string[]> GetFullPath_RelativePaths_Cases
@@ -154,7 +154,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [TestCaseSource(nameof(GetFullPath_RelativePaths_Cases))]
-        public void GetFullPath_RelativePaths_ShouldReturnTheAbsolutePathWithCurrentDirectory(string currentDir, string relativePath, string expectedResult)
+        public async Task GetFullPath_RelativePaths_ShouldReturnTheAbsolutePathWithCurrentDirectory(string currentDir, string relativePath, string expectedResult)
         {
             //Arrange
             var mockFileSystem = new MockFileSystem();
@@ -165,7 +165,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = mockPath.GetFullPath(relativePath);
 
             //Assert
-            Assert.That(actualResult, Is.EqualTo(expectedResult));
+            await That(actualResult).IsEqualTo(expectedResult);
         }
 
         public static IEnumerable<string[]> GetFullPath_RootedPathWithRelativeSegments_Cases
@@ -181,7 +181,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [TestCaseSource(nameof(GetFullPath_RootedPathWithRelativeSegments_Cases))]
-        public void GetFullPath_RootedPathWithRelativeSegments_ShouldReturnAnRootedAbsolutePath(string rootedPath, string expectedResult)
+        public async Task GetFullPath_RootedPathWithRelativeSegments_ShouldReturnAnRootedAbsolutePath(string rootedPath, string expectedResult)
         {
             //Arrange
             var mockFileSystem = new MockFileSystem();
@@ -191,7 +191,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = mockPath.GetFullPath(rootedPath);
 
             //Assert
-            Assert.That(actualResult, Is.EqualTo(expectedResult));
+            await That(actualResult).IsEqualTo(expectedResult);
         }
 
         public static IEnumerable<string[]> GetFullPath_AbsolutePaths_Cases
@@ -210,7 +210,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         }
 
         [TestCaseSource(nameof(GetFullPath_AbsolutePaths_Cases))]
-        public void GetFullPath_AbsolutePaths_ShouldReturnThePathWithTheRoot_Or_Unc(string currentDir, string absolutePath, string expectedResult)
+        public async Task GetFullPath_AbsolutePaths_ShouldReturnThePathWithTheRoot_Or_Unc(string currentDir, string absolutePath, string expectedResult)
         {
             //Arrange
             var mockFileSystem = new MockFileSystem();
@@ -221,63 +221,63 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualResult = mockPath.GetFullPath(absolutePath);
 
             //Assert
-            Assert.That(actualResult, Is.EqualTo(expectedResult));
+            await That(actualResult).IsEqualTo(expectedResult);
         }
 
         [Test]
-        public void GetFullPath_InvalidUNCPaths_ShouldThrowArgumentException()
+        public async Task GetFullPath_InvalidUNCPaths_ShouldThrowArgumentException()
         {
             //Arrange
             var mockFileSystem = new MockFileSystem();
             var mockPath = new MockPath(mockFileSystem);
 
             //Act
-            TestDelegate action = () => mockPath.GetFullPath(XFS.Path(@"\\shareZ"));
+            Action action = () => mockPath.GetFullPath(XFS.Path(@"\\shareZ"));
 
             //Assert
-            Assert.Throws<ArgumentException>(action);
+            await That(action).Throws<ArgumentException>();
         }
 
         [Test]
-        public void GetFullPath_NullValue_ShouldThrowArgumentNullException()
+        public async Task GetFullPath_NullValue_ShouldThrowArgumentNullException()
         {
             //Arrange
             var mockFileSystem = new MockFileSystem();
             var mockPath = new MockPath(mockFileSystem);
 
             //Act
-            TestDelegate action = () => mockPath.GetFullPath(null);
+            Action action = () => mockPath.GetFullPath(null);
 
             //Assert
-            Assert.Throws<ArgumentNullException>(action);
+            await That(action).Throws<ArgumentNullException>();
         }
 
         [Test]
-        public void GetFullPath_EmptyValue_ShouldThrowArgumentException()
+        public async Task GetFullPath_EmptyValue_ShouldThrowArgumentException()
         {
             //Arrange
             var mockFileSystem = new MockFileSystem();
             var mockPath = new MockPath(mockFileSystem);
 
             //Act
-            TestDelegate action = () => mockPath.GetFullPath(string.Empty);
+            Action action = () => mockPath.GetFullPath(string.Empty);
 
             //Assert
-            Assert.Throws<ArgumentException>(action);
+            await That(action).Throws<ArgumentException>();
         }
 
         [Test]
-        public void GetFullPath_WithWhiteSpace_ShouldThrowArgumentException()
+        public async Task GetFullPath_WithWhiteSpace_ShouldThrowArgumentException()
         {
             var mockFileSystem = new MockFileSystem();
 
-            TestDelegate action = () => mockFileSystem.Path.GetFullPath("  ");
+            Action action = () => mockFileSystem.Path.GetFullPath("  ");
 
-            Assert.Throws<ArgumentException>(action);
+            await That(action).Throws<ArgumentException>();
         }
 
         [Test]
-        public void GetFullPath_WithMultipleDirectorySeparators_ShouldReturnTheNormalizedForm()
+        public async Task GetFullPath_WithMultipleDirectorySeparators_ShouldReturnTheNormalizedForm()
         {
             //Arrange
             var mockFileSystem = new MockFileSystem();
@@ -287,11 +287,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var actualFullPath = mockPath.GetFullPath(XFS.Path(@"c:\foo\\//bar\file.dat"));
 
             //Assert
-            Assert.That(actualFullPath, Is.EqualTo(XFS.Path(@"c:\foo\bar\file.dat")));
+            await That(actualFullPath).IsEqualTo(XFS.Path(@"c:\foo\bar\file.dat"));
         }
 
         [Test]
-        public void GetInvalidFileNameChars_Called_ReturnsChars()
+        public async Task GetInvalidFileNameChars_Called_ReturnsChars()
         {
             //Arrange
             var mockPath = new MockPath(new MockFileSystem());
@@ -300,11 +300,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetInvalidFileNameChars();
 
             //Assert
-            Assert.That(result.Length > 0, Is.True);
+            await That(result.Length > 0).IsTrue();
         }
 
         [Test]
-        public void GetInvalidPathChars_Called_ReturnsChars()
+        public async Task GetInvalidPathChars_Called_ReturnsChars()
         {
             //Arrange
             var mockPath = new MockPath(new MockFileSystem());
@@ -313,11 +313,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetInvalidPathChars();
 
             //Assert
-            Assert.That(result.Length > 0, Is.True);
+            await That(result.Length > 0).IsTrue();
         }
 
         [Test]
-        public void GetPathRoot_SendInPath_ReturnsRoot()
+        public async Task GetPathRoot_SendInPath_ReturnsRoot()
         {
             //Arrange
             var mockPath = new MockPath(new MockFileSystem());
@@ -326,11 +326,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetPathRoot(TestPath);
 
             //Assert
-            Assert.That(result, Is.EqualTo(XFS.Path("C:\\")));
+            await That(result).IsEqualTo(XFS.Path("C:\\"));
         }
 
         [Test]
-        public void GetRandomFileName_Called_ReturnsStringLengthGreaterThanZero()
+        public async Task GetRandomFileName_Called_ReturnsStringLengthGreaterThanZero()
         {
             //Arrange
             var mockPath = new MockPath(new MockFileSystem());
@@ -339,11 +339,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetRandomFileName();
 
             //Assert
-            Assert.That(result.Length > 0, Is.True);
+            await That(result.Length > 0).IsTrue();
         }
 
         [Test]
-        public void GetTempFileName_Called_ReturnsStringLengthGreaterThanZero()
+        public async Task GetTempFileName_Called_ReturnsStringLengthGreaterThanZero()
         {
             //Arrange
             var mockPath = new MockPath(new MockFileSystem());
@@ -352,11 +352,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetTempFileName();
 
             //Assert
-            Assert.That(result.Length > 0, Is.True);
+            await That(result.Length > 0).IsTrue();
         }
 
         [Test]
-        public void GetTempFileName_Called_CreatesEmptyFileInTempDirectory()
+        public async Task GetTempFileName_Called_CreatesEmptyFileInTempDirectory()
         {
             //Arrange
             var fileSystem = new MockFileSystem();
@@ -365,12 +365,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             //Act
             var result = mockPath.GetTempFileName();
 
-            Assert.That(fileSystem.FileExists(result), Is.True);
-            Assert.That(fileSystem.FileInfo.New(result).Length, Is.Zero);
+            await That(fileSystem.FileExists(result)).IsTrue();
+            await That(fileSystem.FileInfo.New(result).Length).IsEqualTo(0);
         }
 
         [Test]
-        public void GetTempPath_Called_ReturnsStringLengthGreaterThanZero()
+        public async Task GetTempPath_Called_ReturnsStringLengthGreaterThanZero()
         {
             //Arrange
             var mockPath = new MockPath(new MockFileSystem());
@@ -379,11 +379,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetTempPath();
 
             //Assert
-            Assert.That(result.Length > 0, Is.True);
+            await That(result.Length > 0).IsTrue();
         }
 
         [Test]
-        public void GetTempPath_ShouldEndWithDirectorySeparator()
+        public async Task GetTempPath_ShouldEndWithDirectorySeparator()
         {
             //Arrange
             var mockPath = new MockFileSystem().Path;
@@ -393,14 +393,14 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetTempPath();
 
             //Assert
-            Assert.That(result, Does.EndWith(directorySeparator));
+            await That(result).EndsWith(directorySeparator);
         }
 
         [Test]
         [TestCase(null)]
         [TestCase("")]
         [TestCase(@"C:\temp")]
-        public void GetTempPath_Called_ReturnsStringLengthGreaterThanZero(string tempDirectory)
+        public async Task GetTempPath_Called_ReturnsStringLengthGreaterThanZero(string tempDirectory)
         {
             //Arrange
             var mockPath = new MockPath(new MockFileSystem(), string.IsNullOrEmpty(tempDirectory) ? tempDirectory : XFS.Path(tempDirectory));
@@ -409,11 +409,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetTempPath();
 
             //Assert
-            Assert.That(result.Length > 0, Is.True);
+            await That(result.Length > 0).IsTrue();
         }
 
         [Test]
-        public void GetTempPath_Called_WithNonNullVirtualTempDirectory_ReturnsVirtualTempDirectory()
+        public async Task GetTempPath_Called_WithNonNullVirtualTempDirectory_ReturnsVirtualTempDirectory()
         {
             //Arrange
             var tempDirectory = XFS.Path(@"C:\temp");
@@ -424,13 +424,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetTempPath();
 
             //Assert
-            Assert.That(result, Is.EqualTo(tempDirectory));
+            await That(result).IsEqualTo(tempDirectory);
         }
 
         [Test]
         [TestCase(null)]
         [TestCase("")]
-        public void GetTempPath_Called_WithNullOrEmptyVirtualTempDirectory_ReturnsFallbackTempDirectory(string tempDirectory)
+        public async Task GetTempPath_Called_WithNullOrEmptyVirtualTempDirectory_ReturnsFallbackTempDirectory(string tempDirectory)
         {
             //Arrange
             var mockPath = new MockPath(new MockFileSystem(), tempDirectory);
@@ -439,11 +439,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetTempPath();
 
             //Assert
-            Assert.That(result.Length > 0, Is.True);
+            await That(result.Length > 0).IsTrue();
         }
 
         [Test]
-        public void HasExtension_PathSentIn_DeterminesExtension()
+        public async Task HasExtension_PathSentIn_DeterminesExtension()
         {
             //Arrange
             var mockPath = new MockPath(new MockFileSystem());
@@ -452,11 +452,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.HasExtension(TestPath);
 
             //Assert
-            Assert.That(result, Is.True);
+            await That(result).IsTrue();
         }
 
         [Test]
-        public void IsPathRooted_PathSentIn_DeterminesPathExists()
+        public async Task IsPathRooted_PathSentIn_DeterminesPathExists()
         {
             //Arrange
             var mockPath = new MockPath(new MockFileSystem());
@@ -465,12 +465,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.IsPathRooted(TestPath);
 
             //Assert
-            Assert.That(result, Is.True);
+            await That(result).IsTrue();
         }
 
 #if FEATURE_ADVANCED_PATH_OPERATIONS
         [Test]
-        public void IsPathFullyQualified_WithAbsolutePath_ReturnsTrue()
+        public async Task IsPathFullyQualified_WithAbsolutePath_ReturnsTrue()
         {
             //Arrange
             var mockPath = new MockPath(new MockFileSystem());
@@ -479,11 +479,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.IsPathFullyQualified(XFS.Path("C:\\directory\\file.txt"));
 
             //Assert
-            Assert.That(result, Is.True);
+            await That(result).IsTrue();
         }
 
         [Test]
-        public void IsPathFullyQualified_WithRelativePath_ReturnsFalse()
+        public async Task IsPathFullyQualified_WithRelativePath_ReturnsFalse()
         {
             //Arrange
             var mockPath = new MockPath(new MockFileSystem());
@@ -492,11 +492,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.IsPathRooted(XFS.Path("directory\\file.txt"));
 
             //Assert
-            Assert.That(result, Is.False);
+            await That(result).IsFalse();
         }
 
         [Test]
-        public void IsPathFullyQualified_WithRelativePathParts_ReturnsFalse()
+        public async Task IsPathFullyQualified_WithRelativePathParts_ReturnsFalse()
         {
             //Arrange
             var mockPath = new MockPath(new MockFileSystem());
@@ -505,11 +505,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.IsPathRooted(XFS.Path("directory\\..\\file.txt"));
 
             //Assert
-            Assert.That(result, Is.False);
+            await That(result).IsFalse();
         }
 
         [Test]
-        public void GetRelativePath_Works()
+        public async Task GetRelativePath_Works()
         {
             //Arrange
             var mockPath = new MockPath(new MockFileSystem());
@@ -518,74 +518,74 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var result = mockPath.GetRelativePath(XFS.Path("c:\\d"), XFS.Path("c:\\d\\e\\f.txt"));
 
             //Assert
-            Assert.That(result, Is.EqualTo(XFS.Path("e\\f.txt")));
+            await That(result).IsEqualTo(XFS.Path("e\\f.txt"));
         }
 
         [Test]
-        public void GetRelativePath_WhenPathIsNull_ShouldThrowArgumentNullException()
+        public async Task GetRelativePath_WhenPathIsNull_ShouldThrowArgumentNullException()
         {
             var mockPath = new MockFileSystem().Path;
 
-            var exception = Assert.Throws<ArgumentNullException>(() =>
+            var exception = await That(() =>
             {
                 mockPath.GetRelativePath("foo", null);
-            });
+            }).Throws<ArgumentNullException>();
 
-            Assert.That(exception.ParamName, Is.EqualTo("path"));
+            await That(exception.ParamName).IsEqualTo("path");
         }
 
         [Test]
-        public void GetRelativePath_WhenPathIsWhitespace_ShouldThrowArgumentException()
+        public async Task GetRelativePath_WhenPathIsWhitespace_ShouldThrowArgumentException()
         {
             var mockPath = new MockFileSystem().Path;
 
-            var exception = Assert.Throws<ArgumentException>(() =>
+            var exception = await That(() =>
             {
                 mockPath.GetRelativePath("foo", " ");
-            });
+            }).Throws<ArgumentException>();
 
-            Assert.That(exception.ParamName, Is.EqualTo("path"));
+            await That(exception.ParamName).IsEqualTo("path");
         }
 
         [Test]
-        public void GetRelativePath_WhenRelativeToNull_ShouldThrowArgumentNullException()
+        public async Task GetRelativePath_WhenRelativeToNull_ShouldThrowArgumentNullException()
         {
             var mockPath = new MockFileSystem().Path;
 
-            var exception = Assert.Throws<ArgumentNullException>(() =>
+            var exception = await That(() =>
             {
                 mockPath.GetRelativePath(null, "foo");
-            });
+            }).Throws<ArgumentNullException>();
 
-            Assert.That(exception.ParamName, Is.EqualTo("relativeTo"));
+            await That(exception.ParamName).IsEqualTo("relativeTo");
         }
 
         [Test]
-        public void GetRelativePath_WhenRelativeToIsWhitespace_ShouldThrowArgumentException()
+        public async Task GetRelativePath_WhenRelativeToIsWhitespace_ShouldThrowArgumentException()
         {
             var mockPath = new MockFileSystem().Path;
 
-            var exception = Assert.Throws<ArgumentException>(() =>
+            var exception = await That(() =>
             {
                 mockPath.GetRelativePath(" ", "foo");
-            });
+            }).Throws<ArgumentException>();
 
-            Assert.That(exception.ParamName, Is.EqualTo("relativeTo"));
+            await That(exception.ParamName).IsEqualTo("relativeTo");
         }
 #endif
 
 #if FEATURE_PATH_EXISTS
         [Test]
-        public void Exists_Null_ShouldReturnFalse()
+        public async Task Exists_Null_ShouldReturnFalse()
         {
             var fileSystem = new MockFileSystem();
             bool result = fileSystem.Path.Exists(null);
 
-            Assert.That(result, Is.False);
+            await That(result).IsFalse();
         }
 
         [Test]
-        public void Exists_ShouldWorkWithAbsolutePaths()
+        public async Task Exists_ShouldWorkWithAbsolutePaths()
         {
             var fileSystem = new MockFileSystem();
             string path = "some-path";
@@ -594,11 +594,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             bool result = fileSystem.Path.Exists(absolutePath);
 
-            Assert.That(result, Is.True);
+            await That(result).IsTrue();
         }
 
         [Test]
-        public void Exists_ExistingFile_ShouldReturnTrue()
+        public async Task Exists_ExistingFile_ShouldReturnTrue()
         {
             var fileSystem = new MockFileSystem();
             string path = "some-path";
@@ -606,11 +606,11 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             bool result = fileSystem.Path.Exists(path);
 
-            Assert.That(result, Is.True);
+            await That(result).IsTrue();
         }
 
         [Test]
-        public void Exists_ExistingDirectory_ShouldReturnTrue()
+        public async Task Exists_ExistingDirectory_ShouldReturnTrue()
         {
             var fileSystem = new MockFileSystem();
             string path = "some-path";
@@ -618,23 +618,23 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             bool result = fileSystem.Path.Exists(path);
 
-            Assert.That(result, Is.True);
+            await That(result).IsTrue();
         }
 
         [Test]
-        public void Exists_ExistingFileOrDirectory_ShouldReturnTrue()
+        public async Task Exists_ExistingFileOrDirectory_ShouldReturnTrue()
         {
             var fileSystem = new MockFileSystem();
             string path = "some-path";
             bool result = fileSystem.Path.Exists(path);
 
-            Assert.That(result, Is.False);
+            await That(result).IsFalse();
         }
 #endif
 
 #if FEATURE_ADVANCED_PATH_OPERATIONS
         [Test]
-        public void GetRelativePath_ShouldUseCurrentDirectoryFromMockFileSystem()
+        public async Task GetRelativePath_ShouldUseCurrentDirectoryFromMockFileSystem()
         {
             var fs = new MockFileSystem();
 
@@ -646,7 +646,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
 
             var result = fs.Path.GetRelativePath("/input", "a.txt");
 
-            Assert.That(result, Is.EqualTo("a.txt"));
+            await That(result).IsEqualTo("a.txt");
         }
 #endif
     }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockUnixSupportTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockUnixSupportTests.cs
@@ -9,16 +9,16 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     {
         [Test]
         [UnixOnly(UnixSpecifics.SlashRoot)]
-        public void Should_Convert_Backslashes_To_Slashes_On_Unix()
+        public async Task Should_Convert_Backslashes_To_Slashes_On_Unix()
         {
-            Assert.That(XFS.Path(@"\test\"), Is.EqualTo("/test/"));
+            await That(XFS.Path(@"\test\")).IsEqualTo("/test/");
         }
 
         [Test]
         [UnixOnly(UnixSpecifics.SlashRoot)]
-        public void Should_Remove_Drive_Letter_On_Unix()
+        public async Task Should_Remove_Drive_Letter_On_Unix()
         {
-            Assert.That(XFS.Path(@"c:\test\"), Is.EqualTo("/test/"));
+            await That(XFS.Path(@"c:\test\")).IsEqualTo("/test/");
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/ProductVersionParserTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/ProductVersionParserTests.cs
@@ -6,7 +6,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
     public class ProductVersionParserTests
     {
         [Test]
-        public void ProductVersionParser_Parse_ShouldIgnoreTheSegmentsWhenThereAreMoreThanFiveOfThem()
+        public async Task ProductVersionParser_Parse_ShouldIgnoreTheSegmentsWhenThereAreMoreThanFiveOfThem()
         {
             // Arrange
             string productVersion = "1.2.3.4.5";
@@ -15,13 +15,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var versionInfo = new MockFileVersionInfo("foo", productVersion: productVersion);
 
             // Assert
-            Assert.Multiple(() =>
-            {
-                Assert.That(versionInfo.ProductMajorPart, Is.Zero);
-                Assert.That(versionInfo.ProductMinorPart, Is.Zero);
-                Assert.That(versionInfo.ProductBuildPart, Is.Zero);
-                Assert.That(versionInfo.ProductPrivatePart, Is.Zero);
-            });
+            await ThatAll(
+                That(versionInfo.ProductMajorPart).IsEqualTo(0),
+                That(versionInfo.ProductMinorPart).IsEqualTo(0),
+                That(versionInfo.ProductBuildPart).IsEqualTo(0),
+                That(versionInfo.ProductPrivatePart).IsEqualTo(0)
+            );
         }
 
         [Test]
@@ -29,7 +28,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [TestCase("1.test.3.4", 1, 0, 0, 0)]
         [TestCase("1.2.test.4", 1, 2, 0, 0)]
         [TestCase("1.2.3.test", 1, 2, 3, 0)]
-        public void ProductVersionParser_Parse_ShouldSkipTheRestOfTheSegmentsWhenOneIsNotValidNumber(
+        public async Task ProductVersionParser_Parse_ShouldSkipTheRestOfTheSegmentsWhenOneIsNotValidNumber(
             string productVersion,
             int expectedMajor,
             int expectedMinor,
@@ -40,13 +39,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var versionInfo = new MockFileVersionInfo("foo", productVersion: productVersion);
 
             // Assert
-            Assert.Multiple(() =>
-            {
-                Assert.That(versionInfo.ProductMajorPart, Is.EqualTo(expectedMajor));
-                Assert.That(versionInfo.ProductMinorPart, Is.EqualTo(expectedMinor));
-                Assert.That(versionInfo.ProductBuildPart, Is.EqualTo(expectedBuild));
-                Assert.That(versionInfo.ProductPrivatePart, Is.EqualTo(expectedRevision));
-            });
+            await ThatAll(
+                That(versionInfo.ProductMajorPart).IsEqualTo(expectedMajor),
+                That(versionInfo.ProductMinorPart).IsEqualTo(expectedMinor),
+                That(versionInfo.ProductBuildPart).IsEqualTo(expectedBuild),
+                That(versionInfo.ProductPrivatePart).IsEqualTo(expectedRevision)
+            );
         }
 
         [Test]
@@ -58,7 +56,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [TestCase("1.2.3-test5.4", 1, 2, 3, 0)]
         [TestCase("1.2.3.4-test", 1, 2, 3, 4)]
         [TestCase("1.2.3.4-test5", 1, 2, 3, 4)]
-        public void ProductVersionParser_Parse_ShouldSkipTheRestOfTheSegmentsWhenOneContainsMoreThanJustOneNumber(
+        public async Task ProductVersionParser_Parse_ShouldSkipTheRestOfTheSegmentsWhenOneContainsMoreThanJustOneNumber(
             string productVersion,
             int expectedMajor,
             int expectedMinor,
@@ -69,13 +67,13 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var versionInfo = new MockFileVersionInfo("foo", productVersion: productVersion);
 
             // Assert
-            Assert.Multiple(() =>
-            {
-                Assert.That(versionInfo.ProductMajorPart, Is.EqualTo(expectedMajor));
-                Assert.That(versionInfo.ProductMinorPart, Is.EqualTo(expectedMinor));
-                Assert.That(versionInfo.ProductBuildPart, Is.EqualTo(expectedBuild));
-                Assert.That(versionInfo.ProductPrivatePart, Is.EqualTo(expectedRevision));
-            });
+            
+            await ThatAll(
+                That(versionInfo.ProductMajorPart).IsEqualTo(expectedMajor),
+                That(versionInfo.ProductMinorPart).IsEqualTo(expectedMinor),
+                That(versionInfo.ProductBuildPart).IsEqualTo(expectedBuild),
+                That(versionInfo.ProductPrivatePart).IsEqualTo(expectedRevision)
+            );
         }
 
         [Test]
@@ -84,7 +82,7 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
         [TestCase("1.2", 1, 2, 0, 0)]
         [TestCase("1.2.3", 1, 2, 3, 0)]
         [TestCase("1.2.3.4", 1, 2, 3, 4)]
-        public void ProductVersionParser_Parse_ShouldParseEachProvidedSegment(
+        public async Task ProductVersionParser_Parse_ShouldParseEachProvidedSegment(
             string productVersion,
             int expectedMajor,
             int expectedMinor,
@@ -95,13 +93,12 @@ namespace System.IO.Abstractions.TestingHelpers.Tests
             var versionInfo = new MockFileVersionInfo("foo", productVersion: productVersion);
 
             // Assert
-            Assert.Multiple(() =>
-            {
-                Assert.That(versionInfo.ProductMajorPart, Is.EqualTo(expectedMajor));
-                Assert.That(versionInfo.ProductMinorPart, Is.EqualTo(expectedMinor));
-                Assert.That(versionInfo.ProductBuildPart, Is.EqualTo(expectedBuild));
-                Assert.That(versionInfo.ProductPrivatePart, Is.EqualTo(expectedRevision));
-            });
+            await ThatAll(
+                That(versionInfo.ProductMajorPart).IsEqualTo(expectedMajor),
+                That(versionInfo.ProductMinorPart).IsEqualTo(expectedMinor),
+                That(versionInfo.ProductBuildPart).IsEqualTo(expectedBuild),
+                That(versionInfo.ProductPrivatePart).IsEqualTo(expectedRevision)
+            );
         }
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/Usings.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/Usings.cs
@@ -1,0 +1,4 @@
+﻿global using System.Threading.Tasks;
+global using NUnit.Framework;
+global using aweXpect;
+global using static aweXpect.Expect;


### PR DESCRIPTION
Similar to #1234 use [aweXpect](https://awexpect.com) in `TestableIO.System.IO.Abstractions.TestingHelpers.Tests`.