### PR TITLE
fix: move a read-only file

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/IMockFileDataAccessor.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/IMockFileDataAccessor.cs
@@ -31,8 +31,12 @@ public interface IMockFileDataAccessor : IFileSystem
     MockDriveData GetDrive(string name);
 
     /// <summary>
+    /// Adds the file.
     /// </summary>
-    void AddFile(string path, MockFileData mockFile);
+    /// <param name="path">The path of the file to add.</param>
+    /// <param name="mockFile">The file data to add.</param>
+    /// <param name="verifyAccess">Flag indicating if the access conditions should be verified.</param>
+    void AddFile(string path, MockFileData mockFile, bool verifyAccess = true);
 
     /// <summary>
     /// </summary>
@@ -58,10 +62,11 @@ public interface IMockFileDataAccessor : IFileSystem
     /// Removes the file.
     /// </summary>
     /// <param name="path">The file to remove.</param>
+    /// <param name="verifyAccess">Flag indicating if the access conditions should be verified.</param>
     /// <remarks>
     /// The file must not exist.
     /// </remarks>
-    void RemoveFile(string path);
+    void RemoveFile(string path, bool verifyAccess = true);
 
     /// <summary>
     /// Determines whether the file exists.

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFile.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFile.cs
@@ -546,8 +546,8 @@ public partial class MockFile : FileBase
         }
         VerifyDirectoryExists(destFileName);
 
-        mockFileDataAccessor.RemoveFile(sourceFileName);
-        mockFileDataAccessor.AddFile(destFileName, mockFileDataAccessor.AdjustTimes(new MockFileData(sourceFile), TimeAdjustments.LastAccessTime));
+        mockFileDataAccessor.RemoveFile(sourceFileName, false);
+        mockFileDataAccessor.AddFile(destFileName, mockFileDataAccessor.AdjustTimes(new MockFileData(sourceFile), TimeAdjustments.LastAccessTime), false);
     }
 
 #if FEATURE_FILE_MOVE_WITH_OVERWRITE

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/MockFileSystem.cs
@@ -225,7 +225,7 @@ public class MockFileSystem : FileSystemBase, IMockFileDataAccessor
     }
 
     /// <inheritdoc />
-    public void AddFile(string path, MockFileData mockFile)
+    public void AddFile(string path, MockFileData mockFile, bool verifyAccess = true)
     {
         var fixedPath = FixPath(path, true);
 
@@ -237,7 +237,7 @@ public class MockFileSystem : FileSystemBase, IMockFileDataAccessor
             var isReadOnly = (file.Attributes & FileAttributes.ReadOnly) == FileAttributes.ReadOnly;
             var isHidden = (file.Attributes & FileAttributes.Hidden) == FileAttributes.Hidden;
 
-            if (isReadOnly || isHidden)
+            if (verifyAccess && (isReadOnly || isHidden))
             {
                 throw CommonExceptions.AccessDenied(path);
             }
@@ -294,9 +294,10 @@ public class MockFileSystem : FileSystemBase, IMockFileDataAccessor
     /// </summary>
     /// <param name="path">An <see cref="IFileInfo"/> representing the path of the new file to add.</param>
     /// <param name="data">The data to use for the contents of the new file.</param>
-    public void AddFile(IFileInfo path, MockFileData data)
+    /// <param name="verifyAccess">Flag indicating if the access conditions should be verified.</param>
+    public void AddFile(IFileInfo path, MockFileData data, bool verifyAccess = true)
     {
-        AddFile(path.FullName, data);
+        AddFile(path.FullName, data, verifyAccess);
         path.Refresh();
     }
 
@@ -444,13 +445,13 @@ public class MockFileSystem : FileSystemBase, IMockFileDataAccessor
     }
 
     /// <inheritdoc />
-    public void RemoveFile(string path)
+    public void RemoveFile(string path, bool verifyAccess = true)
     {
         path = FixPath(path);
 
         lock (files)
         {
-            if (FileExists(path) && (FileIsReadOnly(path) || Directory.Exists(path) && AnyFileIsReadOnly(path)))
+            if (FileExists(path) && verifyAccess && (FileIsReadOnly(path) || Directory.Exists(path) && AnyFileIsReadOnly(path)))
             {
                 throw CommonExceptions.AccessDenied(path);
             }

--- a/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.TestingHelpers_net472.txt
+++ b/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.TestingHelpers_net472.txt
@@ -13,7 +13,7 @@ namespace System.IO.Abstractions.TestingHelpers
         System.IO.Abstractions.TestingHelpers.StringOperations StringOperations { get; }
         void AddDirectory(string path);
         void AddDrive(string name, System.IO.Abstractions.TestingHelpers.MockDriveData mockDrive);
-        void AddFile(string path, System.IO.Abstractions.TestingHelpers.MockFileData mockFile);
+        void AddFile(string path, System.IO.Abstractions.TestingHelpers.MockFileData mockFile, bool verifyAccess = true);
         void AddFileFromEmbeddedResource(string path, System.Reflection.Assembly resourceAssembly, string embeddedResourcePath);
         void AddFilesFromEmbeddedNamespace(string path, System.Reflection.Assembly resourceAssembly, string embeddedResourcePath);
         System.IO.Abstractions.TestingHelpers.MockFileData AdjustTimes(System.IO.Abstractions.TestingHelpers.MockFileData fileData, System.IO.Abstractions.TestingHelpers.TimeAdjustments timeAdjustments);
@@ -21,7 +21,7 @@ namespace System.IO.Abstractions.TestingHelpers
         System.IO.Abstractions.TestingHelpers.MockDriveData GetDrive(string name);
         System.IO.Abstractions.TestingHelpers.MockFileData GetFile(string path);
         void MoveDirectory(string sourcePath, string destPath);
-        void RemoveFile(string path);
+        void RemoveFile(string path, bool verifyAccess = true);
     }
     [System.Serializable]
     public class MockDirectory : System.IO.Abstractions.DirectoryBase
@@ -360,8 +360,8 @@ namespace System.IO.Abstractions.TestingHelpers
         public void AddDrive(string name, System.IO.Abstractions.TestingHelpers.MockDriveData mockDrive) { }
         public void AddEmptyFile(System.IO.Abstractions.IFileInfo path) { }
         public void AddEmptyFile(string path) { }
-        public void AddFile(System.IO.Abstractions.IFileInfo path, System.IO.Abstractions.TestingHelpers.MockFileData data) { }
-        public void AddFile(string path, System.IO.Abstractions.TestingHelpers.MockFileData mockFile) { }
+        public void AddFile(System.IO.Abstractions.IFileInfo path, System.IO.Abstractions.TestingHelpers.MockFileData data, bool verifyAccess = true) { }
+        public void AddFile(string path, System.IO.Abstractions.TestingHelpers.MockFileData mockFile, bool verifyAccess = true) { }
         public void AddFileFromEmbeddedResource(string path, System.Reflection.Assembly resourceAssembly, string embeddedResourcePath) { }
         public void AddFilesFromEmbeddedNamespace(string path, System.Reflection.Assembly resourceAssembly, string embeddedResourcePath) { }
         public System.IO.Abstractions.TestingHelpers.MockFileData AdjustTimes(System.IO.Abstractions.TestingHelpers.MockFileData fileData, System.IO.Abstractions.TestingHelpers.TimeAdjustments timeAdjustments) { }
@@ -371,7 +371,7 @@ namespace System.IO.Abstractions.TestingHelpers
         public System.IO.Abstractions.TestingHelpers.MockFileData GetFile(string path) { }
         public System.IO.Abstractions.TestingHelpers.MockFileSystem MockTime(System.Func<System.DateTime> dateTimeProvider) { }
         public void MoveDirectory(string sourcePath, string destPath) { }
-        public void RemoveFile(string path) { }
+        public void RemoveFile(string path, bool verifyAccess = true) { }
     }
     public class MockFileSystemOptions
     {

--- a/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.TestingHelpers_net6.0.txt
+++ b/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.TestingHelpers_net6.0.txt
@@ -13,7 +13,7 @@ namespace System.IO.Abstractions.TestingHelpers
         System.IO.Abstractions.TestingHelpers.StringOperations StringOperations { get; }
         void AddDirectory(string path);
         void AddDrive(string name, System.IO.Abstractions.TestingHelpers.MockDriveData mockDrive);
-        void AddFile(string path, System.IO.Abstractions.TestingHelpers.MockFileData mockFile);
+        void AddFile(string path, System.IO.Abstractions.TestingHelpers.MockFileData mockFile, bool verifyAccess = true);
         void AddFileFromEmbeddedResource(string path, System.Reflection.Assembly resourceAssembly, string embeddedResourcePath);
         void AddFilesFromEmbeddedNamespace(string path, System.Reflection.Assembly resourceAssembly, string embeddedResourcePath);
         System.IO.Abstractions.TestingHelpers.MockFileData AdjustTimes(System.IO.Abstractions.TestingHelpers.MockFileData fileData, System.IO.Abstractions.TestingHelpers.TimeAdjustments timeAdjustments);
@@ -21,7 +21,7 @@ namespace System.IO.Abstractions.TestingHelpers
         System.IO.Abstractions.TestingHelpers.MockDriveData GetDrive(string name);
         System.IO.Abstractions.TestingHelpers.MockFileData GetFile(string path);
         void MoveDirectory(string sourcePath, string destPath);
-        void RemoveFile(string path);
+        void RemoveFile(string path, bool verifyAccess = true);
     }
     [System.Serializable]
     public class MockDirectory : System.IO.Abstractions.DirectoryBase
@@ -415,8 +415,8 @@ namespace System.IO.Abstractions.TestingHelpers
         public void AddDrive(string name, System.IO.Abstractions.TestingHelpers.MockDriveData mockDrive) { }
         public void AddEmptyFile(System.IO.Abstractions.IFileInfo path) { }
         public void AddEmptyFile(string path) { }
-        public void AddFile(System.IO.Abstractions.IFileInfo path, System.IO.Abstractions.TestingHelpers.MockFileData data) { }
-        public void AddFile(string path, System.IO.Abstractions.TestingHelpers.MockFileData mockFile) { }
+        public void AddFile(System.IO.Abstractions.IFileInfo path, System.IO.Abstractions.TestingHelpers.MockFileData data, bool verifyAccess = true) { }
+        public void AddFile(string path, System.IO.Abstractions.TestingHelpers.MockFileData mockFile, bool verifyAccess = true) { }
         public void AddFileFromEmbeddedResource(string path, System.Reflection.Assembly resourceAssembly, string embeddedResourcePath) { }
         public void AddFilesFromEmbeddedNamespace(string path, System.Reflection.Assembly resourceAssembly, string embeddedResourcePath) { }
         public System.IO.Abstractions.TestingHelpers.MockFileData AdjustTimes(System.IO.Abstractions.TestingHelpers.MockFileData fileData, System.IO.Abstractions.TestingHelpers.TimeAdjustments timeAdjustments) { }
@@ -426,7 +426,7 @@ namespace System.IO.Abstractions.TestingHelpers
         public System.IO.Abstractions.TestingHelpers.MockFileData GetFile(string path) { }
         public System.IO.Abstractions.TestingHelpers.MockFileSystem MockTime(System.Func<System.DateTime> dateTimeProvider) { }
         public void MoveDirectory(string sourcePath, string destPath) { }
-        public void RemoveFile(string path) { }
+        public void RemoveFile(string path, bool verifyAccess = true) { }
     }
     public class MockFileSystemOptions
     {

--- a/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.TestingHelpers_net8.0.txt
+++ b/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.TestingHelpers_net8.0.txt
@@ -13,7 +13,7 @@ namespace System.IO.Abstractions.TestingHelpers
         System.IO.Abstractions.TestingHelpers.StringOperations StringOperations { get; }
         void AddDirectory(string path);
         void AddDrive(string name, System.IO.Abstractions.TestingHelpers.MockDriveData mockDrive);
-        void AddFile(string path, System.IO.Abstractions.TestingHelpers.MockFileData mockFile);
+        void AddFile(string path, System.IO.Abstractions.TestingHelpers.MockFileData mockFile, bool verifyAccess = true);
         void AddFileFromEmbeddedResource(string path, System.Reflection.Assembly resourceAssembly, string embeddedResourcePath);
         void AddFilesFromEmbeddedNamespace(string path, System.Reflection.Assembly resourceAssembly, string embeddedResourcePath);
         System.IO.Abstractions.TestingHelpers.MockFileData AdjustTimes(System.IO.Abstractions.TestingHelpers.MockFileData fileData, System.IO.Abstractions.TestingHelpers.TimeAdjustments timeAdjustments);
@@ -21,7 +21,7 @@ namespace System.IO.Abstractions.TestingHelpers
         System.IO.Abstractions.TestingHelpers.MockDriveData GetDrive(string name);
         System.IO.Abstractions.TestingHelpers.MockFileData GetFile(string path);
         void MoveDirectory(string sourcePath, string destPath);
-        void RemoveFile(string path);
+        void RemoveFile(string path, bool verifyAccess = true);
     }
     [System.Serializable]
     public class MockDirectory : System.IO.Abstractions.DirectoryBase
@@ -439,8 +439,8 @@ namespace System.IO.Abstractions.TestingHelpers
         public void AddDrive(string name, System.IO.Abstractions.TestingHelpers.MockDriveData mockDrive) { }
         public void AddEmptyFile(System.IO.Abstractions.IFileInfo path) { }
         public void AddEmptyFile(string path) { }
-        public void AddFile(System.IO.Abstractions.IFileInfo path, System.IO.Abstractions.TestingHelpers.MockFileData data) { }
-        public void AddFile(string path, System.IO.Abstractions.TestingHelpers.MockFileData mockFile) { }
+        public void AddFile(System.IO.Abstractions.IFileInfo path, System.IO.Abstractions.TestingHelpers.MockFileData data, bool verifyAccess = true) { }
+        public void AddFile(string path, System.IO.Abstractions.TestingHelpers.MockFileData mockFile, bool verifyAccess = true) { }
         public void AddFileFromEmbeddedResource(string path, System.Reflection.Assembly resourceAssembly, string embeddedResourcePath) { }
         public void AddFilesFromEmbeddedNamespace(string path, System.Reflection.Assembly resourceAssembly, string embeddedResourcePath) { }
         public System.IO.Abstractions.TestingHelpers.MockFileData AdjustTimes(System.IO.Abstractions.TestingHelpers.MockFileData fileData, System.IO.Abstractions.TestingHelpers.TimeAdjustments timeAdjustments) { }
@@ -450,7 +450,7 @@ namespace System.IO.Abstractions.TestingHelpers
         public System.IO.Abstractions.TestingHelpers.MockFileData GetFile(string path) { }
         public System.IO.Abstractions.TestingHelpers.MockFileSystem MockTime(System.Func<System.DateTime> dateTimeProvider) { }
         public void MoveDirectory(string sourcePath, string destPath) { }
-        public void RemoveFile(string path) { }
+        public void RemoveFile(string path, bool verifyAccess = true) { }
     }
     public class MockFileSystemOptions
     {

--- a/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.TestingHelpers_net9.0.txt
+++ b/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.TestingHelpers_net9.0.txt
@@ -13,7 +13,7 @@ namespace System.IO.Abstractions.TestingHelpers
         System.IO.Abstractions.TestingHelpers.StringOperations StringOperations { get; }
         void AddDirectory(string path);
         void AddDrive(string name, System.IO.Abstractions.TestingHelpers.MockDriveData mockDrive);
-        void AddFile(string path, System.IO.Abstractions.TestingHelpers.MockFileData mockFile);
+        void AddFile(string path, System.IO.Abstractions.TestingHelpers.MockFileData mockFile, bool verifyAccess = true);
         void AddFileFromEmbeddedResource(string path, System.Reflection.Assembly resourceAssembly, string embeddedResourcePath);
         void AddFilesFromEmbeddedNamespace(string path, System.Reflection.Assembly resourceAssembly, string embeddedResourcePath);
         System.IO.Abstractions.TestingHelpers.MockFileData AdjustTimes(System.IO.Abstractions.TestingHelpers.MockFileData fileData, System.IO.Abstractions.TestingHelpers.TimeAdjustments timeAdjustments);
@@ -21,7 +21,7 @@ namespace System.IO.Abstractions.TestingHelpers
         System.IO.Abstractions.TestingHelpers.MockDriveData GetDrive(string name);
         System.IO.Abstractions.TestingHelpers.MockFileData GetFile(string path);
         void MoveDirectory(string sourcePath, string destPath);
-        void RemoveFile(string path);
+        void RemoveFile(string path, bool verifyAccess = true);
     }
     [System.Serializable]
     public class MockDirectory : System.IO.Abstractions.DirectoryBase
@@ -453,8 +453,8 @@ namespace System.IO.Abstractions.TestingHelpers
         public void AddDrive(string name, System.IO.Abstractions.TestingHelpers.MockDriveData mockDrive) { }
         public void AddEmptyFile(System.IO.Abstractions.IFileInfo path) { }
         public void AddEmptyFile(string path) { }
-        public void AddFile(System.IO.Abstractions.IFileInfo path, System.IO.Abstractions.TestingHelpers.MockFileData data) { }
-        public void AddFile(string path, System.IO.Abstractions.TestingHelpers.MockFileData mockFile) { }
+        public void AddFile(System.IO.Abstractions.IFileInfo path, System.IO.Abstractions.TestingHelpers.MockFileData data, bool verifyAccess = true) { }
+        public void AddFile(string path, System.IO.Abstractions.TestingHelpers.MockFileData mockFile, bool verifyAccess = true) { }
         public void AddFileFromEmbeddedResource(string path, System.Reflection.Assembly resourceAssembly, string embeddedResourcePath) { }
         public void AddFilesFromEmbeddedNamespace(string path, System.Reflection.Assembly resourceAssembly, string embeddedResourcePath) { }
         public System.IO.Abstractions.TestingHelpers.MockFileData AdjustTimes(System.IO.Abstractions.TestingHelpers.MockFileData fileData, System.IO.Abstractions.TestingHelpers.TimeAdjustments timeAdjustments) { }
@@ -464,7 +464,7 @@ namespace System.IO.Abstractions.TestingHelpers
         public System.IO.Abstractions.TestingHelpers.MockFileData GetFile(string path) { }
         public System.IO.Abstractions.TestingHelpers.MockFileSystem MockTime(System.Func<System.DateTime> dateTimeProvider) { }
         public void MoveDirectory(string sourcePath, string destPath) { }
-        public void RemoveFile(string path) { }
+        public void RemoveFile(string path, bool verifyAccess = true) { }
     }
     public class MockFileSystemOptions
     {

--- a/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.TestingHelpers_netstandard2.0.txt
+++ b/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.TestingHelpers_netstandard2.0.txt
@@ -13,7 +13,7 @@ namespace System.IO.Abstractions.TestingHelpers
         System.IO.Abstractions.TestingHelpers.StringOperations StringOperations { get; }
         void AddDirectory(string path);
         void AddDrive(string name, System.IO.Abstractions.TestingHelpers.MockDriveData mockDrive);
-        void AddFile(string path, System.IO.Abstractions.TestingHelpers.MockFileData mockFile);
+        void AddFile(string path, System.IO.Abstractions.TestingHelpers.MockFileData mockFile, bool verifyAccess = true);
         void AddFileFromEmbeddedResource(string path, System.Reflection.Assembly resourceAssembly, string embeddedResourcePath);
         void AddFilesFromEmbeddedNamespace(string path, System.Reflection.Assembly resourceAssembly, string embeddedResourcePath);
         System.IO.Abstractions.TestingHelpers.MockFileData AdjustTimes(System.IO.Abstractions.TestingHelpers.MockFileData fileData, System.IO.Abstractions.TestingHelpers.TimeAdjustments timeAdjustments);
@@ -21,7 +21,7 @@ namespace System.IO.Abstractions.TestingHelpers
         System.IO.Abstractions.TestingHelpers.MockDriveData GetDrive(string name);
         System.IO.Abstractions.TestingHelpers.MockFileData GetFile(string path);
         void MoveDirectory(string sourcePath, string destPath);
-        void RemoveFile(string path);
+        void RemoveFile(string path, bool verifyAccess = true);
     }
     [System.Serializable]
     public class MockDirectory : System.IO.Abstractions.DirectoryBase
@@ -360,8 +360,8 @@ namespace System.IO.Abstractions.TestingHelpers
         public void AddDrive(string name, System.IO.Abstractions.TestingHelpers.MockDriveData mockDrive) { }
         public void AddEmptyFile(System.IO.Abstractions.IFileInfo path) { }
         public void AddEmptyFile(string path) { }
-        public void AddFile(System.IO.Abstractions.IFileInfo path, System.IO.Abstractions.TestingHelpers.MockFileData data) { }
-        public void AddFile(string path, System.IO.Abstractions.TestingHelpers.MockFileData mockFile) { }
+        public void AddFile(System.IO.Abstractions.IFileInfo path, System.IO.Abstractions.TestingHelpers.MockFileData data, bool verifyAccess = true) { }
+        public void AddFile(string path, System.IO.Abstractions.TestingHelpers.MockFileData mockFile, bool verifyAccess = true) { }
         public void AddFileFromEmbeddedResource(string path, System.Reflection.Assembly resourceAssembly, string embeddedResourcePath) { }
         public void AddFilesFromEmbeddedNamespace(string path, System.Reflection.Assembly resourceAssembly, string embeddedResourcePath) { }
         public System.IO.Abstractions.TestingHelpers.MockFileData AdjustTimes(System.IO.Abstractions.TestingHelpers.MockFileData fileData, System.IO.Abstractions.TestingHelpers.TimeAdjustments timeAdjustments) { }
@@ -371,7 +371,7 @@ namespace System.IO.Abstractions.TestingHelpers
         public System.IO.Abstractions.TestingHelpers.MockFileData GetFile(string path) { }
         public System.IO.Abstractions.TestingHelpers.MockFileSystem MockTime(System.Func<System.DateTime> dateTimeProvider) { }
         public void MoveDirectory(string sourcePath, string destPath) { }
-        public void RemoveFile(string path) { }
+        public void RemoveFile(string path, bool verifyAccess = true) { }
     }
     public class MockFileSystemOptions
     {

--- a/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.TestingHelpers_netstandard2.1.txt
+++ b/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.TestingHelpers_netstandard2.1.txt
@@ -13,7 +13,7 @@ namespace System.IO.Abstractions.TestingHelpers
         System.IO.Abstractions.TestingHelpers.StringOperations StringOperations { get; }
         void AddDirectory(string path);
         void AddDrive(string name, System.IO.Abstractions.TestingHelpers.MockDriveData mockDrive);
-        void AddFile(string path, System.IO.Abstractions.TestingHelpers.MockFileData mockFile);
+        void AddFile(string path, System.IO.Abstractions.TestingHelpers.MockFileData mockFile, bool verifyAccess = true);
         void AddFileFromEmbeddedResource(string path, System.Reflection.Assembly resourceAssembly, string embeddedResourcePath);
         void AddFilesFromEmbeddedNamespace(string path, System.Reflection.Assembly resourceAssembly, string embeddedResourcePath);
         System.IO.Abstractions.TestingHelpers.MockFileData AdjustTimes(System.IO.Abstractions.TestingHelpers.MockFileData fileData, System.IO.Abstractions.TestingHelpers.TimeAdjustments timeAdjustments);
@@ -21,7 +21,7 @@ namespace System.IO.Abstractions.TestingHelpers
         System.IO.Abstractions.TestingHelpers.MockDriveData GetDrive(string name);
         System.IO.Abstractions.TestingHelpers.MockFileData GetFile(string path);
         void MoveDirectory(string sourcePath, string destPath);
-        void RemoveFile(string path);
+        void RemoveFile(string path, bool verifyAccess = true);
     }
     [System.Serializable]
     public class MockDirectory : System.IO.Abstractions.DirectoryBase
@@ -388,8 +388,8 @@ namespace System.IO.Abstractions.TestingHelpers
         public void AddDrive(string name, System.IO.Abstractions.TestingHelpers.MockDriveData mockDrive) { }
         public void AddEmptyFile(System.IO.Abstractions.IFileInfo path) { }
         public void AddEmptyFile(string path) { }
-        public void AddFile(System.IO.Abstractions.IFileInfo path, System.IO.Abstractions.TestingHelpers.MockFileData data) { }
-        public void AddFile(string path, System.IO.Abstractions.TestingHelpers.MockFileData mockFile) { }
+        public void AddFile(System.IO.Abstractions.IFileInfo path, System.IO.Abstractions.TestingHelpers.MockFileData data, bool verifyAccess = true) { }
+        public void AddFile(string path, System.IO.Abstractions.TestingHelpers.MockFileData mockFile, bool verifyAccess = true) { }
         public void AddFileFromEmbeddedResource(string path, System.Reflection.Assembly resourceAssembly, string embeddedResourcePath) { }
         public void AddFilesFromEmbeddedNamespace(string path, System.Reflection.Assembly resourceAssembly, string embeddedResourcePath) { }
         public System.IO.Abstractions.TestingHelpers.MockFileData AdjustTimes(System.IO.Abstractions.TestingHelpers.MockFileData fileData, System.IO.Abstractions.TestingHelpers.TimeAdjustments timeAdjustments) { }
@@ -399,7 +399,7 @@ namespace System.IO.Abstractions.TestingHelpers
         public System.IO.Abstractions.TestingHelpers.MockFileData GetFile(string path) { }
         public System.IO.Abstractions.TestingHelpers.MockFileSystem MockTime(System.Func<System.DateTime> dateTimeProvider) { }
         public void MoveDirectory(string sourcePath, string destPath) { }
-        public void RemoveFile(string path) { }
+        public void RemoveFile(string path, bool verifyAccess = true) { }
     }
     public class MockFileSystemOptions
     {

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileMoveTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileMoveTests.cs
@@ -28,7 +28,7 @@ public class MockFileMoveTests
     }
 
     [Test]
-    public async Task MockFile_Move_WithReadOnlyAttribute_ShouldThrowUnauthorizedAccessExceptionAndNotMoveFile()
+    public async Task MockFile_Move_WithReadOnlyAttribute_ShouldMoveFile()
     {
         var sourceFilePath = @"c:\foo.txt";
         var destFilePath = @"c:\bar.txt";
@@ -36,10 +36,10 @@ public class MockFileMoveTests
         fileSystem.File.WriteAllText(sourceFilePath, "this is some content");
         fileSystem.File.SetAttributes(sourceFilePath, FileAttributes.ReadOnly);
 
-        await That(() => fileSystem.File.Move(sourceFilePath, destFilePath)).Throws<UnauthorizedAccessException>();
+        fileSystem.File.Move(sourceFilePath, destFilePath);
 
-        await That(fileSystem.File.Exists(sourceFilePath)).IsEqualTo(true);
-        await That(fileSystem.File.Exists(destFilePath)).IsEqualTo(false);
+        await That(fileSystem.File.Exists(destFilePath)).IsTrue();
+        await That(fileSystem.File.Exists(sourceFilePath)).IsFalse();
     }
 
     [Test]


### PR DESCRIPTION
Fixes the bug reported in #1207 (which was introduced in #870) that it is not possible to move a read-only file: The `AddFile` and `RemoveFile` now have an optional parameter `verifyAccess` which if set to `false` will omit the access check, thus not throwing the `UnauthorizedAccessException`.