### PR TITLE
chore: update API due to dependency update

### DIFF
--- a/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.TestingHelpers_net472.txt
+++ b/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.TestingHelpers_net472.txt
@@ -228,8 +228,8 @@ namespace System.IO.Abstractions.TestingHelpers
     {
         public static readonly System.DateTimeOffset DefaultDateTimeOffset;
         public static readonly System.Text.Encoding DefaultEncoding;
-        public MockFileData(byte[] contents) { }
         public MockFileData(System.IO.Abstractions.TestingHelpers.MockFileData template) { }
+        public MockFileData(byte[] contents) { }
         public MockFileData(string textContents) { }
         public MockFileData(string textContents, System.Text.Encoding encoding) { }
         public System.Security.AccessControl.FileSecurity AccessControl { get; set; }
@@ -327,8 +327,8 @@ namespace System.IO.Abstractions.TestingHelpers
         public System.IO.Abstractions.FileSystemStream New(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.IO.FileAccess access, int bufferSize, bool isAsync) { }
         public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share) { }
         public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize) { }
-        public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize, bool useAsync) { }
         public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize, System.IO.FileOptions options) { }
+        public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize, bool useAsync) { }
         public System.IO.Abstractions.FileSystemStream Wrap(System.IO.FileStream fileStream) { }
     }
     [System.Serializable]

--- a/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.TestingHelpers_net6.0.txt
+++ b/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.TestingHelpers_net6.0.txt
@@ -267,8 +267,8 @@ namespace System.IO.Abstractions.TestingHelpers
     {
         public static readonly System.DateTimeOffset DefaultDateTimeOffset;
         public static readonly System.Text.Encoding DefaultEncoding;
-        public MockFileData(byte[] contents) { }
         public MockFileData(System.IO.Abstractions.TestingHelpers.MockFileData template) { }
+        public MockFileData(byte[] contents) { }
         public MockFileData(string textContents) { }
         public MockFileData(string textContents, System.Text.Encoding encoding) { }
         [System.Runtime.Versioning.SupportedOSPlatform("windows")]
@@ -382,8 +382,8 @@ namespace System.IO.Abstractions.TestingHelpers
         public System.IO.Abstractions.FileSystemStream New(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.IO.FileAccess access, int bufferSize, bool isAsync) { }
         public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share) { }
         public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize) { }
-        public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize, bool useAsync) { }
         public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize, System.IO.FileOptions options) { }
+        public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize, bool useAsync) { }
         public System.IO.Abstractions.FileSystemStream Wrap(System.IO.FileStream fileStream) { }
     }
     [System.Serializable]

--- a/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.TestingHelpers_net8.0.txt
+++ b/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.TestingHelpers_net8.0.txt
@@ -290,8 +290,8 @@ namespace System.IO.Abstractions.TestingHelpers
     {
         public static readonly System.DateTimeOffset DefaultDateTimeOffset;
         public static readonly System.Text.Encoding DefaultEncoding;
-        public MockFileData(byte[] contents) { }
         public MockFileData(System.IO.Abstractions.TestingHelpers.MockFileData template) { }
+        public MockFileData(byte[] contents) { }
         public MockFileData(string textContents) { }
         public MockFileData(string textContents, System.Text.Encoding encoding) { }
         [System.Runtime.Versioning.SupportedOSPlatform("windows")]
@@ -406,8 +406,8 @@ namespace System.IO.Abstractions.TestingHelpers
         public System.IO.Abstractions.FileSystemStream New(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.IO.FileAccess access, int bufferSize, bool isAsync) { }
         public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share) { }
         public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize) { }
-        public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize, bool useAsync) { }
         public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize, System.IO.FileOptions options) { }
+        public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize, bool useAsync) { }
         public System.IO.Abstractions.FileSystemStream Wrap(System.IO.FileStream fileStream) { }
     }
     [System.Serializable]

--- a/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.TestingHelpers_net9.0.txt
+++ b/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.TestingHelpers_net9.0.txt
@@ -193,10 +193,10 @@ namespace System.IO.Abstractions.TestingHelpers
     public class MockFile : System.IO.Abstractions.FileBase
     {
         public MockFile(System.IO.Abstractions.TestingHelpers.IMockFileDataAccessor mockFileDataAccessor) { }
-        public override void AppendAllBytes(string path, byte[] bytes) { }
         public override void AppendAllBytes(string path, System.ReadOnlySpan<byte> bytes) { }
-        public override System.Threading.Tasks.Task AppendAllBytesAsync(string path, byte[] bytes, System.Threading.CancellationToken cancellationToken = default) { }
+        public override void AppendAllBytes(string path, byte[] bytes) { }
         public override System.Threading.Tasks.Task AppendAllBytesAsync(string path, System.ReadOnlyMemory<byte> bytes, System.Threading.CancellationToken cancellationToken = default) { }
+        public override System.Threading.Tasks.Task AppendAllBytesAsync(string path, byte[] bytes, System.Threading.CancellationToken cancellationToken = default) { }
         public override void AppendAllLines(string path, System.Collections.Generic.IEnumerable<string> contents) { }
         public override void AppendAllLines(string path, System.Collections.Generic.IEnumerable<string> contents, System.Text.Encoding encoding) { }
         public override System.Threading.Tasks.Task AppendAllLinesAsync(string path, System.Collections.Generic.IEnumerable<string> contents, System.Threading.CancellationToken cancellationToken = default) { }
@@ -280,10 +280,10 @@ namespace System.IO.Abstractions.TestingHelpers
         public override void SetLastWriteTimeUtc(string path, System.DateTime lastWriteTimeUtc) { }
         public override void SetUnixFileMode(Microsoft.Win32.SafeHandles.SafeFileHandle fileHandle, System.IO.UnixFileMode mode) { }
         public override void SetUnixFileMode(string path, System.IO.UnixFileMode mode) { }
-        public override void WriteAllBytes(string path, byte[] bytes) { }
         public override void WriteAllBytes(string path, System.ReadOnlySpan<byte> bytes) { }
-        public override System.Threading.Tasks.Task WriteAllBytesAsync(string path, byte[] bytes, System.Threading.CancellationToken cancellationToken = default) { }
+        public override void WriteAllBytes(string path, byte[] bytes) { }
         public override System.Threading.Tasks.Task WriteAllBytesAsync(string path, System.ReadOnlyMemory<byte> bytes, System.Threading.CancellationToken cancellationToken = default) { }
+        public override System.Threading.Tasks.Task WriteAllBytesAsync(string path, byte[] bytes, System.Threading.CancellationToken cancellationToken = default) { }
         public override void WriteAllLines(string path, System.Collections.Generic.IEnumerable<string> contents) { }
         public override void WriteAllLines(string path, string[] contents) { }
         public override void WriteAllLines(string path, System.Collections.Generic.IEnumerable<string> contents, System.Text.Encoding encoding) { }
@@ -304,8 +304,8 @@ namespace System.IO.Abstractions.TestingHelpers
     {
         public static readonly System.DateTimeOffset DefaultDateTimeOffset;
         public static readonly System.Text.Encoding DefaultEncoding;
-        public MockFileData(byte[] contents) { }
         public MockFileData(System.IO.Abstractions.TestingHelpers.MockFileData template) { }
+        public MockFileData(byte[] contents) { }
         public MockFileData(string textContents) { }
         public MockFileData(string textContents, System.Text.Encoding encoding) { }
         [System.Runtime.Versioning.SupportedOSPlatform("windows")]
@@ -420,8 +420,8 @@ namespace System.IO.Abstractions.TestingHelpers
         public System.IO.Abstractions.FileSystemStream New(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.IO.FileAccess access, int bufferSize, bool isAsync) { }
         public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share) { }
         public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize) { }
-        public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize, bool useAsync) { }
         public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize, System.IO.FileOptions options) { }
+        public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize, bool useAsync) { }
         public System.IO.Abstractions.FileSystemStream Wrap(System.IO.FileStream fileStream) { }
     }
     [System.Serializable]

--- a/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.TestingHelpers_netstandard2.0.txt
+++ b/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.TestingHelpers_netstandard2.0.txt
@@ -228,8 +228,8 @@ namespace System.IO.Abstractions.TestingHelpers
     {
         public static readonly System.DateTimeOffset DefaultDateTimeOffset;
         public static readonly System.Text.Encoding DefaultEncoding;
-        public MockFileData(byte[] contents) { }
         public MockFileData(System.IO.Abstractions.TestingHelpers.MockFileData template) { }
+        public MockFileData(byte[] contents) { }
         public MockFileData(string textContents) { }
         public MockFileData(string textContents, System.Text.Encoding encoding) { }
         public System.Security.AccessControl.FileSecurity AccessControl { get; set; }
@@ -327,8 +327,8 @@ namespace System.IO.Abstractions.TestingHelpers
         public System.IO.Abstractions.FileSystemStream New(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.IO.FileAccess access, int bufferSize, bool isAsync) { }
         public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share) { }
         public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize) { }
-        public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize, bool useAsync) { }
         public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize, System.IO.FileOptions options) { }
+        public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize, bool useAsync) { }
         public System.IO.Abstractions.FileSystemStream Wrap(System.IO.FileStream fileStream) { }
     }
     [System.Serializable]

--- a/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.TestingHelpers_netstandard2.1.txt
+++ b/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.TestingHelpers_netstandard2.1.txt
@@ -254,8 +254,8 @@ namespace System.IO.Abstractions.TestingHelpers
     {
         public static readonly System.DateTimeOffset DefaultDateTimeOffset;
         public static readonly System.Text.Encoding DefaultEncoding;
-        public MockFileData(byte[] contents) { }
         public MockFileData(System.IO.Abstractions.TestingHelpers.MockFileData template) { }
+        public MockFileData(byte[] contents) { }
         public MockFileData(string textContents) { }
         public MockFileData(string textContents, System.Text.Encoding encoding) { }
         public System.Security.AccessControl.FileSecurity AccessControl { get; set; }
@@ -355,8 +355,8 @@ namespace System.IO.Abstractions.TestingHelpers
         public System.IO.Abstractions.FileSystemStream New(Microsoft.Win32.SafeHandles.SafeFileHandle handle, System.IO.FileAccess access, int bufferSize, bool isAsync) { }
         public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share) { }
         public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize) { }
-        public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize, bool useAsync) { }
         public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize, System.IO.FileOptions options) { }
+        public System.IO.Abstractions.FileSystemStream New(string path, System.IO.FileMode mode, System.IO.FileAccess access, System.IO.FileShare share, int bufferSize, bool useAsync) { }
         public System.IO.Abstractions.FileSystemStream Wrap(System.IO.FileStream fileStream) { }
     }
     [System.Serializable]

--- a/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.Wrappers_net8.0.txt
+++ b/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.Wrappers_net8.0.txt
@@ -547,8 +547,8 @@ namespace System.IO.Abstractions
         protected void OnError(object sender, System.IO.ErrorEventArgs args) { }
         protected void OnRenamed(object sender, System.IO.RenamedEventArgs args) { }
         public abstract System.IO.Abstractions.IWaitForChangedResult WaitForChanged(System.IO.WatcherChangeTypes changeType);
-        public abstract System.IO.Abstractions.IWaitForChangedResult WaitForChanged(System.IO.WatcherChangeTypes changeType, int timeout);
         public abstract System.IO.Abstractions.IWaitForChangedResult WaitForChanged(System.IO.WatcherChangeTypes changeType, System.TimeSpan timeout);
+        public abstract System.IO.Abstractions.IWaitForChangedResult WaitForChanged(System.IO.WatcherChangeTypes changeType, int timeout);
         public static System.IO.Abstractions.FileSystemWatcherBase op_Implicit(System.IO.FileSystemWatcher watcher) { }
     }
     [System.Serializable]
@@ -583,8 +583,8 @@ namespace System.IO.Abstractions
         public override void Dispose(bool disposing) { }
         public override void EndInit() { }
         public override System.IO.Abstractions.IWaitForChangedResult WaitForChanged(System.IO.WatcherChangeTypes changeType) { }
-        public override System.IO.Abstractions.IWaitForChangedResult WaitForChanged(System.IO.WatcherChangeTypes changeType, int timeout) { }
         public override System.IO.Abstractions.IWaitForChangedResult WaitForChanged(System.IO.WatcherChangeTypes changeType, System.TimeSpan timeout) { }
+        public override System.IO.Abstractions.IWaitForChangedResult WaitForChanged(System.IO.WatcherChangeTypes changeType, int timeout) { }
     }
     [System.Serializable]
     public abstract class FileVersionInfoBase : System.IO.Abstractions.IFileVersionInfo

--- a/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.Wrappers_net9.0.txt
+++ b/tests/TestableIO.System.IO.Abstractions.Api.Tests/Expected/TestableIO.System.IO.Abstractions.Wrappers_net9.0.txt
@@ -278,10 +278,10 @@ namespace System.IO.Abstractions
     {
         protected FileBase(System.IO.Abstractions.IFileSystem fileSystem) { }
         public System.IO.Abstractions.IFileSystem FileSystem { get; }
-        public abstract void AppendAllBytes(string path, byte[] bytes);
         public abstract void AppendAllBytes(string path, System.ReadOnlySpan<byte> bytes);
-        public abstract System.Threading.Tasks.Task AppendAllBytesAsync(string path, byte[] bytes, System.Threading.CancellationToken cancellationToken = default);
+        public abstract void AppendAllBytes(string path, byte[] bytes);
         public abstract System.Threading.Tasks.Task AppendAllBytesAsync(string path, System.ReadOnlyMemory<byte> bytes, System.Threading.CancellationToken cancellationToken = default);
+        public abstract System.Threading.Tasks.Task AppendAllBytesAsync(string path, byte[] bytes, System.Threading.CancellationToken cancellationToken = default);
         public abstract void AppendAllLines(string path, System.Collections.Generic.IEnumerable<string> contents);
         public abstract void AppendAllLines(string path, System.Collections.Generic.IEnumerable<string> contents, System.Text.Encoding encoding);
         public abstract System.Threading.Tasks.Task AppendAllLinesAsync(string path, System.Collections.Generic.IEnumerable<string> contents, System.Threading.CancellationToken cancellationToken = default);
@@ -364,10 +364,10 @@ namespace System.IO.Abstractions
         public abstract void SetLastWriteTimeUtc(string path, System.DateTime lastWriteTimeUtc);
         public abstract void SetUnixFileMode(Microsoft.Win32.SafeHandles.SafeFileHandle fileHandle, System.IO.UnixFileMode mode);
         public abstract void SetUnixFileMode(string path, System.IO.UnixFileMode mode);
-        public abstract void WriteAllBytes(string path, byte[] bytes);
         public abstract void WriteAllBytes(string path, System.ReadOnlySpan<byte> bytes);
-        public abstract System.Threading.Tasks.Task WriteAllBytesAsync(string path, byte[] bytes, System.Threading.CancellationToken cancellationToken = default);
+        public abstract void WriteAllBytes(string path, byte[] bytes);
         public abstract System.Threading.Tasks.Task WriteAllBytesAsync(string path, System.ReadOnlyMemory<byte> bytes, System.Threading.CancellationToken cancellationToken = default);
+        public abstract System.Threading.Tasks.Task WriteAllBytesAsync(string path, byte[] bytes, System.Threading.CancellationToken cancellationToken = default);
         public abstract void WriteAllLines(string path, System.Collections.Generic.IEnumerable<string> contents);
         public abstract void WriteAllLines(string path, string[] contents);
         public abstract void WriteAllLines(string path, System.Collections.Generic.IEnumerable<string> contents, System.Text.Encoding encoding);
@@ -561,8 +561,8 @@ namespace System.IO.Abstractions
         protected void OnError(object sender, System.IO.ErrorEventArgs args) { }
         protected void OnRenamed(object sender, System.IO.RenamedEventArgs args) { }
         public abstract System.IO.Abstractions.IWaitForChangedResult WaitForChanged(System.IO.WatcherChangeTypes changeType);
-        public abstract System.IO.Abstractions.IWaitForChangedResult WaitForChanged(System.IO.WatcherChangeTypes changeType, int timeout);
         public abstract System.IO.Abstractions.IWaitForChangedResult WaitForChanged(System.IO.WatcherChangeTypes changeType, System.TimeSpan timeout);
+        public abstract System.IO.Abstractions.IWaitForChangedResult WaitForChanged(System.IO.WatcherChangeTypes changeType, int timeout);
         public static System.IO.Abstractions.FileSystemWatcherBase op_Implicit(System.IO.FileSystemWatcher watcher) { }
     }
     [System.Serializable]
@@ -597,8 +597,8 @@ namespace System.IO.Abstractions
         public override void Dispose(bool disposing) { }
         public override void EndInit() { }
         public override System.IO.Abstractions.IWaitForChangedResult WaitForChanged(System.IO.WatcherChangeTypes changeType) { }
-        public override System.IO.Abstractions.IWaitForChangedResult WaitForChanged(System.IO.WatcherChangeTypes changeType, int timeout) { }
         public override System.IO.Abstractions.IWaitForChangedResult WaitForChanged(System.IO.WatcherChangeTypes changeType, System.TimeSpan timeout) { }
+        public override System.IO.Abstractions.IWaitForChangedResult WaitForChanged(System.IO.WatcherChangeTypes changeType, int timeout) { }
     }
     [System.Serializable]
     public abstract class FileVersionInfoBase : System.IO.Abstractions.IFileVersionInfo
@@ -671,10 +671,10 @@ namespace System.IO.Abstractions
     public class FileWrapper : System.IO.Abstractions.FileBase
     {
         public FileWrapper(System.IO.Abstractions.IFileSystem fileSystem) { }
-        public override void AppendAllBytes(string path, byte[] bytes) { }
         public override void AppendAllBytes(string path, System.ReadOnlySpan<byte> bytes) { }
-        public override System.Threading.Tasks.Task AppendAllBytesAsync(string path, byte[] bytes, System.Threading.CancellationToken cancellationToken = default) { }
+        public override void AppendAllBytes(string path, byte[] bytes) { }
         public override System.Threading.Tasks.Task AppendAllBytesAsync(string path, System.ReadOnlyMemory<byte> bytes, System.Threading.CancellationToken cancellationToken = default) { }
+        public override System.Threading.Tasks.Task AppendAllBytesAsync(string path, byte[] bytes, System.Threading.CancellationToken cancellationToken = default) { }
         public override void AppendAllLines(string path, System.Collections.Generic.IEnumerable<string> contents) { }
         public override void AppendAllLines(string path, System.Collections.Generic.IEnumerable<string> contents, System.Text.Encoding encoding) { }
         public override System.Threading.Tasks.Task AppendAllLinesAsync(string path, System.Collections.Generic.IEnumerable<string> contents, System.Threading.CancellationToken cancellationToken = default) { }
@@ -763,10 +763,10 @@ namespace System.IO.Abstractions
         public override void SetUnixFileMode(Microsoft.Win32.SafeHandles.SafeFileHandle fileHandle, System.IO.UnixFileMode mode) { }
         [System.Runtime.Versioning.UnsupportedOSPlatform("windows")]
         public override void SetUnixFileMode(string path, System.IO.UnixFileMode mode) { }
-        public override void WriteAllBytes(string path, byte[] bytes) { }
         public override void WriteAllBytes(string path, System.ReadOnlySpan<byte> bytes) { }
-        public override System.Threading.Tasks.Task WriteAllBytesAsync(string path, byte[] bytes, System.Threading.CancellationToken cancellationToken = default) { }
+        public override void WriteAllBytes(string path, byte[] bytes) { }
         public override System.Threading.Tasks.Task WriteAllBytesAsync(string path, System.ReadOnlyMemory<byte> bytes, System.Threading.CancellationToken cancellationToken = default) { }
+        public override System.Threading.Tasks.Task WriteAllBytesAsync(string path, byte[] bytes, System.Threading.CancellationToken cancellationToken = default) { }
         public override void WriteAllLines(string path, System.Collections.Generic.IEnumerable<string> contents) { }
         public override void WriteAllLines(string path, string[] contents) { }
         public override void WriteAllLines(string path, System.Collections.Generic.IEnumerable<string> contents, System.Text.Encoding encoding) { }


### PR DESCRIPTION
In #1240 and #1241 the PublicApiGenerator dependency was updated to v11.4.5, which introduced a change in the format (different order).

This PR updates the expected API accordingly.

The Api Test check was changed to required, so that this will be caught in the CI-Build in future!