### PR TITLE
fix: handle case-sensitive file overwrite on Windows and add tests

### DIFF
--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileCopyTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileCopyTests.cs
@@ -256,7 +256,10 @@ public class MockFileCopyTests
 
         fileSystem.File.WriteAllText(path, "Hello");
 
-        await That(() => fileSystem.File.Copy(path, pathUpper, true)).Throws<IOException>().HasMessage($"The process cannot access the file '{pathUpper}' because it is being used by another process.");
+        void Act() => fileSystem.File.Copy(path, pathUpper, true);
+
+        await That(Act).Throws<IOException>()
+            .WithMessage($"The process cannot access the file '{pathUpper}' because it is being used by another process.");
     }
 
     [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileCopyTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileCopyTests.cs
@@ -248,6 +248,19 @@ public class MockFileCopyTests
 
     [Test]
     [WindowsOnly(WindowsSpecifics.Drives)]
+    public async Task Copy_Should_ThrowIOException_When_OverwritingWithSameNameDifferentCase()
+    {
+        var fileSystem = new MockFileSystem();
+        string path = @"C:\Temp\file.txt";
+        string pathUpper = @"C:\Temp\FILE.TXT";
+
+        fileSystem.File.WriteAllText(path, "Hello");
+
+        await That(() => fileSystem.File.Copy(path, pathUpper, true)).Throws<IOException>().HasMessage($"The process cannot access the file '{pathUpper}' because it is being used by another process.");
+    }
+
+    [Test]
+    [WindowsOnly(WindowsSpecifics.Drives)]
     public async Task MockFile_Copy_ShouldThrowNotSupportedExceptionWhenSourcePathContainsInvalidDriveLetter()
     {
         var badSourcePath = @"0:\something\demo.txt";

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileCopyTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileCopyTests.cs
@@ -248,7 +248,7 @@ public class MockFileCopyTests
 
     [Test]
     [WindowsOnly(WindowsSpecifics.Drives)]
-    public async Task Copy_Should_ThrowIOException_When_OverwritingWithSameNameDifferentCase()
+    public async Task MockFile_Copy_ShouldThrowIOExceptionWhenOverwritingWithSameNameDifferentCase()
     {
         var fileSystem = new MockFileSystem();
         string path = @"C:\Temp\file.txt";

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileMoveTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileMoveTests.cs
@@ -250,6 +250,26 @@ public class MockFileMoveTests
     }
 
     [Test]
+    [WindowsOnly(WindowsSpecifics.Drives)]
+    public async Task MockFile_Move_CaseOnlyRename_ShouldChangeCase()
+    {
+        string sourceFilePath = @"c:\something\demo.txt";
+        string destFilePath = @"c:\something\DEMO.TXT";
+        string sourceFileContent = "content";
+
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+        {
+                sourceFilePath, new MockFileData(sourceFileContent)}
+        });
+
+        fileSystem.File.Move(sourceFilePath, destFilePath);
+
+        await That(fileSystem.FileExists(destFilePath)).IsTrue();
+        await That(fileSystem.GetFile(destFilePath).TextContents).IsEqualTo(sourceFileContent);
+    }
+
+    [Test]
     public async Task MockFile_Move_ShouldThrowArgumentExceptionWhenSourceIsEmpty_Message()
     {
         string destFilePath = XFS.Path(@"c:\something\demo.txt");

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileMoveTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileMoveTests.cs
@@ -253,20 +253,16 @@ public class MockFileMoveTests
     [WindowsOnly(WindowsSpecifics.Drives)]
     public async Task MockFile_Move_CaseOnlyRename_ShouldChangeCase()
     {
-        string sourceFilePath = @"c:\something\demo.txt";
-        string destFilePath = @"c:\something\DEMO.TXT";
+        var fileSystem = new MockFileSystem();
+        string sourceFilePath = @"c:\temp\demo.txt";
+        string destFilePath = @"c:\temp\DEMO.TXT";
         string sourceFileContent = "content";
-
-        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
-        {
-        {
-                sourceFilePath, new MockFileData(sourceFileContent)}
-        });
+        fileSystem.File.WriteAllText(sourceFilePath, sourceFileContent);
 
         fileSystem.File.Move(sourceFilePath, destFilePath);
 
-        await That(fileSystem.FileExists(destFilePath)).IsTrue();
-        await That(fileSystem.GetFile(destFilePath).TextContents).IsEqualTo(sourceFileContent);
+        await That(fileSystem.File.Exists(destFilePath)).IsTrue();
+        await That(fileSystem.File.ReadAllText(destFilePath)).IsEqualTo(sourceFileContent);
     }
 
     [Test]

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
@@ -547,7 +547,7 @@ public class MockFileTests
         await That(file.TextContents).IsEqualTo("New too!");
         await That(filesystem.FileExists(filepath)).IsTrue();
     }
-        
+
 #if !NET9_0_OR_GREATER
     [Test]
     public void Serializable_works()
@@ -567,7 +567,7 @@ public class MockFileTests
         Assert.Pass();
     }
 #endif
-        
+
 #if !NET9_0_OR_GREATER
     [Test]
     public async Task Serializable_can_deserialize()
@@ -670,7 +670,7 @@ public class MockFileTests
         fileSystem.File.Replace(path1, path2, path3);
 
         await That(fileSystem.File.ReadAllText(path3)).IsEqualTo("2");
-    } 
+    }
 
     [Test]
     public async Task MockFile_Replace_ShouldThrowIfDirectoryOfBackupPathDoesNotExist()
@@ -729,5 +729,21 @@ public class MockFileTests
         // Assert
         await That(stream.CanWrite).IsFalse();
         await That(() => stream.WriteByte(0)).Throws<NotSupportedException>();
+    }
+
+    [Test]
+    [WindowsOnly(WindowsSpecifics.Drives)]
+    public async Task MockFile_Replace_SameSourceAndDestination_ShouldThrowIOException()
+    {
+        string sourceFilePath = @"c:\something\demo.txt";
+        string destFilePath = @"c:\something\Demo.txt";
+        string fileContent = "content";
+
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { sourceFilePath, new MockFileData(fileContent) }
+        });
+
+        await That(() => fileSystem.File.Replace(sourceFilePath, destFilePath, null, true)).Throws<IOException>().HasMessage("The process cannot access the file because it is being used by another process.");
     }
 }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockFileTests.cs
@@ -733,17 +733,17 @@ public class MockFileTests
 
     [Test]
     [WindowsOnly(WindowsSpecifics.Drives)]
-    public async Task MockFile_Replace_SameSourceAndDestination_ShouldThrowIOException()
+    public async Task MockFile_Replace_SourceAndDestinationDifferOnlyInCasing_ShouldThrowIOException()
     {
-        string sourceFilePath = @"c:\something\demo.txt";
-        string destFilePath = @"c:\something\Demo.txt";
+        var fileSystem = new MockFileSystem();
+        string sourceFilePath = @"c:\temp\demo.txt";
+        string destFilePath = @"c:\temp\DEMO.txt";
         string fileContent = "content";
+        fileSystem.File.WriteAllText(sourceFilePath, fileContent);
 
-        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
-        {
-            { sourceFilePath, new MockFileData(fileContent) }
-        });
+        void Act() => fileSystem.File.Replace(sourceFilePath, destFilePath, null, true);
 
-        await That(() => fileSystem.File.Replace(sourceFilePath, destFilePath, null, true)).Throws<IOException>().HasMessage("The process cannot access the file because it is being used by another process.");
+        await That(Act).Throws<IOException>()
+            .HasMessage("The process cannot access the file because it is being used by another process.");
     }
 }


### PR DESCRIPTION
This PR fixes an issue (#1140) where copying a file with the same name but different casing on Windows resulted in an "already in use" error. It aligns the behavior with the native file system.  

## Changes  
- Fixed file overwrite logic to properly handle case-insensitive paths on Windows.  
- Added Windows-specific checks to mimic `System.IO.File.Copy` `System.IO.File.Move` and `System.IO.File.Replace` behavior.  
- Implemented test cases to verify expected behavior for case-sensitive and case-insensitive file systems. 
- Ensured that the fix does not affect Linux behavior.  

## Testing  
- Verified that the fix works correctly on Windows by checking file existence before and after copying,moving and replacing file with different cases 
- Ran test cases on both Windows and Linux to ensure no unintended side effects.