### PR TITLE
fix: MockFileSystem's File.WriteAllText, File.ReadAllText, Directory.GetFiles, Directory.Create fail with \\?\C:\foo style paths

### DIFF
--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/PathVerifier.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/PathVerifier.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 namespace System.IO.Abstractions.TestingHelpers;
 
@@ -97,6 +98,16 @@ public class PathVerifier
 
         if (checkAdditional)
         {
+            // AdditionalInvalidPathChars includes '?', but this character is allowed in extended-length
+            // windows path prefixes (`\\?\`). If we're dealing with such a path, check for invalid
+            // characters after the prefix.
+            // Ref: https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry
+            const string EXTENDED_LENGTH_PATH_PREFIX = @"\\?\";
+            if (XFS.IsWindowsPlatform() && path.StartsWith(EXTENDED_LENGTH_PATH_PREFIX))
+            {
+                path = path.Substring(EXTENDED_LENGTH_PATH_PREFIX.Length);
+            }
+
             return path.IndexOfAny(invalidPathChars.Concat(AdditionalInvalidPathChars).ToArray()) >= 0;
         }
 

--- a/src/TestableIO.System.IO.Abstractions.TestingHelpers/PathVerifier.cs
+++ b/src/TestableIO.System.IO.Abstractions.TestingHelpers/PathVerifier.cs
@@ -65,6 +65,12 @@ public class PathVerifier
 
     private static bool IsValidUseOfVolumeSeparatorChar(string path)
     {
+        const string EXTENDED_LENGTH_PATH_PREFIX = @"\\?\";
+        if (path.StartsWith(EXTENDED_LENGTH_PATH_PREFIX))
+        {
+            path = path.Substring(EXTENDED_LENGTH_PATH_PREFIX.Length);
+        }
+
         var lastVolSepIndex = path.LastIndexOf(Path.VolumeSeparatorChar);
         return lastVolSepIndex == -1 || lastVolSepIndex == 1 && char.IsLetter(path[0]);
     }

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -747,6 +747,20 @@ public class MockDirectoryTests
         await That(createDelegate).Throws<ArgumentException>();
     }
 
+    [Test]
+    [WindowsOnly(WindowsSpecifics.UNCPaths)]
+    public async Task MockDirectory_CreateDirectory_ShouldSupportExtendedLengthPaths()
+    {
+        // Arrange
+        var fileSystem = new MockFileSystem();
+
+        // Act
+        fileSystem.Directory.CreateDirectory(XFS.Path(@"\\?\c:\bar"));
+
+        // Assert
+        await That(fileSystem.Directory.Exists(XFS.Path(@"\\?\c:\bar"))).IsTrue();
+    }
+
     // Issue #210
     [Test]
     public async Task MockDirectory_CreateDirectory_ShouldIgnoreExistingDirectoryRegardlessOfTrailingSlash()

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -756,10 +756,14 @@ public class MockDirectoryTests
 
         // Act
         var directoryInfo = fileSystem.Directory.CreateDirectory(XFS.Path(@"\\?\c:\bar"));
+        fileSystem.File.WriteAllText(@"\\?\c:\bar\grok.txt", "hello world\n");
 
         // Assert
         await That(fileSystem.Directory.Exists(XFS.Path(@"\\?\c:\bar"))).IsTrue();
         await That(directoryInfo.FullName).IsEqualTo(@"\\?\c:\bar");
+        await That(fileSystem.File.ReadAllText(@"\\?\c:\bar\grok.txt")).IsEqualTo("hello world\n");
+        await That(fileSystem.Directory.GetFiles(@"\\?\c:\bar")).HasSingle()
+            .Which.IsEqualTo(@"\\?\c:\bar\grok.txt");
     }
 
     // Issue #210

--- a/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
+++ b/tests/TestableIO.System.IO.Abstractions.TestingHelpers.Tests/MockDirectoryTests.cs
@@ -755,10 +755,11 @@ public class MockDirectoryTests
         var fileSystem = new MockFileSystem();
 
         // Act
-        fileSystem.Directory.CreateDirectory(XFS.Path(@"\\?\c:\bar"));
+        var directoryInfo = fileSystem.Directory.CreateDirectory(XFS.Path(@"\\?\c:\bar"));
 
         // Assert
         await That(fileSystem.Directory.Exists(XFS.Path(@"\\?\c:\bar"))).IsTrue();
+        await That(directoryInfo.FullName).IsEqualTo(@"\\?\c:\bar");
     }
 
     // Issue #210


### PR DESCRIPTION
This is an attempt to fix #1304.