### PR TITLE
fix: Add TypeForwardedTo attribute to forward other moved interfaces 

### DIFF
--- a/src/TestableIO.System.IO.Abstractions/AssemblyRedirects.cs
+++ b/src/TestableIO.System.IO.Abstractions/AssemblyRedirects.cs
@@ -1,4 +1,23 @@
 ﻿using System.IO.Abstractions;
 using System.Runtime.CompilerServices;
 
+[assembly: TypeForwardedTo(typeof(FileSystemStream))]
+[assembly: TypeForwardedTo(typeof(IDirectory))]
+[assembly: TypeForwardedTo(typeof(IDirectoryInfo))]
+[assembly: TypeForwardedTo(typeof(IDirectoryInfoFactory))]
+[assembly: TypeForwardedTo(typeof(IDriveInfo))]
+[assembly: TypeForwardedTo(typeof(IDriveInfoFactory))]
+[assembly: TypeForwardedTo(typeof(IFile))]
+[assembly: TypeForwardedTo(typeof(IFileInfo))]
+[assembly: TypeForwardedTo(typeof(IFileInfoFactory))]
+[assembly: TypeForwardedTo(typeof(IFileStreamFactory))]
 [assembly: TypeForwardedTo(typeof(IFileSystem))]
+[assembly: TypeForwardedTo(typeof(IFileSystemAclSupport))]
+[assembly: TypeForwardedTo(typeof(IFileSystemEntity))]
+[assembly: TypeForwardedTo(typeof(IFileSystemInfo))]
+[assembly: TypeForwardedTo(typeof(IFileSystemWatcher))]
+[assembly: TypeForwardedTo(typeof(IFileSystemWatcherFactory))]
+[assembly: TypeForwardedTo(typeof(IFileVersionInfo))]
+[assembly: TypeForwardedTo(typeof(IFileVersionInfoFactory))]
+[assembly: TypeForwardedTo(typeof(IPath))]
+[assembly: TypeForwardedTo(typeof(IWaitForChangedResult))]


### PR DESCRIPTION
Following #1338 

This PR adds TypeForwardedToAttribute to fix a problem where a transitive dependency on ver 21 can't find interfaces that were moved to a separate assembly in version 22.

Using the attribute, allows third parties that are built with ver 21 to be redirected to Testably.Abstractions.FileSystem.Interface.dll when trying to resolve the interface in its old location: TestableIO.System.IO.Abstractions.dll

This change adds backwards compatibility with ver 21.
Users of ver 22 are not affected in any way.