### PR TITLE
docs: removed erroneous content from Testably section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Both projects share the same maintainer, but active development and new features
 - **Use Testably.Abstractions** if you need:
   - Advanced testing scenarios (FileSystemWatcher, SafeFileHandles, multiple drives)
   - Additional abstractions (ITimeSystem, IRandomSystem)
-  - Cross-platform file system simulation (Linux, MacOS, Windows)Expand commentComment on line R163ResolvedCode has comments. Press enter to view.
+  - Cross-platform file system simulation (Linux, MacOS, Windows)
   - More extensive and consistent behavior validation
   - Active development and new features
 


### PR DESCRIPTION
Removed seemingly-accidentally pasted content from the Testably section in README, specifically the line mentioning its use for "Cross-platform file system simulation (Linux, MacOS, Windows)".

Previously, "Expand commentComment on line R163ResolvedCode has comments. Press enter to view." appeared on the end of the line.